### PR TITLE
Enhancement: mjpeg stream widget placeholder image

### DIFF
--- a/src/widgets/mjpeg/component.jsx
+++ b/src/widgets/mjpeg/component.jsx
@@ -1,14 +1,16 @@
 import Image from "next/image";
+import { useState } from 'react';
 
 export default function Component({ service }) {
   const { widget } = service;
   const { stream, fit = "contain" } = widget;
+  const [src, setImgSrc] = useState(stream);
 
   return (
     <div>
       <div className="absolute top-0 bottom-0 right-0 left-0">
-        <Image layout="fill" objectFit="fill" className="blur-md" src={stream} alt="stream" />
-        <Image layout="fill" objectFit={fit} className="drop-shadow-2xl" src={stream} alt="stream" />
+        <Image layout="fill" objectFit="fill" className="blur-md" src={src} alt="stream" onError={() => setImgSrc('https://images.unsplash.com/photo-1610337673044-720471f83677?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1972&q=80')} />
+        <Image layout="fill" objectFit={fit} className="drop-shadow-2xl" src={src} alt="stream" onError={() => setImgSrc('https://images.unsplash.com/photo-1610337673044-720471f83677?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1972&q=80')} />
       </div>
       <div className="absolute top-0 right-0 bottom-0 left-0 overflow-clip shadow-[inset_0_0_200px_#000] shadow-theme-700/10 dark:shadow-theme-900/10" />
       <div className="h-[68px] overflow-clip" />


### PR DESCRIPTION
## Proposed change

Added a placeholder image (no signal) when stream fails to load/ stream is switched off in mjpeg widget instead of showing the default broken image. Broken image ruins the overall look of the dashboard :)

Earlier (alongside Octoprint):
![Screenshot from 2023-10-15 21-01-51](https://github.com/gethomepage/homepage/assets/5275731/8bf47050-4c5c-4e04-a9e0-d71cfa2c84b1)

With Fix (alongside Octoprint):
![Screenshot from 2023-10-15 22-07-05](https://github.com/gethomepage/homepage/assets/5275731/0805d92d-a13c-4eb2-858e-eb7cfd790e5e)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added corresponding documentation changes.
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] If applicable, I have checked that all tests pass with e.g. `pnpm lint`.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
