### PR TITLE
Enhancement: improve fritzbox proxy perfomance

### DIFF
--- a/docs/widgets/services/fritzbox.md
+++ b/docs/widgets/services/fritzbox.md
@@ -11,7 +11,7 @@ Home Network > Network > Network Settings > Access Settings in the Home Network
 [x] Transmit status information over UPnP
 ```
 
-You don't need to provide any credentials. Since that, you should consider using `http` instead of `https` as the requests are significantly faster.
+Credentials are not needed and, as such, you may want to consider using `http` instead of `https` as those requests are significantly faster.
 
 Allowed fields (limited to a max of 4): `["connectionStatus", "upTime", "maxDown", "maxUp", "down", "up", "received", "sent", "externalIPAddress"]`.
 

--- a/docs/widgets/services/fritzbox.md
+++ b/docs/widgets/services/fritzbox.md
@@ -11,12 +11,12 @@ Home Network > Network > Network Settings > Access Settings in the Home Network
 [x] Transmit status information over UPnP
 ```
 
-You don't need to provide any credentials.
+You don't need to provide any credentials. Since that, you should consider using `http` instead of `https` as the requests are significantly faster.
 
 Allowed fields (limited to a max of 4): `["connectionStatus", "upTime", "maxDown", "maxUp", "down", "up", "received", "sent", "externalIPAddress"]`.
 
 ```yaml
 widget:
   type: fritzbox
-  url: https://192.168.178.1
+  url: http://192.168.178.1
 ```

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -127,7 +127,7 @@
         "connectionStatusUnconfigured": "Unkonfiguriert",
         "connectionStatusConnecting": "Verbinde",
         "connectionStatusAuthenticating": "Authenifiziere",
-        "connectionStatusPendingDisconnect": "Anstehende Trennung",
+        "connectionStatusPendingDisconnect": "Ausstehende Trennung",
         "connectionStatusDisconnecting": "Trenne",
         "connectionStatusDisconnected": "Getrennt",
         "connectionStatusConnected": "Verbunden",

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -127,7 +127,7 @@
         "connectionStatusUnconfigured": "Unkonfiguriert",
         "connectionStatusConnecting": "Verbinde",
         "connectionStatusAuthenticating": "Authenifiziere",
-        "connectionStatusPendingDisconnect": "Ausstehende Trennung",
+        "connectionStatusPendingDisconnect": "Anstehende Trennung",
         "connectionStatusDisconnecting": "Trenne",
         "connectionStatusDisconnected": "Getrennt",
         "connectionStatusConnected": "Verbunden",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -127,7 +127,7 @@
         "connectionStatusUnconfigured": "Unconfigured",
         "connectionStatusConnecting": "Connecting",
         "connectionStatusAuthenticating": "Authenticating",
-        "connectionStatusPendingDisconnect": "PendingDisconnect",
+        "connectionStatusPendingDisconnect": "Pending Disconnect",
         "connectionStatusDisconnecting": "Disconnecting",
         "connectionStatusDisconnected": "Disconnected",
         "connectionStatusConnected": "Connected",

--- a/src/widgets/fritzbox/component.jsx
+++ b/src/widgets/fritzbox/component.jsx
@@ -4,6 +4,8 @@ import Container from "components/services/widget/container";
 import Block from "components/services/widget/block";
 import useWidgetAPI from "utils/proxy/use-widget-api";
 
