### PR TITLE
Enhancement: Add port_forwarded field to Gluetun widget

### DIFF
--- a/docs/widgets/services/gluetun.md
+++ b/docs/widgets/services/gluetun.md
@@ -9,7 +9,7 @@ Learn more about [Gluetun](https://github.com/qdm12/gluetun).
 
     Requires [HTTP control server options](https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md) to be enabled. By default this runs on port `8000`.
 
-Allowed fields: `["public_ip", "region", "country"]`.
+Allowed fields: `["public_ip", "region", "country", "port_forwarded"]`.
 
 To setup authentication, follow [the official Gluetun documentation](https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md#authentication). Note that to use the api key method, you must add the route `GET /v1/publicip/ip` to the `routes` array in your Gluetun config.toml.
 

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -568,7 +568,8 @@
     "gluetun": {
         "public_ip": "Public IP",
         "region": "Region",
-        "country": "Country"
+        "country": "Country",
+        "port_forwarded": "Port Forwarded"
     },
     "hdhomerun": {
         "channels": "Channels",

--- a/src/widgets/gluetun/component.jsx
+++ b/src/widgets/gluetun/component.jsx
@@ -7,17 +7,19 @@ export default function Component({ service }) {
   const { widget } = service;
 
   const { data: gluetunData, error: gluetunError } = useWidgetAPI(widget, "ip");
+  const { data: portForwardedData, error: portForwardedError } = useWidgetAPI(widget, "port_forwarded");
 
-  if (gluetunError) {
-    return <Container service={service} error={gluetunError} />;
+  if (gluetunError || portForwardedError) {
+    return <Container service={service} error={gluetunError || portForwardedError} />;
   }
 
-  if (!gluetunData) {
+  if (!gluetunData || !portForwardedData) {
     return (
       <Container service={service}>
         <Block label="gluetun.public_ip" />
         <Block label="gluetun.region" />
         <Block label="gluetun.country" />
+        <Block label="gluetun.port_forwarded" />
       </Container>
     );
   }
@@ -27,6 +29,7 @@ export default function Component({ service }) {
       <Block label="gluetun.public_ip" value={gluetunData.public_ip} />
       <Block label="gluetun.region" value={gluetunData.region} />
       <Block label="gluetun.country" value={gluetunData.country} />
+      <Block label="gluetun.port_forwarded" value={portForwardedData.port} />
     </Container>
   );
 }

--- a/src/widgets/gluetun/widget.js
+++ b/src/widgets/gluetun/widget.js
@@ -9,6 +9,10 @@ const widget = {
       endpoint: "publicip/ip",
       validate: ["public_ip", "country"],
     },
+    port_forwarded: {
+      endpoint: "openvpn/portforwarded",
+      validate: ["port"],
+    },
   },
 };
 


### PR DESCRIPTION
## Proposed change

Adds a fourth field block displaying the server side port  being forwarded. 

This information is useful to have at glance on your homepage as some vpn services don't assign a static forwarded port. For p2p services such as BitTorrent in order to be connectable you will need to configure and continually keep this port updated.

<img width="508" alt="Screenshot 2023-10-30 at 11 31 20 PM" src="https://github.com/gethomepage/homepage/assets/7660824/0cbc3c58-349e-49a7-a097-7af693c0739e">


Closes #4576

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If adding a service widget or a change that requires it, I have added corresponding documentation changes.
- [x] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using pre-commit hooks and linting checks with `pnpm lint` (see development guidelines).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
