### PR TITLE
Fix: Browser warning for search

### DIFF
--- a/src/components/widgets/search/search.jsx
+++ b/src/components/widgets/search/search.jsx
@@ -120,7 +120,7 @@ export default function Search({ options }) {
           placeholder={t("search.placeholder")}
           onChange={(s) => setQuery(s.currentTarget.value)}
           required
-          autoCapitalize="off"
+          autoCapitalize="none"
           autoCorrect="off"
           autoComplete="off"
           // eslint-disable-next-line jsx-a11y/no-autofocus


### PR DESCRIPTION
## Proposed change

Fixes browser warning for search functionality:
![image](https://github.com/gethomepage/homepage/assets/5442891/b7232e61-3af4-490a-b3d2-e31a60d55913)


## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added corresponding documentation changes.
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
