### PR TITLE
Fix: Quicklaunch shows also services without a url

### DIFF
--- a/src/components/quicklaunch.jsx
+++ b/src/components/quicklaunch.jsx
@@ -117,7 +117,7 @@ export default function QuickLaunch({servicesAndBookmarks, searchString, setSear
         )
       }
 
-      setResults(newResults);
+      setResults(newResults.filter(r => r?.href));
 
       if (newResults.length) {
         setCurrentItemIndex(0);

--- a/src/components/quicklaunch.jsx
+++ b/src/components/quicklaunch.jsx
@@ -117,7 +117,7 @@ export default function QuickLaunch({servicesAndBookmarks, searchString, setSear
         )
       }
 
-      setResults(newResults.filter(r => r?.href));
+      setResults(newResults);
 
       if (newResults.length) {
         setCurrentItemIndex(0);

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -183,7 +183,7 @@ function Home({ initialSettings }) {
   const { data: bookmarks } = useSWR("/api/bookmarks");
   const { data: widgets } = useSWR("/api/widgets");
 
-  const servicesAndBookmarks = [...services.map(sg => sg.services).flat(), ...bookmarks.map(bg => bg.bookmarks).flat()]
+  const servicesAndBookmarks = [...services.map(sg => sg.services).flat(), ...bookmarks.map(bg => bg.bookmarks).flat()].filter(i => i?.href);
 
   useEffect(() => {
     if (settings.language) {


### PR DESCRIPTION
## Proposed change

This fix addresses the issue where quicklaunch shows all the services, even non-clickable ones, without a url. 

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added corresponding documentation changes.
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
