### PR TITLE
feat: adding a widget n8n

### DIFF
--- a/docs/widgets/services/n8n.md
+++ b/docs/widgets/services/n8n.md
@@ -1,0 +1,15 @@
+---
+title: n8n
+description: n8n Widget Configuration
+---
+
+Grab your API key in n8n : Settings -> n8n API.
+
+Allowed fields: `["workflows", "executions"]`.
+
+```yaml
+widget:
+  type: n8n
+  url: http://n8n.host.or.ip:port
+  key: key
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
       - widgets/services/mjpeg.md
       - widgets/services/moonraker.md
       - widgets/services/mylar.md
+      - widgets/services/n8n.md
       - widgets/services/navidrome.md
       - widgets/services/nextcloud.md
       - widgets/services/nextdns.md

--- a/public/locales/af/common.json
+++ b/public/locales/af/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Physical release",
         "digitalRelease": "Digital release",
         "noEventsToday": "No events for today!"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/ar/common.json
+++ b/public/locales/ar/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Physical release",
         "digitalRelease": "Digital release",
         "noEventsToday": "No events for today!"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/bg/common.json
+++ b/public/locales/bg/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Physical release",
         "digitalRelease": "Digital release",
         "noEventsToday": "No events for today!"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/ca/common.json
+++ b/public/locales/ca/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Physical release",
         "digitalRelease": "Digital release",
         "noEventsToday": "No events for today!"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/cs/common.json
+++ b/public/locales/cs/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Physical release",
         "digitalRelease": "Digital release",
         "noEventsToday": "No events for today!"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/da/common.json
+++ b/public/locales/da/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Fysisk udgivelse",
         "digitalRelease": "Digitale udgivelser",
         "noEventsToday": "No events for today!"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Physische Version",
         "digitalRelease": "Digitale Version",
         "noEventsToday": "Heute keine Ereignisse!"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/el/common.json
+++ b/public/locales/el/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Physical release",
         "digitalRelease": "Digital release",
         "noEventsToday": "No events for today!"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Physical release",
         "digitalRelease": "Digital release",
         "noEventsToday": "No events for today!"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/eo/common.json
+++ b/public/locales/eo/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Physical release",
         "digitalRelease": "Digital release",
         "noEventsToday": "No events for today!"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Lanzamiento en físico",
         "digitalRelease": "Lanzamiento en digital",
         "noEventsToday": "Sin eventos para hoy"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/eu/common.json
+++ b/public/locales/eu/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Physical release",
         "digitalRelease": "Digital release",
         "noEventsToday": "No events for today!"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Physical release",
         "digitalRelease": "Digital release",
         "noEventsToday": "No events for today!"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Sortie physique",
         "digitalRelease": "Sortie numérique",
         "noEventsToday": "Rien pour aujourd'hui !"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/he/common.json
+++ b/public/locales/he/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Physical release",
         "digitalRelease": "Digital release",
         "noEventsToday": "No events for today!"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/hi/common.json
+++ b/public/locales/hi/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Physical release",
         "digitalRelease": "Digital release",
         "noEventsToday": "No events for today!"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/hr/common.json
+++ b/public/locales/hr/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Physical release",
         "digitalRelease": "Digital release",
         "noEventsToday": "No events for today!"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/hu/common.json
+++ b/public/locales/hu/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Physical release",
         "digitalRelease": "Digital release",
         "noEventsToday": "No events for today!"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/id/common.json
+++ b/public/locales/id/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Physical release",
         "digitalRelease": "Digital release",
         "noEventsToday": "No events for today!"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/it/common.json
+++ b/public/locales/it/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Release fisici",
         "digitalRelease": "Digital release",
         "noEventsToday": "No events for today!"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/ja/common.json
+++ b/public/locales/ja/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "物理的なリリース",
         "digitalRelease": "デジタル・リリース",
         "noEventsToday": "No events for today!"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/ko/common.json
+++ b/public/locales/ko/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Physical release",
         "digitalRelease": "Digital release",
         "noEventsToday": "No events for today!"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/lv/common.json
+++ b/public/locales/lv/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Physical release",
         "digitalRelease": "Digital release",
         "noEventsToday": "No events for today!"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/ms/common.json
+++ b/public/locales/ms/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Physical release",
         "digitalRelease": "Digital release",
         "noEventsToday": "No events for today!"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/nb-NO/common.json
+++ b/public/locales/nb-NO/common.json
@@ -746,5 +746,9 @@
         "physicalRelease": "Physical release",
         "inCinemas": "In cinemas",
         "digitalRelease": "Digital release"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Fysieke versie",
         "digitalRelease": "Digitale versie",
         "noEventsToday": "Geen gebeurtenissen voor vandaag!"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/no/common.json
+++ b/public/locales/no/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Physical release",
         "digitalRelease": "Digital release",
         "noEventsToday": "No events for today!"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/pl/common.json
+++ b/public/locales/pl/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Physical release",
         "digitalRelease": "Digital release",
         "noEventsToday": "No events for today!"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/pt-BR/common.json
+++ b/public/locales/pt-BR/common.json
@@ -746,5 +746,9 @@
         "physicalRelease": "Physical release",
         "inCinemas": "In cinemas",
         "digitalRelease": "Digital release"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/pt/common.json
+++ b/public/locales/pt/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Lançamento físico",
         "digitalRelease": "Lançamento digital",
         "noEventsToday": "Não existem eventos hoje!"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/pt_BR/common.json
+++ b/public/locales/pt_BR/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Physical release",
         "digitalRelease": "Digital release",
         "noEventsToday": "No events for today!"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/ro/common.json
+++ b/public/locales/ro/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Physical release",
         "digitalRelease": "Digital release",
         "noEventsToday": "No events for today!"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/ru/common.json
+++ b/public/locales/ru/common.json
@@ -746,5 +746,9 @@
         "physicalRelease": "Physical release",
         "inCinemas": "In cinemas",
         "digitalRelease": "Digital release"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/sk/common.json
+++ b/public/locales/sk/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Fyzické vydanie",
         "digitalRelease": "Digitálne vydanie",
         "noEventsToday": "Žiadne udalosti na dnešný deň!"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/sl/common.json
+++ b/public/locales/sl/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Physical release",
         "digitalRelease": "Digital release",
         "noEventsToday": "No events for today!"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/sr/common.json
+++ b/public/locales/sr/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Physical release",
         "digitalRelease": "Digital release",
         "noEventsToday": "No events for today!"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/sv/common.json
+++ b/public/locales/sv/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Physical release",
         "digitalRelease": "Digital release",
         "noEventsToday": "No events for today!"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/te/common.json
+++ b/public/locales/te/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Physical release",
         "digitalRelease": "Digital release",
         "noEventsToday": "No events for today!"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/th/common.json
+++ b/public/locales/th/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Physical release",
         "digitalRelease": "Digital release",
         "noEventsToday": "No events for today!"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/tr/common.json
+++ b/public/locales/tr/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Physical release",
         "digitalRelease": "Digital release",
         "noEventsToday": "No events for today!"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/uk/common.json
+++ b/public/locales/uk/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Physical release",
         "digitalRelease": "Digital release",
         "noEventsToday": "No events for today!"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/vi/common.json
+++ b/public/locales/vi/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Physical release",
         "digitalRelease": "Digital release",
         "noEventsToday": "No events for today!"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/yue/common.json
+++ b/public/locales/yue/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Physical release",
         "digitalRelease": "Digital release",
         "noEventsToday": "No events for today!"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/zh-CN/common.json
+++ b/public/locales/zh-CN/common.json
@@ -746,5 +746,9 @@
         "physicalRelease": "Physical release",
         "inCinemas": "In cinemas",
         "digitalRelease": "Digital release"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/zh-Hans/common.json
+++ b/public/locales/zh-Hans/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "实体发行",
         "digitalRelease": "数字发行",
         "noEventsToday": "今天没有活动！"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/public/locales/zh-Hant/common.json
+++ b/public/locales/zh-Hant/common.json
@@ -766,5 +766,9 @@
         "physicalRelease": "Physical release",
         "digitalRelease": "Digital release",
         "noEventsToday": "No events for today!"
+    },
+    "n8n":{
+        "workflows": "Workflows",
+        "executions": "Executions"
     }
 }

--- a/src/utils/proxy/handlers/credentialed.js
+++ b/src/utils/proxy/handlers/credentialed.js
@@ -61,6 +61,8 @@ export default async function credentialedProxyHandler(req, res, map) {
         headers.Authorization = `Basic ${Buffer.from(`$:${widget.key}`).toString("base64")}`;
       } else if (widget.type === "glances") {
         headers.Authorization = `Basic ${Buffer.from(`${widget.username}:${widget.password}`).toString("base64")}`;
+      } else if (widget.type === "n8n") {
+        headers["X-N8N-API-KEY"] = `${widget.key}`;
       } else {
         headers["X-API-Key"] = `${widget.key}`;
       }

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -58,6 +58,7 @@ const components = {
   navidrome: dynamic(() => import("./navidrome/component")),
   nextcloud: dynamic(() => import("./nextcloud/component")),
   nextdns: dynamic(() => import("./nextdns/component")),
+  n8n: dynamic(() => import("./n8n/component")),
   npm: dynamic(() => import("./npm/component")),
   nzbget: dynamic(() => import("./nzbget/component")),
   octoprint: dynamic(() => import("./octoprint/component")),

--- a/src/widgets/n8n/component.jsx
+++ b/src/widgets/n8n/component.jsx
@@ -1,0 +1,33 @@
+import { useTranslation } from "next-i18next";
+
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+  const { widget } = service;
+
+  const { data: workflowsData, error: workflowsError } = useWidgetAPI(widget, "workflows");
+  const { data: executionsData, error: executionsError } = useWidgetAPI(widget, "executions");
+
+  if (workflowsError || executionsError) {
+    const finalError = workflowsError ?? executionsError;
+    return <Container service={service} error={finalError} />;
+  }
+  if (!workflowsData || !executionsData) {
+    return (
+      <Container service={service}>
+        <Block label="n8n.workflows" />
+        <Block label="n8n.executions" />
+      </Container>
+    );
+  }
+
+  return (
+    <Container service={service}>
+      <Block label="n8n.workflows" value={t("common.number", { value: workflowsData.data.length })} />
+      <Block label="n8n.executions" value={t("common.number", { value: executionsData.data.length })} />
+    </Container>
+  );
+}

--- a/src/widgets/n8n/widget.js
+++ b/src/widgets/n8n/widget.js
@@ -1,0 +1,20 @@
+import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
+// import { jsonArrayFilter } from "utils/proxy/api-helpers";
+
+const widget = {
+  api: "{url}/api/v1/{endpoint}",
+  proxyHandler: credentialedProxyHandler,
+
+  mappings: {
+    workflows: {
+      endpoint: "workflows?active=true",
+      validate: ["data"],
+    },
+    executions: {
+      endpoint: "executions?includeData=false&status=success",
+      validate: ["data"],
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -50,6 +50,7 @@ import mylar from "./mylar/widget";
 import navidrome from "./navidrome/widget";
 import nextcloud from "./nextcloud/widget";
 import nextdns from "./nextdns/widget";
+import n8n from "./n8n/widget";
 import npm from "./npm/widget";
 import nzbget from "./nzbget/widget";
 import octoprint from "./octoprint/widget";
@@ -152,6 +153,7 @@ const widgets = {
   navidrome,
   nextcloud,
   nextdns,
+  n8n,
   npm,
   nzbget,
   octoprint,


### PR DESCRIPTION
## Proposed change

Adding a service widget for n8n service. Code is really simple (wel done on your mappers :) ). 
I have just some questions on going; about the totals. Executions is maybe a little too large.
Workflows = length of the API workflows with `workflows?active=true`
Executions = length of the API executions with `executions?includeData=false&status=success`
<img width="617" alt="image" src="https://github.com/gethomepage/homepage/assets/2108171/84bbc728-91cc-4f6f-a495-0c3f85bbcceb">


## Type of change

- [x] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If adding a service widget or a change that requires it, I have added corresponding documentation changes.
- [x] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using pre-commit hooks and linting checks with `pnpm lint` (see development guidelines).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
