### PR TITLE
Feature: Added timeStyle to date format for custom API

### DIFF
--- a/docs/widgets/services/customapi.md
+++ b/docs/widgets/services/customapi.md
@@ -35,6 +35,7 @@ widget:
       label: Field 4
       format: date # optional - defaults to text
       dateStyle: long # optional - defaults to "long". Allowed values: `["full", "long", "medium", "short"]`.
+      timeStyle: medium # optional - Allowed values: `["full", "long", "medium", "short"]`.
 ```
 
 Supported formats for the values are `text`, `number`, `float`, `percent`, `bytes`, `bitrate` and `date`.

--- a/src/widgets/customapi/component.jsx
+++ b/src/widgets/customapi/component.jsx
@@ -70,7 +70,7 @@ function formatValue(t, mapping, rawValue) {
       value = t("common.bitrate", { value });
       break;
     case "date":
-      value = t("common.date", { value, dateStyle: mapping?.dateStyle ?? "long" });
+      value = t("common.date", { value, dateStyle: mapping?.dateStyle ?? "long", timeStyle: mapping?.timeStyle });
       break;
     case "text":
     default:


### PR DESCRIPTION
## Proposed change

- Added timeStyle option to custom API service.
- If no timeStyle option is set, only the date is shown.

Example: (November 8, 2023 at 7:00:00 PM)
```yaml
widget:
  type: customapi
  ...
  mappings:
    - field: key
      label: Field 4
      format: date
      dateStyle: long
      timeStyle: medium # optional - Allowed values: `["full", "long", "medium", "short"]`.
```

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If adding a service widget or a change that requires it, I have added corresponding documentation changes.
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using pre-commit hooks and linting checks with `pnpm lint` (see development guidelines).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
