### PR TITLE
Fix: sum throughput data for docker stats

### DIFF
--- a/src/widgets/docker/component.jsx
+++ b/src/widgets/docker/component.jsx
@@ -1,7 +1,7 @@
 import useSWR from "swr";
 import { useTranslation } from "next-i18next";
 
-import { calculateCPUPercent, calculateUsedMemory } from "./stats-helpers";
+import { calculateCPUPercent, calculateUsedMemory, calculateThroughput } from "./stats-helpers";
 
 import Container from "components/services/widget/container";
 import Block from "components/services/widget/block";
@@ -41,7 +41,7 @@ export default function Component({ service }) {
     );
   }
 
-  const network = statsData.stats.networks?.eth0 || statsData.stats.networks?.network;
+  const { rx_bytes, tx_bytes } = calculateThroughput(statsData.stats);
 
   return (
     <Container service={service}>
@@ -49,10 +49,10 @@ export default function Component({ service }) {
       {statsData.stats.memory_stats.usage && (
         <Block label="docker.mem" value={t("common.bytes", { value: calculateUsedMemory(statsData.stats) })} />
       )}
-      {network && (
+      {statsData.stats.networks && (
         <>
-          <Block label="docker.rx" value={t("common.bytes", { value: network.rx_bytes })} />
-          <Block label="docker.tx" value={t("common.bytes", { value: network.tx_bytes })} />
+          <Block label="docker.rx" value={t("common.bytes", { value: rx_bytes })} />
+          <Block label="docker.tx" value={t("common.bytes", { value: tx_bytes })} />
         </>
       )}
     </Container>

--- a/src/widgets/docker/stats-helpers.js
+++ b/src/widgets/docker/stats-helpers.js
@@ -16,3 +16,18 @@ export function calculateUsedMemory(stats) {
     stats.memory_stats.usage - (stats.memory_stats.total_inactive_file ?? stats.memory_stats.stats?.inactive_file ?? 0)
   );
 }
+
+export function calculateThroughput(stats) {
+  let rx_bytes = 0;
+  let tx_bytes = 0;
+  if (stats.networks?.network) {
+    rx_bytes = stats.networks?.network.rx_bytes;
+    tx_bytes = stats.networks?.network.tx_bytes;
+  } else if (stats.networks && Array.isArray(Object.values(stats.networks))) {
+    Object.values(stats.networks).forEach((containerInterface) => {
+      rx_bytes += containerInterface.rx_bytes;
+      tx_bytes += containerInterface.tx_bytes;
+    });
+  }
+  return { rx_bytes, tx_bytes };
+}


### PR DESCRIPTION
## Proposed change

I believe this is in fact correct, see https://github.com/docker/cli/issues/647

E.g. with the data from the linked issue:
<img width="179" alt="Screenshot 2023-11-16 at 11 51 12 PM" src="https://github.com/gethomepage/homepage/assets/4887959/0e404bdb-db2b-4ca3-9f62-da49f9cf7ea1">


Closes #2333

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added corresponding documentation changes.
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using pre-commit hooks and linting checks with `pnpm lint` (see development guidelines).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
