### PR TITLE
Fix: Typo in fritzbox documentation 

### DIFF
--- a/docs/widgets/services/fritzbox.md
+++ b/docs/widgets/services/fritzbox.md
@@ -13,7 +13,7 @@ Home Network > Network > Network Settings > Access Settings in the Home Network
 
 Credentials are not needed and, as such, you may want to consider using `http` instead of `https` as those requests are significantly faster.
 
-Allowed fields (limited to a max of 4): `["connectionStatus", "upTime", "maxDown", "maxUp", "down", "up", "received", "sent", "externalIPAddress"]`.
+Allowed fields (limited to a max of 4): `["connectionStatus", "uptime", "maxDown", "maxUp", "down", "up", "received", "sent", "externalIPAddress"]`.
 
 ```yaml
 widget:


### PR DESCRIPTION
## Proposed change

`upTime`  corrected to `uptime`

Closes #2456

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
