### PR TITLE
Feature: setting for equal height cards

### DIFF
--- a/docs/configs/settings.md
+++ b/docs/configs/settings.md
@@ -229,6 +229,28 @@ disableCollapse: true
 
 By default the feature is enabled.
 
+### Use Equal Height Cards
+
+You can enable equal height cards for groups of services, this will make all cards in a row the same height.
+
+Global setting in `settings.yaml`:
+
+```yaml
+useEqualHeights: true
+```
+
+Per layout group in `settings.yaml`:
+
+```yaml
+useEqualHeights: false
+layout:
+  ...
+  Group Name:
+    useEqualHeights: true # overrides global setting
+```
+
+By default the feature is disabled
+
 ## Header Style
 
 There are currently 4 options for header styles, you can see each one below.

--- a/src/components/services/group.jsx
+++ b/src/components/services/group.jsx
@@ -6,7 +6,7 @@ import { MdKeyboardArrowDown } from "react-icons/md";
 import List from "components/services/list";
 import ResolvedIcon from "components/resolvedicon";
 
-export default function ServicesGroup({ group, services, layout, fiveColumns, disableCollapse }) {
+export default function ServicesGroup({ group, services, layout, fiveColumns, disableCollapse, useEqualHeights }) {
   const panel = useRef();
 
   return (
@@ -62,7 +62,7 @@ export default function ServicesGroup({ group, services, layout, fiveColumns, di
               }}
             >
               <Disclosure.Panel className="transition-all overflow-hidden duration-300 ease-out" ref={panel} static>
-                <List group={group} services={services.services} layout={layout} />
+                <List group={group} services={services.services} layout={layout} useEqualHeights={useEqualHeights} />
               </Disclosure.Panel>
             </Transition>
           </>

--- a/src/components/services/item.jsx
+++ b/src/components/services/item.jsx
@@ -37,7 +37,7 @@ export default function Item({ service, group }) {
         className={classNames(
           settings.cardBlur !== undefined && `backdrop-blur${settings.cardBlur.length ? "-" : ""}${settings.cardBlur}`,
           hasLink && "cursor-pointer",
-          "transition-all h-15 mb-2 p-1 rounded-md font-medium text-theme-700 dark:text-theme-200 dark:hover:text-theme-300 shadow-md shadow-theme-900/10 dark:shadow-theme-900/20 bg-theme-100/20 hover:bg-theme-300/20 dark:bg-white/5 dark:hover:bg-white/10 relative overflow-clip service-card",
+          "transition-all h-[calc(100%-0.5rem)] mb-2 p-1 rounded-md font-medium text-theme-700 dark:text-theme-200 dark:hover:text-theme-300 shadow-md shadow-theme-900/10 dark:shadow-theme-900/20 bg-theme-100/20 hover:bg-theme-300/20 dark:bg-white/5 dark:hover:bg-white/10 relative overflow-clip service-card",
         )}
       >
         <div className="flex select-none z-0 service-title">

--- a/src/components/services/item.jsx
+++ b/src/components/services/item.jsx
@@ -12,7 +12,7 @@ import Kubernetes from "widgets/kubernetes/component";
 import { SettingsContext } from "utils/contexts/settings";
 import ResolvedIcon from "components/resolvedicon";
 
-export default function Item({ service, group }) {
+export default function Item({ service, group, useEqualHeights }) {
   const hasLink = service.href && service.href !== "#";
   const { settings } = useContext(SettingsContext);
   const showStats = service.showStats === false ? false : settings.showStats;
@@ -37,7 +37,8 @@ export default function Item({ service, group }) {
         className={classNames(
           settings.cardBlur !== undefined && `backdrop-blur${settings.cardBlur.length ? "-" : ""}${settings.cardBlur}`,
           hasLink && "cursor-pointer",
-          "transition-all h-[calc(100%-0.5rem)] mb-2 p-1 rounded-md font-medium text-theme-700 dark:text-theme-200 dark:hover:text-theme-300 shadow-md shadow-theme-900/10 dark:shadow-theme-900/20 bg-theme-100/20 hover:bg-theme-300/20 dark:bg-white/5 dark:hover:bg-white/10 relative overflow-clip service-card",
+          useEqualHeights && "h-[calc(100%-0.5rem)]",
+          "transition-all mb-2 p-1 rounded-md font-medium text-theme-700 dark:text-theme-200 dark:hover:text-theme-300 shadow-md shadow-theme-900/10 dark:shadow-theme-900/20 bg-theme-100/20 hover:bg-theme-300/20 dark:bg-white/5 dark:hover:bg-white/10 relative overflow-clip service-card",
         )}
       >
         <div className="flex select-none z-0 service-title">

--- a/src/components/services/list.jsx
+++ b/src/components/services/list.jsx
@@ -4,7 +4,7 @@ import { columnMap } from "../../utils/layout/columns";
 
 import Item from "components/services/item";
 
-export default function List({ group, services, layout }) {
+export default function List({ group, services, layout, useEqualHeights }) {
   return (
     <ul
       className={classNames(
@@ -13,7 +13,12 @@ export default function List({ group, services, layout }) {
       )}
     >
       {services.map((service) => (
-        <Item key={service.container ?? service.app ?? service.name} service={service} group={group} />
+        <Item
+          key={service.container ?? service.app ?? service.name}
+          service={service}
+          group={group}
+          useEqualHeights={layout?.useEqualHeights ?? useEqualHeights}
+        />
       ))}
     </ul>
   );

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -307,6 +307,7 @@ function Home({ initialSettings }) {
                   layout={settings.layout?.[group.name]}
                   fiveColumns={settings.fiveColumns}
                   disableCollapse={settings.disableCollapse}
+                  useEqualHeights={settings.useEqualHeights}
                 />
               ) : (
                 <BookmarksGroup
@@ -355,6 +356,7 @@ function Home({ initialSettings }) {
     settings.layout,
     settings.fiveColumns,
     settings.disableCollapse,
+    settings.useEqualHeights,
     settings.cardBlur,
     initialSettings.layout,
   ]);


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant API output as well updates to the docs for the new widget.
-->
 

Forces every service in a row to be the same vertical size without removing any content.

Before
![Screenshot 2023-12-06 112758](https://github.com/gethomepage/homepage/assets/8876122/3751cba2-33b3-4974-b78e-01305210b9a3)

After
![Screenshot 2023-12-06 113653](https://github.com/gethomepage/homepage/assets/8876122/8a62eb71-fc0c-40e8-a304-40d4a4af395a)

Desktop tested on chromium & firefox
Mobile on iOS Safari

Closes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
