### PR TITLE
Fix: sonarr widget queue duplicates

### DIFF
--- a/src/widgets/sonarr/component.jsx
+++ b/src/widgets/sonarr/component.jsx
@@ -72,7 +72,7 @@ export default function Component({ service }) {
             timeLeft={queueEntry.timeLeft}
             title={getTitle(queueEntry, seriesData) ?? t("sonarr.unknown")}
             activity={formatDownloadState(queueEntry.trackedDownloadState)}
-            key={`${queueEntry.seriesId}-${queueEntry.sizeLeft}`}
+            key={`${queueEntry.seriesId}-${queueEntry.episodeId}`}
           />
         ))
       }


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well updates to the docs for the new widget.
-->

Closes #1801
A queue item could end up with a different React component key after each API call. 

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added corresponding documentation changes.
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
