### PR TITLE
Documentation: Fix link to widgets page in docs

### DIFF
--- a/docs/configs/services.md
+++ b/docs/configs/services.md
@@ -179,7 +179,7 @@ Services may be connected to a Docker container, either running on the local mac
 
 Services may also have a service widget (or integration) attached to them, this works independently of the Docker integration.
 
-You can find information and configuration for each of the supported integrations on the [Widgets](widgets.md) page.
+You can find information and configuration for each of the supported integrations on the [Widgets](../widgets/index.md) page.
 
 Here is an example of a Radarr & Sonarr service, with their respective integrations.
 

--- a/docs/configs/services.md
+++ b/docs/configs/services.md
@@ -179,7 +179,7 @@ Services may be connected to a Docker container, either running on the local mac
 
 Services may also have a service widget (or integration) attached to them, this works independently of the Docker integration.
 
-You can find information and configuration for each of the supported integrations on the [Service Widgets](service-widgets.md) page.
+You can find information and configuration for each of the supported integrations on the [Widgets](widgets.md) page.
 
 Here is an example of a Radarr & Sonarr service, with their respective integrations.
 


### PR DESCRIPTION
## Proposed change

This PR changes the destination of a link in the docs which refers to information and configuration for each of the supported integrations. The link should point to `/widgets/`, which contains this information, but currently points to `/configs/service-widgets/`, which does not.

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [n/a] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [n/a] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
