### PR TITLE
Enhancement: Add configurable refresh interval and points for glances service

### DIFF
--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -336,49 +336,87 @@ export function cleanServiceGroups(groups) {
 
       if (cleanedService.widget) {
         // whitelisted set of keys to pass to the frontend
+        // alphabetical, grouped by widget(s)
         const {
-          type, // all widgets
+          // all widgets
           fields,
           hideErrors,
-          server, // docker widget
-          container,
-          currency, // coinmarketcap widget
-          symbols,
-          slugs,
-          defaultinterval,
-          site, // unifi widget
-          namespace, // kubernetes widget
-          app,
-          podSelector,
-          wan, // opnsense widget, pfsense widget
-          enableBlocks, // emby/jellyfin
-          enableNowPlaying,
-          volume, // diskstation widget,
-          enableQueue, // sonarr/radarr
-          node, // Proxmox
-          snapshotHost, // kopia
-          snapshotPath,
-          userEmail, // azuredevops
+          type,
+
+          // azuredevops
           repositoryId,
-          metric, // glances
-          chart, // glances
-          pointsLimit, // glances
-          stream, // mjpeg
-          fit,
-          method, // openmediavault widget
-          mappings, // customapi widget
-          refreshInterval,
-          integrations, // calendar widget
+          userEmail,
+
+          // calendar
           firstDayInWeek,
-          view,
+          integrations,
           maxEvents,
-          src, // iframe widget
-          classes,
-          referrerPolicy,
-          allowPolicy,
+          view,
+
+          // coinmarketcap
+          currency,
+          defaultinterval,
+          slugs,
+          symbols,
+
+          // customapi
+          mappings,
+
+          // diskstation
+          volume,
+
+          // docker
+          container,
+          server,
+
+          // emby, jellyfin
+          enableBlocks,
+          enableNowPlaying,
+
+          // glances
+          chart,
+          metric,
+          pointsLimit,
+
+          // glances, customapi
+          refreshInterval,
+
+          // iframe
           allowFullscreen,
-          loadingStrategy,
+          allowPolicy,
           allowScrolling,
+          classes,
+          loadingStrategy,
+          referrerPolicy,
+          src,
+
+          // kopia
+          snapshotHost,
+          snapshotPath,
+
+          // kubernetes
+          app,
+          namespace,
+          podSelector,
+
+          // mjpeg
+          fit,
+          stream,
+
+          // openmediavault
+          method,
+
+          // opnsense, pfsense
+          wan,
+
+          // proxmox
+          node,
+
+          // sonarr, radarr
+          enableQueue,
+
+          // unifi
+          site,
         } = cleanedService.widget;
 
         let fieldsList = fields;
@@ -460,10 +498,10 @@ export function cleanServiceGroups(groups) {
           } else {
             cleanedService.widget.chart = true;
           }
-          if(refreshInterval && Number.isInteger(refreshInterval) && refreshInterval > 0){
+          if (refreshInterval && Number.isInteger(refreshInterval) && refreshInterval > 0) {
             cleanedService.widget.refreshInterval = refreshInterval;
           }
-          if(pointsLimit && Number.isInteger(pointsLimit) && pointsLimit > 0){
+          if (pointsLimit && Number.isInteger(pointsLimit) && pointsLimit > 0) {
             cleanedService.widget.pointsLimit = pointsLimit;
           }
         }

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -378,7 +378,7 @@ export function cleanServiceGroups(groups) {
           metric,
           pointsLimit,
 
-          // glances, customapi
+          // glances, customapi, iframe
           refreshInterval,
 
           // iframe
@@ -498,12 +498,8 @@ export function cleanServiceGroups(groups) {
           } else {
             cleanedService.widget.chart = true;
           }
-          if (refreshInterval && Number.isInteger(refreshInterval) && refreshInterval > 0) {
-            cleanedService.widget.refreshInterval = refreshInterval;
-          }
-          if (pointsLimit && Number.isInteger(pointsLimit) && pointsLimit > 0) {
-            cleanedService.widget.pointsLimit = pointsLimit;
-          }
+          if (refreshInterval) cleanedService.widget.refreshInterval = refreshInterval;
+          if (pointsLimit) cleanedService.widget.pointsLimit = pointsLimit;
         }
         if (type === "mjpeg") {
           if (stream) cleanedService.widget.stream = stream;

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -337,47 +337,47 @@ export function cleanServiceGroups(groups) {
       if (cleanedService.widget) {
         // whitelisted set of keys to pass to the frontend
         const {
-          type, // all widgets
-          fields,
-          hideErrors,
-          server, // docker widget
+          allowFullscreen,
+          allowPolicy,
+          allowScrolling,
+          app,
+          chart, // glances
+          classes,
           container,
           currency, // coinmarketcap widget
-          symbols,
-          slugs,
           defaultinterval,
-          site, // unifi widget
-          namespace, // kubernetes widget
-          app,
-          podSelector,
-          wan, // opnsense widget, pfsense widget
           enableBlocks, // emby/jellyfin
           enableNowPlaying,
-          volume, // diskstation widget,
           enableQueue, // sonarr/radarr
+          fields,
+          firstDayInWeek,
+          fit,
+          hideErrors,
+          integrations, // calendar widget
+          loadingStrategy,
+          mappings, // customapi widget
+          maxEvents,
+          method, // openmediavault widget
+          metric, // glances
+          namespace, // kubernetes widget
           node, // Proxmox
+          podSelector,
+          pointsLimit, // glances
+          refreshInterval,
+          referrerPolicy,
+          repositoryId,
+          server, // docker widget
+          site, // unifi widget
           snapshotHost, // kopia
           snapshotPath,
-          userEmail, // azuredevops
-          repositoryId,
-          metric, // glances
-          chart, // glances
-          stream, // mjpeg
-          fit,
-          method, // openmediavault widget
-          mappings, // customapi widget
-          refreshInterval,
-          integrations, // calendar widget
-          firstDayInWeek,
-          view,
-          maxEvents,
           src, // iframe widget
-          classes,
-          referrerPolicy,
-          allowPolicy,
-          allowFullscreen,
-          loadingStrategy,
-          allowScrolling,
+          stream, // mjpeg
+          symbols,
+          type, // all widgets
+          userEmail, // azuredevops
+          view,
+          volume, // diskstation widget,
+          wan, // opnsense widget, pfsense widget
         } = cleanedService.widget;
 
         let fieldsList = fields;
@@ -458,6 +458,12 @@ export function cleanServiceGroups(groups) {
             cleanedService.widget.chart = chart;
           } else {
             cleanedService.widget.chart = true;
+          }
+          if(refreshInterval && Number.isInteger(refreshInterval) && refreshInterval > 0){
+            cleanedService.widget.refreshInterval = refreshInterval;
+          }
+          if(pointsLimit && Number.isInteger(pointsLimit) && pointsLimit > 0){
+            cleanedService.widget.pointsLimit = pointsLimit;
           }
         }
         if (type === "mjpeg") {

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -337,47 +337,48 @@ export function cleanServiceGroups(groups) {
       if (cleanedService.widget) {
         // whitelisted set of keys to pass to the frontend
         const {
-          allowFullscreen,
-          allowPolicy,
-          allowScrolling,
-          app,
-          chart, // glances
-          classes,
+          type, // all widgets
+          fields,
+          hideErrors,
+          server, // docker widget
           container,
           currency, // coinmarketcap widget
+          symbols,
+          slugs,
           defaultinterval,
+          site, // unifi widget
+          namespace, // kubernetes widget
+          app,
+          podSelector,
+          wan, // opnsense widget, pfsense widget
           enableBlocks, // emby/jellyfin
           enableNowPlaying,
+          volume, // diskstation widget,
           enableQueue, // sonarr/radarr
-          fields,
-          firstDayInWeek,
-          fit,
-          hideErrors,
-          integrations, // calendar widget
-          loadingStrategy,
-          mappings, // customapi widget
-          maxEvents,
-          method, // openmediavault widget
-          metric, // glances
-          namespace, // kubernetes widget
           node, // Proxmox
-          podSelector,
-          pointsLimit, // glances
-          refreshInterval,
-          referrerPolicy,
-          repositoryId,
-          server, // docker widget
-          site, // unifi widget
           snapshotHost, // kopia
           snapshotPath,
-          src, // iframe widget
-          stream, // mjpeg
-          symbols,
-          type, // all widgets
           userEmail, // azuredevops
+          repositoryId,
+          metric, // glances
+          chart, // glances
+          pointsLimit, // glances
+          stream, // mjpeg
+          fit,
+          method, // openmediavault widget
+          mappings, // customapi widget
+          refreshInterval,
+          integrations, // calendar widget
+          firstDayInWeek,
           view,
-          volume, // diskstation widget,
-          wan, // opnsense widget, pfsense widget
+          maxEvents,
+          src, // iframe widget
+          classes,
+          referrerPolicy,
+          allowPolicy,
+          allowFullscreen,
+          loadingStrategy,
+          allowScrolling,
         } = cleanedService.widget;
 
         let fieldsList = fields;

--- a/src/widgets/glances/metrics/cpu.jsx
+++ b/src/widgets/glances/metrics/cpu.jsx
@@ -36,7 +36,7 @@ export default function Component({ service }) {
         return newDataPoints;
       });
     }
-  }, [data]);
+  }, [data, pointsLimit]);
 
   if (error) {
     return (

--- a/src/widgets/glances/metrics/cpu.jsx
+++ b/src/widgets/glances/metrics/cpu.jsx
@@ -21,7 +21,7 @@ export default function Component({ service }) {
   const [dataPoints, setDataPoints] = useState(new Array(pointsLimit).fill({ value: 0 }, 0, pointsLimit));
 
   const { data, error } = useWidgetAPI(service.widget, "cpu", {
-    refreshInterval,
+    refreshInterval: Math.max(defaultInterval, refreshInterval),
   });
 
   const { data: systemData, error: systemError } = useWidgetAPI(service.widget, "system");

--- a/src/widgets/glances/metrics/cpu.jsx
+++ b/src/widgets/glances/metrics/cpu.jsx
@@ -10,17 +10,18 @@ import useWidgetAPI from "utils/proxy/use-widget-api";
 
 const Chart = dynamic(() => import("../components/chart"), { ssr: false });
 
-const pointsLimit = 15;
+const defaultPointsLimit = 15;
+const defaultInterval = 1000;
 
 export default function Component({ service }) {
   const { t } = useTranslation();
   const { widget } = service;
-  const { chart } = widget;
+  const { chart, refreshInterval = defaultInterval, pointsLimit = defaultPointsLimit } = widget;
 
   const [dataPoints, setDataPoints] = useState(new Array(pointsLimit).fill({ value: 0 }, 0, pointsLimit));
 
   const { data, error } = useWidgetAPI(service.widget, "cpu", {
-    refreshInterval: 1000,
+    refreshInterval
   });
 
   const { data: systemData, error: systemError } = useWidgetAPI(service.widget, "system");

--- a/src/widgets/glances/metrics/cpu.jsx
+++ b/src/widgets/glances/metrics/cpu.jsx
@@ -21,7 +21,7 @@ export default function Component({ service }) {
   const [dataPoints, setDataPoints] = useState(new Array(pointsLimit).fill({ value: 0 }, 0, pointsLimit));
 
   const { data, error } = useWidgetAPI(service.widget, "cpu", {
-    refreshInterval
+    refreshInterval,
   });
 
   const { data: systemData, error: systemError } = useWidgetAPI(service.widget, "system");

--- a/src/widgets/glances/metrics/disk.jsx
+++ b/src/widgets/glances/metrics/disk.jsx
@@ -46,7 +46,7 @@ export default function Component({ service }) {
         return newDataPoints;
       });
     }
-  }, [data, diskName]);
+  }, [data, diskName, pointsLimit]);
 
   useEffect(() => {
     setRatePoints(calculateRates(dataPoints));

--- a/src/widgets/glances/metrics/disk.jsx
+++ b/src/widgets/glances/metrics/disk.jsx
@@ -25,7 +25,7 @@ export default function Component({ service }) {
   const [ratePoints, setRatePoints] = useState(new Array(pointsLimit).fill({ a: 0, b: 0 }, 0, pointsLimit));
 
   const { data, error } = useWidgetAPI(service.widget, "diskio", {
-    refreshInterval,
+    refreshInterval: Math.max(defaultInterval, refreshInterval),
   });
 
   const calculateRates = (d) =>

--- a/src/widgets/glances/metrics/disk.jsx
+++ b/src/widgets/glances/metrics/disk.jsx
@@ -10,12 +10,13 @@ import useWidgetAPI from "utils/proxy/use-widget-api";
 
 const ChartDual = dynamic(() => import("../components/chart_dual"), { ssr: false });
 
-const pointsLimit = 15;
+const defaultPointsLimit = 15;
+const defaultInterval = 1000;
 
 export default function Component({ service }) {
   const { t } = useTranslation();
   const { widget } = service;
-  const { chart } = widget;
+  const { chart, refreshInterval = defaultInterval, pointsLimit = defaultPointsLimit } = widget;
   const [, diskName] = widget.metric.split(":");
 
   const [dataPoints, setDataPoints] = useState(
@@ -24,7 +25,7 @@ export default function Component({ service }) {
   const [ratePoints, setRatePoints] = useState(new Array(pointsLimit).fill({ a: 0, b: 0 }, 0, pointsLimit));
 
   const { data, error } = useWidgetAPI(service.widget, "diskio", {
-    refreshInterval: 1000,
+    refreshInterval,
   });
 
   const calculateRates = (d) =>

--- a/src/widgets/glances/metrics/fs.jsx
+++ b/src/widgets/glances/metrics/fs.jsx
@@ -6,14 +6,16 @@ import Block from "../components/block";
 
 import useWidgetAPI from "utils/proxy/use-widget-api";
 
+const defaultInterval = 1000;
+
 export default function Component({ service }) {
   const { t } = useTranslation();
   const { widget } = service;
-  const { chart } = widget;
+  const { chart, refreshInterval = defaultInterval } = widget;
   const [, fsName] = widget.metric.split("fs:");
 
   const { data, error } = useWidgetAPI(widget, "fs", {
-    refreshInterval: 1000,
+    refreshInterval,
   });
 
   if (error) {

--- a/src/widgets/glances/metrics/fs.jsx
+++ b/src/widgets/glances/metrics/fs.jsx
@@ -15,7 +15,7 @@ export default function Component({ service }) {
   const [, fsName] = widget.metric.split("fs:");
 
   const { data, error } = useWidgetAPI(widget, "fs", {
-    refreshInterval,
+    refreshInterval: Math.max(defaultInterval, refreshInterval),
   });
 
   if (error) {

--- a/src/widgets/glances/metrics/gpu.jsx
+++ b/src/widgets/glances/metrics/gpu.jsx
@@ -22,7 +22,7 @@ export default function Component({ service }) {
   const [dataPoints, setDataPoints] = useState(new Array(pointsLimit).fill({ a: 0, b: 0 }, 0, pointsLimit));
 
   const { data, error } = useWidgetAPI(widget, "gpu", {
-    refreshInterval,
+    refreshInterval: Math.max(defaultInterval, refreshInterval),
   });
 
   useEffect(() => {

--- a/src/widgets/glances/metrics/gpu.jsx
+++ b/src/widgets/glances/metrics/gpu.jsx
@@ -10,18 +10,19 @@ import useWidgetAPI from "utils/proxy/use-widget-api";
 
 const ChartDual = dynamic(() => import("../components/chart_dual"), { ssr: false });
 
-const pointsLimit = 15;
+const defaultPointsLimit = 15;
+const defaultInterval = 1000;
 
 export default function Component({ service }) {
   const { t } = useTranslation();
   const { widget } = service;
-  const { chart } = widget;
+  const { chart, refreshInterval = defaultInterval, pointsLimit = defaultPointsLimit } = widget;
   const [, gpuName] = widget.metric.split(":");
 
   const [dataPoints, setDataPoints] = useState(new Array(pointsLimit).fill({ a: 0, b: 0 }, 0, pointsLimit));
 
   const { data, error } = useWidgetAPI(widget, "gpu", {
-    refreshInterval: 1000,
+    refreshInterval,
   });
 
   useEffect(() => {

--- a/src/widgets/glances/metrics/gpu.jsx
+++ b/src/widgets/glances/metrics/gpu.jsx
@@ -40,7 +40,7 @@ export default function Component({ service }) {
         });
       }
     }
-  }, [data, gpuName]);
+  }, [data, gpuName, pointsLimit]);
 
   if (error) {
     return (

--- a/src/widgets/glances/metrics/info.jsx
+++ b/src/widgets/glances/metrics/info.jsx
@@ -69,16 +69,19 @@ function Mem({ quicklookData, className = "" }) {
   );
 }
 
+const defaultInterval = 1000;
+const defaultSystemInterval = 30000; // This data (OS, hostname, distribution) is usually super stable.
+
 export default function Component({ service }) {
   const { widget } = service;
-  const { chart } = widget;
+  const { chart, refreshInterval = defaultInterval } = widget;
 
   const { data: quicklookData, errorL: quicklookError } = useWidgetAPI(service.widget, "quicklook", {
-    refreshInterval: 1000,
+    refreshInterval,
   });
 
   const { data: systemData, errorL: systemError } = useWidgetAPI(service.widget, "system", {
-    refreshInterval: 30000,
+    refreshInterval: defaultSystemInterval,
   });
 
   if (quicklookError) {

--- a/src/widgets/glances/metrics/memory.jsx
+++ b/src/widgets/glances/metrics/memory.jsx
@@ -11,13 +11,13 @@ import useWidgetAPI from "utils/proxy/use-widget-api";
 const ChartDual = dynamic(() => import("../components/chart_dual"), { ssr: false });
 
 const defaultPointsLimit = 15;
-const defaultInterval = (isChart) => isChart ? 1000 : 5000;
+const defaultInterval = (isChart) => (isChart ? 1000 : 5000);
 
 export default function Component({ service }) {
   const { t } = useTranslation();
   const { widget } = service;
-  const { chart} = widget;
-  const {refreshInterval = defaultInterval(chart), pointsLimit = defaultPointsLimit } = widget;
+  const { chart } = widget;
+  const { refreshInterval = defaultInterval(chart), pointsLimit = defaultPointsLimit } = widget;
 
   const [dataPoints, setDataPoints] = useState(new Array(pointsLimit).fill({ value: 0 }, 0, pointsLimit));
 

--- a/src/widgets/glances/metrics/memory.jsx
+++ b/src/widgets/glances/metrics/memory.jsx
@@ -22,7 +22,7 @@ export default function Component({ service }) {
   const [dataPoints, setDataPoints] = useState(new Array(pointsLimit).fill({ value: 0 }, 0, pointsLimit));
 
   const { data, error } = useWidgetAPI(service.widget, "mem", {
-    refreshInterval,
+    refreshInterval: Math.max(defaultInterval(chart), refreshInterval),
   });
 
   useEffect(() => {

--- a/src/widgets/glances/metrics/memory.jsx
+++ b/src/widgets/glances/metrics/memory.jsx
@@ -35,7 +35,7 @@ export default function Component({ service }) {
         return newDataPoints;
       });
     }
-  }, [data]);
+  }, [data, pointsLimit]);
 
   if (error) {
     return (

--- a/src/widgets/glances/metrics/memory.jsx
+++ b/src/widgets/glances/metrics/memory.jsx
@@ -10,17 +10,19 @@ import useWidgetAPI from "utils/proxy/use-widget-api";
 
 const ChartDual = dynamic(() => import("../components/chart_dual"), { ssr: false });
 
-const pointsLimit = 15;
+const defaultPointsLimit = 15;
+const defaultInterval = (isChart) => isChart ? 1000 : 5000;
 
 export default function Component({ service }) {
   const { t } = useTranslation();
   const { widget } = service;
-  const { chart } = widget;
+  const { chart} = widget;
+  const {refreshInterval = defaultInterval(chart), pointsLimit = defaultPointsLimit } = widget;
 
   const [dataPoints, setDataPoints] = useState(new Array(pointsLimit).fill({ value: 0 }, 0, pointsLimit));
 
   const { data, error } = useWidgetAPI(service.widget, "mem", {
-    refreshInterval: chart ? 1000 : 5000,
+    refreshInterval,
   });
 
   useEffect(() => {

--- a/src/widgets/glances/metrics/net.jsx
+++ b/src/widgets/glances/metrics/net.jsx
@@ -11,13 +11,13 @@ import useWidgetAPI from "utils/proxy/use-widget-api";
 const ChartDual = dynamic(() => import("../components/chart_dual"), { ssr: false });
 
 const defaultPointsLimit = 15;
-const defaultInterval = (isChart) => isChart ? 1000 : 5000;
+const defaultInterval = (isChart) => (isChart ? 1000 : 5000);
 
 export default function Component({ service }) {
   const { t } = useTranslation();
   const { widget } = service;
   const { chart, metric } = widget;
-  const {refreshInterval = defaultInterval(chart), pointsLimit = defaultPointsLimit } = widget;
+  const { refreshInterval = defaultInterval(chart), pointsLimit = defaultPointsLimit } = widget;
 
   const [, interfaceName] = metric.split(":");
 

--- a/src/widgets/glances/metrics/net.jsx
+++ b/src/widgets/glances/metrics/net.jsx
@@ -24,7 +24,7 @@ export default function Component({ service }) {
   const [dataPoints, setDataPoints] = useState(new Array(pointsLimit).fill({ value: 0 }, 0, pointsLimit));
 
   const { data, error } = useWidgetAPI(widget, "network", {
-    refreshInterval,
+    refreshInterval: Math.max(defaultInterval(chart), refreshInterval),
   });
 
   useEffect(() => {

--- a/src/widgets/glances/metrics/net.jsx
+++ b/src/widgets/glances/metrics/net.jsx
@@ -47,7 +47,7 @@ export default function Component({ service }) {
         });
       }
     }
-  }, [data, interfaceName]);
+  }, [data, interfaceName, pointsLimit]);
 
   if (error) {
     return (

--- a/src/widgets/glances/metrics/net.jsx
+++ b/src/widgets/glances/metrics/net.jsx
@@ -10,18 +10,21 @@ import useWidgetAPI from "utils/proxy/use-widget-api";
 
 const ChartDual = dynamic(() => import("../components/chart_dual"), { ssr: false });
 
-const pointsLimit = 15;
+const defaultPointsLimit = 15;
+const defaultInterval = (isChart) => isChart ? 1000 : 5000;
 
 export default function Component({ service }) {
   const { t } = useTranslation();
   const { widget } = service;
   const { chart, metric } = widget;
+  const {refreshInterval = defaultInterval(chart), pointsLimit = defaultPointsLimit } = widget;
+
   const [, interfaceName] = metric.split(":");
 
   const [dataPoints, setDataPoints] = useState(new Array(pointsLimit).fill({ value: 0 }, 0, pointsLimit));
 
   const { data, error } = useWidgetAPI(widget, "network", {
-    refreshInterval: chart ? 1000 : 5000,
+    refreshInterval,
   });
 
   useEffect(() => {

--- a/src/widgets/glances/metrics/process.jsx
+++ b/src/widgets/glances/metrics/process.jsx
@@ -17,13 +17,15 @@ const statusMap = {
   X: <ResolvedIcon icon="mdi-rhombus-outline" width={32} height={32} />, // dead
 };
 
+const defaultInterval = 1000;
+
 export default function Component({ service }) {
   const { t } = useTranslation();
   const { widget } = service;
-  const { chart } = widget;
+  const { chart, refreshInterval = defaultInterval } = widget;
 
   const { data, error } = useWidgetAPI(service.widget, "processlist", {
-    refreshInterval: 1000,
+    refreshInterval,
   });
 
   if (error) {

--- a/src/widgets/glances/metrics/process.jsx
+++ b/src/widgets/glances/metrics/process.jsx
@@ -25,7 +25,7 @@ export default function Component({ service }) {
   const { chart, refreshInterval = defaultInterval } = widget;
 
   const { data, error } = useWidgetAPI(service.widget, "processlist", {
-    refreshInterval,
+    refreshInterval: Math.max(defaultInterval, refreshInterval),
   });
 
   if (error) {

--- a/src/widgets/glances/metrics/sensor.jsx
+++ b/src/widgets/glances/metrics/sensor.jsx
@@ -36,7 +36,7 @@ export default function Component({ service }) {
         return newDataPoints;
       });
     }
-  }, [data, sensorName]);
+  }, [data, sensorName, pointsLimit]);
 
   if (error) {
     return (

--- a/src/widgets/glances/metrics/sensor.jsx
+++ b/src/widgets/glances/metrics/sensor.jsx
@@ -22,7 +22,7 @@ export default function Component({ service }) {
   const [dataPoints, setDataPoints] = useState(new Array(pointsLimit).fill({ value: 0 }, 0, pointsLimit));
 
   const { data, error } = useWidgetAPI(service.widget, "sensors", {
-    refreshInterval,
+    refreshInterval: Math.max(defaultInterval, refreshInterval),
   });
 
   useEffect(() => {

--- a/src/widgets/glances/metrics/sensor.jsx
+++ b/src/widgets/glances/metrics/sensor.jsx
@@ -10,18 +10,19 @@ import useWidgetAPI from "utils/proxy/use-widget-api";
 
 const Chart = dynamic(() => import("../components/chart"), { ssr: false });
 
-const pointsLimit = 15;
+const defaultPointsLimit = 15;
+const defaultInterval = 1000;
 
 export default function Component({ service }) {
   const { t } = useTranslation();
   const { widget } = service;
-  const { chart } = widget;
+  const { chart, refreshInterval = defaultInterval, pointsLimit = defaultPointsLimit } = widget;
   const [, sensorName] = widget.metric.split(":");
 
   const [dataPoints, setDataPoints] = useState(new Array(pointsLimit).fill({ value: 0 }, 0, pointsLimit));
 
   const { data, error } = useWidgetAPI(service.widget, "sensors", {
-    refreshInterval: 1000,
+    refreshInterval,
   });
 
   useEffect(() => {


### PR DESCRIPTION
## Proposed change

Add support for configurable refresh interval and amounts of points for the Glances service widget.

``` services.yaml
-CPU:
  widget:
    type: glances
    url: http://url:port
    metric: cpu
    refreshInterval: 2500
    pointsLimit: 50
```

This opens 2 possibilities, mainly useful for people with a home that stays open for a long period:
- Reduce the number of API calls by increasing the interval.
- Have different monitored periods (see below)

![image](https://github.com/gethomepage/homepage/assets/2590880/1d033baa-f3e7-4fb3-8554-6e5091acfe6a)

**A small note about network / disk**
Information about IO/s for net (RX, TX) and disk (Read, Write) might seems strange, but is still correct. It will simply show the value for the immediate last refresh on glances' side, regardless of the configured interval

(I also alphabetically sorted the allowed keys to ease finding existing values)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added corresponding documentation changes.
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using pre-commit hooks and linting checks with `pnpm lint` (see development guidelines).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
