### PR TITLE
Fix references to podSelector in k8s manifests

### DIFF
--- a/docs/configs/kubernetes.md
+++ b/docs/configs/kubernetes.md
@@ -36,7 +36,7 @@ Inside of the service you'd like to connect to a pod:
 
 The `app` field is used to create a label selector, in this example case it would match pods with the label: `app.kubernetes.io/name=emby`.
 
-Sometimes this is insufficient for complex or atypical application deployments. In these cases, the `podSelector` field can be used. Any field selector can be used with it, so it allows for some very powerful selection capabilities.
+Sometimes this is insufficient for complex or atypical application deployments. In these cases, the `pod-selector` field can be used. Any field selector can be used with it, so it allows for some very powerful selection capabilities.
 
 For instance, it can be utilized to roll multiple underlying deployments under one application to see a high-level aggregate:
 
@@ -47,7 +47,7 @@ For instance, it can be utilized to roll multiple underlying deployments under o
       description: Matrix Synapse Powered Chat
       app: matrix-element
       namespace: comms
-      podSelector: >-
+      pod-selector: >-
           app.kubernetes.io/instance in (
               matrix-element,
               matrix-media-repo,
@@ -58,7 +58,7 @@ For instance, it can be utilized to roll multiple underlying deployments under o
 
 !!! note
 
-    A blank string as a podSelector does not deactivate it, but will actually select all pods in the namespace. This is a useful way to capture the resource usage of a complex application siloed to a single namespace, like Longhorn.
+    A blank string as a pod-selector does not deactivate it, but will actually select all pods in the namespace. This is a useful way to capture the resource usage of a complex application siloed to a single namespace, like Longhorn.
 
 ## Automatic Service Discovery
 
@@ -77,7 +77,7 @@ metadata:
         gethomepage.dev/name: Emby
         gethomepage.dev/widget.type: "emby"
         gethomepage.dev/widget.url: "https://emby.example.com"
-        gethomepage.dev/podSelector: ""
+        gethomepage.dev/pod-selector: ""
         gethomepage.dev/weight: 10 # optional
 spec:
     rules:
@@ -113,7 +113,7 @@ metadata:
         gethomepage.dev/name: Emby
         gethomepage.dev/widget.type: "emby"
         gethomepage.dev/widget.url: "https://emby.example.com"
-        gethomepage.dev/podSelector: ""
+        gethomepage.dev/pod-selector: ""
         gethomepage.dev/weight: 10 # optional
 spec:
     entryPoints:

--- a/kubernetes.md
+++ b/kubernetes.md
@@ -98,7 +98,7 @@ be configured on the service entry.
 This works by creating a label selector `app.kubernetes.io/name=home-assistant`,
 which typically will be the same both for the ingress and the deployment. However,
 some deployments can be complex and will not conform to this rule. In such
-cases the `podSelector` variable can bridge the gap. Any field selector can
+cases the `pod-selector` variable can bridge the gap. Any field selector can
 be used in it which allows for some powerful selection capabilities.
 
 For instance, it can be utilized to roll multiple underlying deployments under
@@ -112,7 +112,7 @@ one application to see a high-level aggregate:
         description: Matrix Synapse Powered Chat
         app: matrix-element
         namespace: comms
-        podSelector: >-
+        pod-selector: >-
             app.kubernetes.io/instance in (
                 matrix-element,
                 matrix-media-repo,

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -164,7 +164,6 @@ export async function checkCRD(kc, name) {
 export async function servicesFromKubernetes() {
   const ANNOTATION_BASE = "gethomepage.dev";
   const ANNOTATION_WIDGET_BASE = `${ANNOTATION_BASE}/widget.`;
-  const ANNOTATION_POD_SELECTOR = `${ANNOTATION_BASE}/pod-selector`;
 
   checkAndCopyConfig("kubernetes.yaml");
 
@@ -253,8 +252,8 @@ export async function servicesFromKubernetes() {
           constructedService.external =
             String(ingress.metadata.annotations[`${ANNOTATION_BASE}/external`]).toLowerCase() === "true";
         }
-        if (ingress.metadata.annotations[ANNOTATION_POD_SELECTOR]) {
-          constructedService.podSelector = ingress.metadata.annotations[ANNOTATION_POD_SELECTOR];
+        if (ingress.metadata.annotations[`${ANNOTATION_BASE}/pod-selector`]) {
+          constructedService.podSelector = ingress.metadata.annotations[`${ANNOTATION_BASE}/pod-selector`];
         }
         if (ingress.metadata.annotations[`${ANNOTATION_BASE}/ping`]) {
           constructedService.ping = ingress.metadata.annotations[`${ANNOTATION_BASE}/ping`];


### PR DESCRIPTION
## Proposed change

This may have been causing some confusion. Internally homepage uses `podSelector` (it gets assigned in service-helpers) but in manifests should be `pod-selector`.

See https://github.com/gethomepage/homepage/commit/4d6ce1f7e2a8dfa99225877d74a506c5ab5f4bd1

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added corresponding documentation changes.
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [ ] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
