### PR TITLE
Changedetection.io: Skip checking for diff if watch never had a change

### DIFF
--- a/src/widgets/changedetectionio/component.jsx
+++ b/src/widgets/changedetectionio/component.jsx
@@ -28,7 +28,7 @@ export default function Component({ service }) {
   let diffsDetected = 0;
 
   Object.keys(data).forEach((key) => {
-    if ((data[key].last_changed > 0) && (data[key].last_checked === data[key].last_changed)) {
+    if (data[key].last_changed > 0 && data[key].last_checked === data[key].last_changed) {
       diffsDetected += 1;
     }
   });

--- a/src/widgets/changedetectionio/component.jsx
+++ b/src/widgets/changedetectionio/component.jsx
@@ -28,7 +28,7 @@ export default function Component({ service }) {
   let diffsDetected = 0;
 
   Object.keys(data).forEach((key) => {
-    if (data[key].last_checked === data[key].last_changed) {
+    if ((data[key].last_changed > 0) && (data[key].last_checked === data[key].last_changed)) {
       diffsDetected += 1;
     }
   });


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well updates to the docs for the new widget.
-->


If a changedetection.io watch never had a change before, the api will return `0` for `last_changed`, this is often combined with the same watch never been checked before, which would make `last_checked` also `0`, that in turn would trigger a `diffsDetected` for the widget. That's incorrect, since the watch never been checked (and also never seen any changes) before.

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added corresponding documentation changes.
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
