### PR TITLE
Fix: dont set pinned icon if custom favicon

### DIFF
--- a/src/pages/_document.jsx
+++ b/src/pages/_document.jsx
@@ -10,7 +10,6 @@ export default function Document() {
         />
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <link rel="manifest" href="/site.webmanifest?v=4" crossOrigin="use-credentials" />
-        <link rel="mask-icon" href="/safari-pinned-tab.svg?v=4" color="#1e9cd7" />
       </Head>
       <body>
         <Main />

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -375,6 +375,7 @@ function Home({ initialSettings }) {
             <link rel="shortcut icon" href="/homepage.ico" />
             <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=4" />
             <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?v=4" />
+            <link rel="mask-icon" href="/safari-pinned-tab.svg?v=4" color="#1e9cd7" />
           </>
         )}
         <meta name="msapplication-TileColor" content={themes[settings.color || "slate"][settings.theme || "dark"]} />


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well updates to the docs for the new widget.
-->

Closes #2323 

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added corresponding documentation changes.
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using pre-commit hooks and linting checks with `pnpm lint` (see development guidelines).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
