### PR TITLE
Fix authentik users endpoint URL

### DIFF
--- a/src/widgets/authentik/widget.js
+++ b/src/widgets/authentik/widget.js
@@ -6,7 +6,7 @@ const widget = {
 
   mappings: {
     users: {
-      endpoint: "core/users?page_size=1",
+      endpoint: "core/users/?page_size=1",
     },
     login: {
       endpoint: "events/events/per_month/?action=login",


### PR DESCRIPTION
## Proposed change

Has nothing to do with uuid, seems their new versions enforce the trailing slash

Closes #2243

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added corresponding documentation changes.
- [x] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using pre-commit hooks and linting checks with `pnpm lint` (see development guidelines).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
