### PR TITLE
Feature: Add widget for Matrix/Synapse server stats

### DIFF
--- a/docs/widgets/services/synapse.md
+++ b/docs/widgets/services/synapse.md
@@ -1,0 +1,19 @@
+---
+title: Synapse (Matrix)
+description: Synapse (Matrix) Widget Configuration
+---
+
+This widget displays statistics of your Synapse Matrix homeserver, showing registered users, stored rooms, and federated peers.
+
+Note that the URL provided in the widget should be one that has access to the Admin API at `/_synapse/admin/`. This API is not normally publicly accessible behind a reverse proxy, so be sure to use a URL that points to the homeserver locally.
+
+For obtaining your access_token, see the [documentation on the Admin API](https://matrix-org.github.io/synapse/latest/usage/administration/admin_api/index.html). Element lets you obtain it through `All Settings > Help & About > Advanced > Access Token`.
+
+Allowed fields: `["users", "rooms", "peers"]`.
+
+```yaml
+widget:
+  type: synapse
+  url: http://synapse.host.or.ip:port
+  key: access_token
+```

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -757,5 +757,10 @@
         "inCinemas": "In cinemas",
         "physicalRelease": "Physical release",
         "digitalRelease": "Digital release"
+    },
+    "synapse": {
+        "users": "Users",
+        "rooms": "Rooms",
+        "peers": "Peers"
     }
 }

--- a/src/utils/proxy/handlers/credentialed.js
+++ b/src/utils/proxy/handlers/credentialed.js
@@ -36,6 +36,7 @@ export default async function credentialedProxyHandler(req, res, map) {
         "tailscale",
         "truenas",
         "pterodactyl",
+        "synapse",
         ].includes(widget.type))
         {
           headers.Authorization = `Bearer ${widget.key}`;

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -88,6 +88,7 @@ const components = {
   scrutiny: dynamic(() => import("./scrutiny/component")),
   sonarr: dynamic(() => import("./sonarr/component")),
   speedtest: dynamic(() => import("./speedtest/component")),
+  synapse: dynamic(() => import("./synapse/component")),
   strelaysrv: dynamic(() => import("./strelaysrv/component")),
   tailscale: dynamic(() => import("./tailscale/component")),
   tautulli: dynamic(() => import("./tautulli/component")),

--- a/src/widgets/synapse/component.jsx
+++ b/src/widgets/synapse/component.jsx
@@ -1,0 +1,37 @@
+import { useTranslation } from "next-i18next";
+
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+
+  const { widget } = service;
+
+  const { data: usersData, error: usersError } = useWidgetAPI(widget, "users");
+  const { data: roomsData, error: roomsError } = useWidgetAPI(widget, "rooms");
+  const { data: peersData, error: peersError } = useWidgetAPI(widget, "peers");
+
+  if (usersError || roomsError || peersError) {
+    return <Container service={service} error={usersError ?? roomsError ?? peersError} />;
+  }
+
+  if (!usersData || !roomsData || !peersData) {
+    return (
+      <Container service={service}>
+        <Block label="synapse.users" />
+        <Block label="synapse.rooms" />
+        <Block label="synapse.peers" />
+      </Container>
+    );
+  }
+
+  return (
+    <Container service={service}>
+      <Block label="synapse.users" value={t("common.number", { value: usersData.total })} />
+      <Block label="synapse.rooms" value={t("common.number", { value: roomsData.total_rooms })} />
+      <Block label="synapse.peers" value={t("common.number", { value: peersData.total })} />
+    </Container>
+  );
+}

--- a/src/widgets/synapse/widget.js
+++ b/src/widgets/synapse/widget.js
@@ -1,0 +1,20 @@
+import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
+
+const widget = {
+  api: "{url}/_synapse/admin/{endpoint}",
+  proxyHandler: credentialedProxyHandler,
+
+  mappings: {
+    users: {
+      endpoint: "v2/users",
+    },
+    rooms: {
+      endpoint: "v1/rooms",
+    },
+    peers: {
+      endpoint: "v1/federation/destinations",
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -81,6 +81,7 @@ import sabnzbd from "./sabnzbd/widget";
 import scrutiny from "./scrutiny/widget";
 import sonarr from "./sonarr/widget";
 import speedtest from "./speedtest/widget";
+import synapse from "./synapse/widget";
 import strelaysrv from "./strelaysrv/widget";
 import tailscale from "./tailscale/widget";
 import tautulli from "./tautulli/widget";
@@ -183,6 +184,7 @@ const widgets = {
   scrutiny,
   sonarr,
   speedtest,
+  synapse,
   strelaysrv,
   tailscale,
   tautulli,


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well updates to the docs for the new widget.
-->

A service widget that allows for easy viewing of server statistics for Synapse, the official homeserver application for Matrix.

![image](https://github.com/gethomepage/homepage/assets/41478239/721e94a1-c82d-4ad6-a4c6-bd24373e58da)

This doesn't close any issues. I just thought this would be a nice thing to have, especially for administrators of larger Matrix homeservers.

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [x] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If adding a service widget or a change that requires it, I have added corresponding documentation changes.
- [x] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
