### PR TITLE
Fix: show recurring and multi-day events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "react-i18next": "^11.18.6",
         "react-icons": "^4.4.0",
         "recharts": "^2.7.2",
+        "rrule": "^2.8.1",
         "swr": "^1.3.0",
         "systeminformation": "^5.17.12",
         "tough-cookie": "^4.1.2",
@@ -5501,9 +5502,9 @@
       }
     },
     "node_modules/rrule": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/rrule/-/rrule-2.7.2.tgz",
-      "integrity": "sha512-NkBsEEB6FIZOZ3T8frvEBOB243dm46SPufpDckY/Ap/YH24V1zLeMmDY8OA10lk452NdrF621+ynDThE7FQU2A==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/rrule/-/rrule-2.8.1.tgz",
+      "integrity": "sha512-hM3dHSBMeaJ0Ktp7W38BJZ7O1zOgaFEsn41PDk+yHoEtfLV+PoJt9E9xAlZiWgf/iqEqionN0ebHFZIDAp+iGw==",
       "dependencies": {
         "tslib": "^2.4.0"
       }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-i18next": "^11.18.6",
     "react-icons": "^4.4.0",
     "recharts": "^2.7.2",
+    "rrule": "^2.8.1",
     "swr": "^1.3.0",
     "systeminformation": "^5.17.12",
     "tough-cookie": "^4.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ dependencies:
   recharts:
     specifier: ^2.7.2
     version: 2.7.2(prop-types@15.8.1)(react-dom@18.2.0)(react@18.2.0)
+  rrule:
+    specifier: ^2.8.1
+    version: 2.8.1
   swr:
     specifier: ^1.3.0
     version: 1.3.0(react@18.2.0)
@@ -871,7 +874,7 @@ packages:
     resolution: {integrity: sha512-wlQwcF0fl4eLclyGdncF9rcNNq0ipRYZGagG6h3LVgRXvCWE1fdMUaCLXwfC9YWoz9jKKbjQAq7TpO2Y3yrvmA==}
     dependencies:
       ical-date-parser: 4.0.0
-      rrule: 2.7.2
+      rrule: 2.8.1
     dev: false
 
   /call-bind@1.0.2:
@@ -3552,8 +3555,8 @@ packages:
     dependencies:
       glob: 7.2.3
 
-  /rrule@2.7.2:
-    resolution: {integrity: sha512-NkBsEEB6FIZOZ3T8frvEBOB243dm46SPufpDckY/Ap/YH24V1zLeMmDY8OA10lk452NdrF621+ynDThE7FQU2A==}
+  /rrule@2.8.1:
+    resolution: {integrity: sha512-hM3dHSBMeaJ0Ktp7W38BJZ7O1zOgaFEsn41PDk+yHoEtfLV+PoJt9E9xAlZiWgf/iqEqionN0ebHFZIDAp+iGw==}
     dependencies:
       tslib: 2.5.0
     dev: false


### PR DESCRIPTION
## Proposed change

This PR fixes issue where all recurring ical events aren't shown and multi-day events don't show instance for every day they're scheduled.

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
