### PR TITLE
Fix: fritzbox error when response contains empty values

### DIFF
--- a/src/widgets/fritzbox/proxy.js
+++ b/src/widgets/fritzbox/proxy.js
@@ -33,9 +33,9 @@ async function requestEndpoint(apiBaseUrl, service, action) {
   const response = {};
   try {
     const jsonData = JSON.parse(xml2json(data));
-    const responseElements = jsonData?.elements[0]?.elements[0]?.elements[0]?.elements || [];
+    const responseElements = jsonData?.elements?.[0]?.elements?.[0]?.elements?.[0]?.elements || [];
     responseElements.forEach((element) => {
-      response[element.name] = element.elements[0]?.text || "";
+      response[element.name] = element.elements?.[0].text || "";
     });
   } catch (e) {
     logger.debug(`Failed parsing ${service}->${action} response:`, data);


### PR DESCRIPTION
## Proposed change

Make the fritzbox proxy more robust, that missing or empty properties does not result in an error.

Closes #2461

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
