### PR TITLE
Fix: Service without a name breaks homepage when using quicklaunch

### DIFF
--- a/src/components/quicklaunch.jsx
+++ b/src/components/quicklaunch.jsx
@@ -84,7 +84,7 @@ export default function QuickLaunch({servicesAndBookmarks, searchString, setSear
     if (searchString.length === 0) setResults([]);
     else {
       let newResults = servicesAndBookmarks.filter(r => {
-        const nameMatch = r.name.toLowerCase().includes(searchString);
+        const nameMatch = r?.name?.toLowerCase()?.includes(searchString);
         let descriptionMatch;
         if (searchDescriptions) {
           descriptionMatch = r.description?.toLowerCase().includes(searchString)


### PR DESCRIPTION
## Proposed change

As per title, following configuration breaks homepage 

```yaml
- Calendar:
    - Calendar:
        name:
        widget:
          type: calendar
```

with following error:
> Unhandled Runtime Error
> TypeError: can't access property "toLowerCase", r.name is null


## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added corresponding documentation changes.
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
