### PR TITLE
Enhancement: open the searchbox on paste

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -223,7 +223,10 @@ function Home({ initialSettings }) {
   useEffect(() => {
     function handleKeyDown(e) {
       if (e.target.tagName === "BODY" || e.target.id === "inner_wrapper") {
-        if (e.key.length === 1 && (e.key.match(/(\w|\s)/g) && !(e.altKey || e.ctrlKey || e.metaKey || e.shiftKey)) || (e.key === "v" && e.ctrlKey)) {
+        if (
+          (e.key.length === 1 && e.key.match(/(\w|\s)/g) && !(e.altKey || e.ctrlKey || e.metaKey || e.shiftKey)) ||
+          (e.key === "v" && (e.ctrlKey || e.metaKey))
+        ) {
           setSearching(true);
         } else if (e.key === "Escape") {
           setSearchString("");

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -223,7 +223,7 @@ function Home({ initialSettings }) {
   useEffect(() => {
     function handleKeyDown(e) {
       if (e.target.tagName === "BODY" || e.target.id === "inner_wrapper") {
-        if (e.key.length === 1 && e.key.match(/(\w|\s)/g) && !(e.altKey || e.ctrlKey || e.metaKey || e.shiftKey)) {
+        if (e.key.length === 1 && (e.key.match(/(\w|\s)/g) && !(e.altKey || e.ctrlKey || e.metaKey || e.shiftKey)) || (e.key === "v" && e.ctrlKey)) {
           setSearching(true);
         } else if (e.key === "Escape") {
           setSearchString("");


### PR DESCRIPTION
## Open the searchbox when detecting Ctrl-V.

This changes allows the user to search for the string in the clipboard by pasting it into Homepage.

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added corresponding documentation changes.
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using pre-commit hooks and linting checks with `pnpm lint` (see development guidelines).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
