### PR TITLE
Documentation: add defaultinterval option for coinmarketcap

### DIFF
--- a/docs/widgets/services/coin-market-cap.md
+++ b/docs/widgets/services/coin-market-cap.md
@@ -13,6 +13,7 @@ widget:
     currency: GBP # Optional
     symbols: [BTC, LTC, ETH]
     key: apikeyapikeyapikeyapikeyapikey
+    defaultinterval: 7d # Optional
 ```
 
 You can also specify slugs instead of symbols (since symbols aren't garaunteed to be unique). If you supply both, slugs will be used. For example:


### PR DESCRIPTION
Found a missing parameter in docs - "defaultinterval"

## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well updates to the docs for the new widget.
-->

Adds missing parameter into documentation

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added corresponding documentation changes.
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [ ] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
