### PR TITLE
Added a link wrapper to the icon if the href config option has been set

### DIFF
--- a/src/components/widgets/logo/logo.jsx
+++ b/src/components/widgets/logo/logo.jsx
@@ -12,7 +12,13 @@ export default function Logo({ options }) {
       <Raw>
         {options.icon ? (
           <div className="resolved mr-3">
-            <ResolvedIcon icon={options.icon} width={48} height={48} />
+            {options.href ? (
+              <a href={options.href} target="_blank" rel="noreferrer">
+                <ResolvedIcon icon={options.icon} width={48} height={48} />
+              </a>
+            ) : (
+              <ResolvedIcon icon={options.icon} width={48} height={48} />
+            )}
           </div>
         ) : (
           // fallback to homepage logo


### PR DESCRIPTION
## Proposed change

This change modifies the existing logo information widget and simply adds a link wrapper around the icon if the href configuration option has been set. The purpose of this is to enable the use of links for icons set in the header bar. If accepted the documentation would need to be [updated to reflect the change](https://gethomepage.dev/v0.8.2/widgets/info/logo/)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If adding a service widget or a change that requires it, I have added corresponding documentation changes.
- [ ] If adding a new widget I have reviewed the [guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
