### PR TITLE
Added WolframAlpha to search widget

### DIFF
--- a/src/components/widgets/search/search.jsx
+++ b/src/components/widgets/search/search.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, Fragment } from "react";
 import { useTranslation } from "next-i18next";
 import { FiSearch } from "react-icons/fi";
-import { SiDuckduckgo, SiMicrosoftbing, SiGoogle, SiBaidu, SiBrave } from "react-icons/si";
+import { SiDuckduckgo, SiMicrosoftbing, SiGoogle, SiBaidu, SiBrave, SiWolfram } from "react-icons/si";
 import { Listbox, Transition } from "@headlessui/react";
 import classNames from "classnames";
 
@@ -30,6 +30,11 @@ export const searchProviders = {
     name: "Brave",
     url: "https://search.brave.com/search?q=",
     icon: SiBrave,
+  },
+  wolframalpha: {
+    name: "WolframAlpha",
+    url: "https://www.wolframalpha.com/input?i=",
+    icon: SiWolfram,
   },
   custom: {
     name: "Custom",


### PR DESCRIPTION
	modified:   src/components/widgets/search/search.jsx

## Proposed change

Added [WolframAlpha](https://www.wolframalpha.com/) to search.   
Wanted WolframAlpha to be in the search drop down.


## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (please explain)

## Checklist:

- [x] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [x] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
