### PR TITLE
Fix: fields not working for healthchecks widget

### DIFF
--- a/src/widgets/healthchecks/component.jsx
+++ b/src/widgets/healthchecks/component.jsx
@@ -40,17 +40,17 @@ export default function Component({ service }) {
   if (!data) {
     return (
       <Container service={service}>
-        <Block label={t("healthchecks.status")} />
-        <Block label={t("healthchecks.last_ping")} />
+        <Block label="healthchecks.status" />
+        <Block label="healthchecks.last_ping" />
       </Container>
     );
   }
 
   return (
     <Container service={service}>
-      <Block label={t("healthchecks.status")} value={t(`healthchecks.${data.status}`)} />
+      <Block label="healthchecks.status" value={t(`healthchecks.${data.status}`)} />
       <Block
-        label={t("healthchecks.last_ping")}
+        label="healthchecks.last_ping"
         value={data.last_ping ? formatDate(data.last_ping) : t("healthchecks.never")}
       />
     </Container>


### PR DESCRIPTION
## Proposed change

If the `fields` key is defined for the `healthchecks` widget, no fields will show due to the field labels being translated manually on the `Block` component's `label` prop.

Before (fields not set in YAML):
![before-no-fields](https://github.com/gethomepage/homepage/assets/27016794/6033582f-b39c-40ad-a0c4-9d8e17bb0b68)


Before (fields: ["status"] set in YAML):
![before-fields](https://github.com/gethomepage/homepage/assets/27016794/0260e5e8-5743-4f3b-a3c1-f144d7ef1d4f)

After (fields: ["status"] set in YAML):
![after](https://github.com/gethomepage/homepage/assets/27016794/8bd7124f-25fb-4df1-b10b-5ea12742c12e)

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well updates to the docs for the new widget.
-->

Closes # N/A

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)


## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
