### PR TITLE
Handle invalid fields syntax in service labels

### DIFF
--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -291,8 +291,15 @@ export function cleanServiceGroups(groups) {
           enableQueue, // sonarr/radarr
         } = cleanedService.widget;
 
-        const fieldsList = typeof fields === 'string' ? JSON.parse(fields) : fields;
-
+        let fieldsList = fields;
+        if (typeof fields === 'string') {
+          try { JSON.parse(fields) }
+          catch (e) {
+            logger.error("Invalid fields list detected in config for service '%s'", service.name);
+            fieldsList = null;
+          }
+        }
+        
         cleanedService.widget = {
           type,
           fields: fieldsList || null,


### PR DESCRIPTION
## Proposed change

Gracefully handle invalid `fields` in service labels, just ignore it and log an error.

Closes #1639

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added a corresponding PR to the [documentation](https://github.com/benphelps/homepage-docs) here: 
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/en/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
