### PR TITLE
chore: update gamedig dep to 4.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "compare-versions": "^5.0.1",
         "dockerode": "^3.3.4",
         "follow-redirects": "^1.15.2",
-        "gamedig": "^4.1.0",
+        "gamedig": "^4.3.0",
         "i18next": "^21.9.2",
         "js-yaml": "^4.1.0",
         "json-rpc-2.0": "^1.4.1",
@@ -2958,9 +2958,9 @@
       }
     },
     "node_modules/gamedig": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/gamedig/-/gamedig-4.1.0.tgz",
-      "integrity": "sha512-jvLUEakihJgpiw9t9yQRsbcemeALeTNlnaWY1gvYdwI63ZlkxznTaLqX5K/eluRTTCtAWNW3YceT6NVjyAZIwA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/gamedig/-/gamedig-4.3.0.tgz",
+      "integrity": "sha512-73wQM/mYLh0giljtg9OmF7QySxTGUj52+MxGklm2cveakOuB2zk0cvQl7vIFYcv6uI3HwenjOZKZ5507c/ZyzA==",
       "dependencies": {
         "cheerio": "^1.0.0-rc.10",
         "gbxremote": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "compare-versions": "^5.0.1",
     "dockerode": "^3.3.4",
     "follow-redirects": "^1.15.2",
-    "gamedig": "^4.1.0",
+    "gamedig": "^4.3.0",
     "i18next": "^21.9.2",
     "js-yaml": "^4.1.0",
     "json-rpc-2.0": "^1.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ dependencies:
     specifier: ^1.15.2
     version: 1.15.2
   gamedig:
-    specifier: ^4.1.0
-    version: 4.1.0
+    specifier: ^4.3.0
+    version: 4.3.0
   i18next:
     specifier: ^21.9.2
     version: 21.10.0
@@ -1973,8 +1973,8 @@ packages:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
     dev: true
 
-  /gamedig@4.1.0:
-    resolution: {integrity: sha512-jvLUEakihJgpiw9t9yQRsbcemeALeTNlnaWY1gvYdwI63ZlkxznTaLqX5K/eluRTTCtAWNW3YceT6NVjyAZIwA==}
+  /gamedig@4.3.0:
+    resolution: {integrity: sha512-73wQM/mYLh0giljtg9OmF7QySxTGUj52+MxGklm2cveakOuB2zk0cvQl7vIFYcv6uI3HwenjOZKZ5507c/ZyzA==}
     engines: {node: '>=14.0.0'}
     hasBin: true
     dependencies:


### PR DESCRIPTION
## Proposed change

Update the `GameDig` dependency from `4.1.0` to `4.3.0`.
Checkout the changelog [here](https://github.com/gamedig/node-gamedig/blob/master/CHANGELOG.md), but shortly said, `4.2.0` introduced a lot of new supported games and `4.3.0` a single new game and 2 fixes, no code breaking changes.


## Type of change
- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:
- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
