### PR TITLE
Changing widget doc url

### DIFF
--- a/src/skeleton/widgets.yaml
+++ b/src/skeleton/widgets.yaml
@@ -1,6 +1,6 @@
 ---
 # For configuration options and examples, please see:
-# https://gethomepage.dev/latest/configs/service-widgets/
+# https://gethomepage.dev/latest/configs/service-widgets
 
 - resources:
     cpu: true

--- a/src/skeleton/widgets.yaml
+++ b/src/skeleton/widgets.yaml
@@ -1,6 +1,6 @@
 ---
 # For configuration options and examples, please see:
-# https://gethomepage.dev/latest/configs/widgets
+# https://gethomepage.dev/latest/configs/service-widgets/
 
 - resources:
     cpu: true


### PR DESCRIPTION
## Proposed change

The url in the skeleton is dead, i have change it to point at the new active url.

Closes # (issue)

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Documentation only
- [ ] Other (please explain)

## Checklist:

- [X] If applicable, I have added corresponding documentation changes.
- [X] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [X] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [X] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