+export const fritzboxDefaultFields = ["connectionStatus", "uptime", "maxDown", "maxUp"];
+
 const formatUptime = (timestamp) => {
   const hours = Math.floor(timestamp / 3600);
   const minutes = Math.floor((timestamp % 3600) / 60);
@@ -27,7 +29,7 @@ export default function Component({ service }) {
 
   // Default fields
   if (!widget.fields?.length > 0) {
-    widget.fields = ["connectionStatus", "uptime", "maxDown", "maxUp"];
+    widget.fields = fritzboxDefaultFields;
   }
   const MAX_ALLOWED_FIELDS = 4;
   // Limits max number of displayed fields

--- a/src/widgets/fritzbox/proxy.js
+++ b/src/widgets/fritzbox/proxy.js
@@ -1,5 +1,7 @@
 import { xml2json } from "xml-js";
 
+import { fritzboxDefaultFields } from "./component";
+
 import { httpProxy } from "utils/proxy/http";
 import getServiceWidget from "utils/config/service-helpers";
 import createLogger from "utils/logger";
@@ -46,36 +48,45 @@ async function requestEndpoint(apiBaseUrl, service, action) {
 export default async function fritzboxProxyHandler(req, res) {
   const { group, service } = req.query;
   const serviceWidget = await getServiceWidget(group, service);
+
   if (!serviceWidget) {
     res.status(500).json({ error: "Service widget not found" });
     return;
   }
+
   if (!serviceWidget.url) {
     res.status(500).json({ error: "Service widget url not configured" });
     return;
   }
 
   const serviceWidgetUrl = new URL(serviceWidget.url);
-  const port = serviceWidgetUrl.protocol === "https:" ? 49443 : 49000;
-  const apiBaseUrl = `${serviceWidgetUrl.protocol}//${serviceWidgetUrl.hostname}:${port}`;
+  const apiBaseUrl = `http://${serviceWidgetUrl.hostname}:49000`;
+
+  if (!serviceWidget.fields?.length > 0) {
+    serviceWidget.fields = fritzboxDefaultFields;
+  }
+  const requestStatusInfo = ["connectionStatus", "uptime"].some((field) => serviceWidget.fields.includes(field));
+  const requestLinkProperties = ["maxDown", "maxUp"].some((field) => serviceWidget.fields.includes(field));
+  const requestAddonInfos = ["down", "up", "received", "sent"].some((field) => serviceWidget.fields.includes(field));
+  const requestExternalIPAddress = ["externalIPAddress"].some((field) => serviceWidget.fields.includes(field));
 
   await Promise.all([
-    requestEndpoint(apiBaseUrl, "WANIPConnection", "GetStatusInfo"),
-    requestEndpoint(apiBaseUrl, "WANIPConnection", "GetExternalIPAddress"),
-    requestEndpoint(apiBaseUrl, "WANCommonInterfaceConfig", "GetCommonLinkProperties"),
-    requestEndpoint(apiBaseUrl, "WANCommonInterfaceConfig", "GetAddonInfos"),
+    requestStatusInfo ? requestEndpoint(apiBaseUrl, "WANIPConnection", "GetStatusInfo") : null,
+    requestLinkProperties ? requestEndpoint(apiBaseUrl, "WANCommonInterfaceConfig", "GetCommonLinkProperties") : null,
+    requestAddonInfos ? requestEndpoint(apiBaseUrl, "WANCommonInterfaceConfig", "GetAddonInfos") : null,
+    requestExternalIPAddress ? requestEndpoint(apiBaseUrl, "WANIPConnection", "GetExternalIPAddress") : null,
   ])
-    .then(([statusInfo, externalIPAddress, linkProperties, addonInfos]) => {
+    .then(([statusInfo, linkProperties, addonInfos, externalIPAddress]) => {
       res.status(200).json({
-        connectionStatus: statusInfo.NewConnectionStatus,
-        uptime: statusInfo.NewUptime,
-        maxDown: linkProperties.NewLayer1DownstreamMaxBitRate,
-        maxUp: linkProperties.NewLayer1UpstreamMaxBitRate,
-        down: addonInfos.NewByteReceiveRate,
-        up: addonInfos.NewByteSendRate,
-        received: addonInfos.NewX_AVM_DE_TotalBytesReceived64,
-        sent: addonInfos.NewX_AVM_DE_TotalBytesSent64,
-        externalIPAddress: externalIPAddress.NewExternalIPAddress,
+        connectionStatus: statusInfo?.NewConnectionStatus || "Unconfigured",
+        uptime: statusInfo?.NewUptime || 0,
+        maxDown: linkProperties?.NewLayer1DownstreamMaxBitRate || 0,
+        maxUp: linkProperties?.NewLayer1UpstreamMaxBitRate || 0,
+        down: addonInfos?.NewByteReceiveRate || 0,
+        up: addonInfos?.NewByteSendRate || 0,
+        received: addonInfos?.NewX_AVM_DE_TotalBytesReceived64 || 0,
+        sent: addonInfos?.NewX_AVM_DE_TotalBytesSent64 || 0,
+        externalIPAddress: externalIPAddress?.NewExternalIPAddress || null,
       });
     })
     .catch((error) => {

--- a/src/widgets/fritzbox/proxy.js
+++ b/src/widgets/fritzbox/proxy.js
@@ -60,7 +60,8 @@ export default async function fritzboxProxyHandler(req, res) {
   }
 
   const serviceWidgetUrl = new URL(serviceWidget.url);
-  const apiBaseUrl = `http://${serviceWidgetUrl.hostname}:49000`;
+  const port = serviceWidgetUrl.protocol === "https:" ? 49443 : 49000;
+  const apiBaseUrl = `${serviceWidgetUrl.protocol}//${serviceWidgetUrl.hostname}:${port}`;
 
   if (!serviceWidget.fields?.length > 0) {
     serviceWidget.fields = fritzboxDefaultFields;


### PR DESCRIPTION
- only request the endpoints required by the field configuration
- note in the documentation on the use of http instead of https, as it is significantly faster (~1.2 seconds => ~90 milliseconds)

## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well updates to the docs for the new widget.
-->

Closes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
