### PR TITLE
Change: changedetection.io widget count diff if not viewed

### DIFF
--- a/src/widgets/changedetectionio/component.jsx
+++ b/src/widgets/changedetectionio/component.jsx
@@ -28,7 +28,7 @@ export default function Component({ service }) {
   let diffsDetected = 0;
 
   Object.keys(data).forEach((key) => {
-    if (data[key].last_changed > 0 && data[key].last_checked === data[key].last_changed) {
+    if (data[key].last_changed > 0 && data[key].last_checked === data[key].last_changed && !data[key].viewed) {
       diffsDetected += 1;
     }
   });


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well updates to the docs for the new widget.
-->

I would consider this non-breaking, and non-contentious, but I am open to other critiques/options

I think this makes the widget match the functionality of changedetection and what is shown on the changedetection site a bit better...

Prior to this change, the widget could display a count of diffs detected that did not match "new unseen" diffs so when you navigated to the changedetection site, they had already been seen and were not bolded. The state would not "reset" until the following check happened.

More background at https://github.com/dgtlmoon/changedetection.io/issues/1998

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
