### PR TITLE
Feature: add date formatting option in custom api

### DIFF
--- a/docs/widgets/services/customapi.md
+++ b/docs/widgets/services/customapi.md
@@ -31,9 +31,13 @@ widget:
             another: key3
       label: Field 3
       format: percent # optional - defaults to text
+    - field: key # needs to be YAML string or object
+      label: Field 4
+      format: date # optional - defaults to text
+      dateStyle: long # optional - defaults to "long". Allowed values: `["full", "long", "medium", "short"]`.
 ```
 
-Supported formats for the values are `text`, `number`, `float`, `percent`, `bytes` and `bitrate`.
+Supported formats for the values are `text`, `number`, `float`, `percent`, `bytes`, `bitrate` and `date`.
 
 ## Example
 

--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -123,6 +123,9 @@ module.exports = {
         i18next.services.formatter.add("percent", (value, lng, options) =>
           new Intl.NumberFormat(lng, { style: "percent", ...options }).format(parseFloat(value) / 100.0),
         );
+        i18next.services.formatter.add("date", (value, lng, options) =>
+          new Intl.DateTimeFormat(lng, { ...options }).format(new Date(value)),
+        );
       },
       type: "3rdParty",
     },

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -10,7 +10,8 @@
         "bibitrate": "{{value, rate(bits: true; binary: true)}}",
         "percent": "{{value, percent}}",
         "number": "{{value, number}}",
-        "ms": "{{value, number}}"
+        "ms": "{{value, number}}",
+        "date": "{{value, date}}"
     },
     "widget": {
         "missing_type": "Missing Widget Type: {{type}}",

--- a/src/widgets/customapi/component.jsx
+++ b/src/widgets/customapi/component.jsx
@@ -70,7 +70,7 @@ function formatValue(t, mapping, rawValue) {
       value = t("common.bitrate", { value });
       break;
     case "date":
-      value = t("common.date", { value, dateStyle: "long" });
+      value = t("common.date", { value, dateStyle: mapping?.dateStyle ?? "long" });
       break;
     case "text":
     default:

--- a/src/widgets/customapi/component.jsx
+++ b/src/widgets/customapi/component.jsx
@@ -69,6 +69,9 @@ function formatValue(t, mapping, rawValue) {
     case "bitrate":
       value = t("common.bitrate", { value });
       break;
+    case "date":
+      value = t("common.date", { value, dateStyle: "long" });
+      break;
     case "text":
     default:
     // nothing


### PR DESCRIPTION
## Proposed change

* Add date formatting option

Before:
![image](https://github.com/gethomepage/homepage/assets/16289034/0871a4ac-138e-49dd-8386-a63ba0b2015b)

After:

![image](https://github.com/gethomepage/homepage/assets/16289034/34d5ea0e-17d4-41d5-8e3a-0622cdf69e0d)

* The date format will be parsed from the `dateStyle` property (default value: `long`):
```yaml
...
- field:
    time_entries:
      0: created_on
  label: Created at
  format: date
  dateStyle: long
...
```

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added corresponding documentation changes.
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using pre-commit hooks and linting checks with `pnpm lint` (see development guidelines).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
