### PR TITLE
Fix: calendar widget radarr integration API params invalid

### DIFF
--- a/src/widgets/calendar/component.jsx
+++ b/src/widgets/calendar/component.jsx
@@ -52,15 +52,18 @@ export default function Component({ service }) {
 
   // params for API fetch
   const params = useMemo(() => {
-    if (!showDate) {
-      return {};
+    const constructedParams = {
+      start: "",
+      end: "",
+      unmonitored: false,
+    };
+
+    if (showDate) {
+      constructedParams.start = showDate.minus({ months: 3 }).toFormat("yyyy-MM-dd");
+      constructedParams.end = showDate.plus({ months: 3 }).toFormat("yyyy-MM-dd");
     }
 
-    return {
-      start: showDate.minus({ months: 3 }).toFormat("yyyy-MM-dd"),
-      end: showDate.plus({ months: 3 }).toFormat("yyyy-MM-dd"),
-      unmonitored: "false",
-    };
+    return constructedParams;
   }, [showDate]);
 
   // Load active integrations


### PR DESCRIPTION
## Proposed change

Unclear if this changed or has always been an issue but since params gets serialized, Radarr seems happier with empty strings for these values

Closes #2469 

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
