### PR TITLE
Update the Gluetun widget docs to have more details

### DIFF
--- a/docs/widgets/services/gluetun.md
+++ b/docs/widgets/services/gluetun.md
@@ -4,6 +4,7 @@ description: Gluetun Widget Configuration
 ---
 
 !!! note
+
     Requires [HTTP control server options](https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md) to be enabled. By default this runs on port `8000`.
 
 Allowed fields: `["public_ip", "region", "country"]`.

--- a/docs/widgets/services/gluetun.md
+++ b/docs/widgets/services/gluetun.md
@@ -11,8 +11,5 @@ Allowed fields: `["public_ip", "region", "country"]`.
 ```yaml
 widget:
   type: gluetun
-  # Default port for HTTP control server. If you have changed 
-  # Gluetun's HTTP control server port, you will need to change
-  # the port here to match.
-  url: http://gluetun.host.or.ip:8000
+  url: http://gluetun.host.or.ip:port
 ```

--- a/docs/widgets/services/gluetun.md
+++ b/docs/widgets/services/gluetun.md
@@ -3,12 +3,16 @@ title: Gluetun
 description: Gluetun Widget Configuration
 ---
 
-Requires [HTTP control server options](https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md) to be enabled.
+!!! note
+    Requires [HTTP control server options](https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md) to be enabled. By default this runs on port `8000`.
 
 Allowed fields: `["public_ip", "region", "country"]`.
 
 ```yaml
 widget:
   type: gluetun
-  url: http://gluetun.host.or.ip
+  # Default port for HTTP control server. If you have changed 
+  # Gluetun's HTTP control server port, you will need to change
+  # the port here to match.
+  url: http://gluetun.host.or.ip:8000
 ```


### PR DESCRIPTION
## Proposed change

Add more details to the Gluetun's widget page:

* Converted the note about the HTTP control server to an [admonition](https://squidfunk.github.io/mkdocs-material/reference/admonitions/).
* Added more details about the default `8000` port number.

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added corresponding documentation changes.
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using pre-commit hooks and linting checks with `pnpm lint` (see development guidelines).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
