### PR TITLE
Fix: Tab spacing on mobile

### DIFF
--- a/src/components/tab.jsx
+++ b/src/components/tab.jsx
@@ -14,7 +14,7 @@ export default function Tab({ tab }) {
     <li
       key={tab}
       role="presentation"
-      className={classNames("text-theme-700 dark:text-theme-200 relative h-8 w-full rounded-md flex m-1")}
+      className={classNames("text-theme-700 dark:text-theme-200 relative h-10 w-full rounded-md flex")}
     >
       <button
         id={`${tab}-tab`}
@@ -23,7 +23,7 @@ export default function Tab({ tab }) {
         aria-controls={`#${tab}`}
         aria-selected={activeTab === slugify(tab) ? "true" : "false"}
         className={classNames(
-          "h-full w-full rounded-md",
+          "w-full rounded-md m-1",
           activeTab === slugify(tab)
             ? "bg-theme-300/20 dark:bg-white/10"
             : "hover:bg-theme-100/20 dark:hover:bg-white/5",


### PR DESCRIPTION
## Proposed change

<img width="708" alt="Screenshot 2023-10-18 at 1 17 54 PM" src="https://github.com/gethomepage/homepage/assets/4887959/4c8bea82-b9df-48d4-8a17-4b19e5ea118a">
<img width="701" alt="Screenshot 2023-10-18 at 1 21 17 PM" src="https://github.com/gethomepage/homepage/assets/4887959/c8609579-e90e-4eeb-b1f9-007cfb1eb31c">

desktop stays same:
<img width="1495" alt="Screenshot 2023-10-18 at 1 21 23 PM" src="https://github.com/gethomepage/homepage/assets/4887959/b8943abe-c414-4126-89b2-effcfcec65ea">


Closes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added corresponding documentation changes.
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using pre-commit hooks and linting checks with `pnpm lint` (see development guidelines).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
