### PR TITLE
Enhancement: Add service discovery support for multiple homepage instances

### DIFF
--- a/docs/configs/docker.md
+++ b/docs/configs/docker.md
@@ -201,6 +201,21 @@ In order to detect every service within the Docker swarm it is necessary that se
 ...
 ```
 
+## Multiple Homepage Instances
+
+The optional field `instanceName` can be configured in [settings.md](settings.md#instance-name) to differentiate between multiple homepage instances.
+
+To limit a label to an instance, insert `.instance.{{instanceName}}` after the `homepage` prefix.
+```yaml
+labels:
+  - homepage.group=Media
+  - homepage.name=Emby
+  - homepage.icon=emby.png
+  - homepage.instance.internal.href=http://emby.lan/
+  - homepage.instance.public.href=https://emby.mydomain.com/
+  - homepage.description=Media server
+```
+
 ## Ordering
 
 As of v0.6.4 discovered services can include an optional `weight` field to determine sorting such that:

--- a/docs/configs/docker.md
+++ b/docs/configs/docker.md
@@ -206,6 +206,7 @@ In order to detect every service within the Docker swarm it is necessary that se
 The optional field `instanceName` can be configured in [settings.md](settings.md#instance-name) to differentiate between multiple homepage instances.
 
 To limit a label to an instance, insert `.instance.{{instanceName}}` after the `homepage` prefix.
+
 ```yaml
 labels:
   - homepage.group=Media

--- a/docs/configs/settings.md
+++ b/docs/configs/settings.md
@@ -404,6 +404,16 @@ or per-service (`services.yaml`) with:
 
 If you have both set, the per-service settings take precedence.
 
+## Instance Name
+
+Name used by automatic docker service discovery to differentiate between multiple homepage instances.
+
+For example:
+
+```yaml
+instanceName: public
+```
+
 ## Hide Widget Error Messages
 
 Hide the visible API error messages either globally in `settings.yaml`:

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -59,7 +59,7 @@ export async function servicesFromDocker() {
     return [];
   }
 
-  const {instanceName} = getSettings()
+  const { instanceName } = getSettings();
 
   const serviceServers = await Promise.all(
     Object.keys(servers).map(async (serverName) => {
@@ -84,9 +84,9 @@ export async function servicesFromDocker() {
 
           Object.keys(containerLabels).forEach((label) => {
             if (label.startsWith("homepage.")) {
-              let value = label.replace("homepage.", "")
+              let value = label.replace("homepage.", "");
               if (instanceName && value.startsWith(`instance.${instanceName}.`)) {
-                value = value.replace(`instance.${instanceName}.`, "")
+                value = value.replace(`instance.${instanceName}.`, "");
               } else if (value.startsWith("instance.")) {
                 return;
               }
@@ -98,11 +98,7 @@ export async function servicesFromDocker() {
                   type: "service",
                 };
               }
-              shvl.set(
-                constructedService,
-                value,
-                substituteEnvironmentVars(containerLabels[label]),
-              );
+              shvl.set(constructedService, value, substituteEnvironmentVars(containerLabels[label]));
             }
           });
 

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -6,7 +6,7 @@ import Docker from "dockerode";
 import { CustomObjectsApi, NetworkingV1Api, ApiextensionsV1Api } from "@kubernetes/client-node";
 
 import createLogger from "utils/logger";
-import checkAndCopyConfig, { CONF_DIR, substituteEnvironmentVars } from "utils/config/config";
+import checkAndCopyConfig, { CONF_DIR, getSettings, substituteEnvironmentVars } from "utils/config/config";
 import getDockerArguments from "utils/config/docker";
 import getKubeConfig from "utils/config/kubernetes";
 import * as shvl from "utils/config/shvl";
@@ -59,6 +59,8 @@ export async function servicesFromDocker() {
     return [];
   }
 
+  const {instanceName} = getSettings()
+
   const serviceServers = await Promise.all(
     Object.keys(servers).map(async (serverName) => {
       try {
@@ -82,6 +84,13 @@ export async function servicesFromDocker() {
 
           Object.keys(containerLabels).forEach((label) => {
             if (label.startsWith("homepage.")) {
+              let value = label.replace("homepage.", "")
+              if (instanceName && value.startsWith(`instance.${instanceName}.`)) {
+                value = value.replace(`instance.${instanceName}.`, "")
+              } else if (value.startsWith("instance.")) {
+                return;
+              }
+
               if (!constructedService) {
                 constructedService = {
                   container: containerName.replace(/^\//, ""),
@@ -91,7 +100,7 @@ export async function servicesFromDocker() {
               }
               shvl.set(
                 constructedService,
-                label.replace("homepage.", ""),
+                value,
                 substituteEnvironmentVars(containerLabels[label]),
               );
             }


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well updates to the docs for the new widget.
-->

Adds support for scoping docker labels to specific homepage instances.

To limit a label to an instance, insert `.instance.{{instanceName}}` after the `homepage` prefix.
```yaml
labels:
  - homepage.group=Media
  - homepage.name=Emby
  - homepage.icon=emby.png
  - homepage.instance.internal.href=http://emby.lan/
  - homepage.instance.public.href=https://emby.mydomain.com/
  - homepage.description=Media server
```
In this example it is used with two homepage instances for internal and public access.

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If adding a service widget or a change that requires it, I have added corresponding documentation changes.
- [X] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [X] I have checked that all code style checks pass using pre-commit hooks and linting checks with `pnpm lint` (see development guidelines).
- [X] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
