### PR TITLE
Documentation: add example of Longhorn with basic auth

### DIFF
--- a/docs/widgets/info/longhorn.md
+++ b/docs/widgets/info/longhorn.md
@@ -26,4 +26,12 @@ It can show the aggregate metrics and/or the individual node metrics.
       - node2
 ```
 
-The Longhorn URL and credentials are stored in the `providers` section of the `settings.yaml`.
+The Longhorn URL and credentials are stored in the `providers` section of the `settings.yaml`.  e.g.:
+
+```yaml
+providers:
+    longhorn:
+        username: "longhorn-username" # optional
+        password: "very-secret-longhorn-password" # optional
+        url: https://longhorn.aesop.network
+```


### PR DESCRIPTION
## Proposed change
Had to dig into the source code to find the keys "username" and "password".  Adding to documentation to (hopefully) have less digging for others.

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If adding a service widget or a change that requires it, I have added corresponding documentation changes.
- [x] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using pre-commit hooks and linting checks with `pnpm lint` (see development guidelines).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
