### PR TITLE
Enhancement: Use `hasFile` instead of `isAvailable` for Radarr integr…

### DIFF
--- a/src/widgets/calendar/integrations/radarr.jsx
+++ b/src/widgets/calendar/integrations/radarr.jsx
@@ -25,27 +25,35 @@ export default function Integration({ config, params, hideErrors = false }) {
       const physicalTitle = `${event.title} - ${t("calendar.physicalRelease")}`;
       const digitalTitle = `${event.title} - ${t("calendar.digitalRelease")}`;
 
-      eventsToAdd[cinemaTitle] = {
-        title: cinemaTitle,
-        date: DateTime.fromISO(event.inCinemas),
-        color: config?.color ?? "amber",
-        isCompleted: event.isAvailable,
-        additional: "",
-      };
-      eventsToAdd[physicalTitle] = {
-        title: physicalTitle,
-        date: DateTime.fromISO(event.physicalRelease),
-        color: config?.color ?? "cyan",
-        isCompleted: event.isAvailable,
-        additional: "",
-      };
-      eventsToAdd[digitalTitle] = {
-        title: digitalTitle,
-        date: DateTime.fromISO(event.digitalRelease),
-        color: config?.color ?? "emerald",
-        isCompleted: event.isAvailable,
-        additional: "",
-      };
+      if (event.inCinemas) {
+        eventsToAdd[cinemaTitle] = {
+          title: cinemaTitle,
+          date: DateTime.fromISO(event.inCinemas),
+          color: config?.color ?? "amber",
+          isCompleted: event.hasFile,
+          additional: "",
+        };
+      }
+
+      if (event.physicalRelease) {
+        eventsToAdd[physicalTitle] = {
+          title: physicalTitle,
+          date: DateTime.fromISO(event.physicalRelease),
+          color: config?.color ?? "cyan",
+          isCompleted: event.hasFile,
+          additional: "",
+        };
+      }
+
+      if (event.digitalRelease) {
+        eventsToAdd[digitalTitle] = {
+          title: digitalTitle,
+          date: DateTime.fromISO(event.digitalRelease),
+          color: config?.color ?? "emerald",
+          isCompleted: event.hasFile,
+          additional: "",
+        };
+      }
     });
 
     setEvents((prevEvents) => ({ ...prevEvents, ...eventsToAdd }));


### PR DESCRIPTION
…ation on Calendar; show Radarr release only when it exists.

## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well updates to the docs for the new widget.
-->

Closes #2324 

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [x] Other (please explain): Improves calendar radarr integration.

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added corresponding documentation changes.
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using pre-commit hooks and linting checks with `pnpm lint` (see development guidelines).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
