### PR TITLE
changedetection.io widget count diff not showing all valid diffs

### DIFF
--- a/src/widgets/changedetectionio/component.jsx
+++ b/src/widgets/changedetectionio/component.jsx
@@ -28,7 +28,7 @@ export default function Component({ service }) {
   let diffsDetected = 0;
 
   Object.keys(data).forEach((key) => {
-    if (data[key].last_changed > 0 && data[key].last_checked === data[key].last_changed && !data[key].viewed) {
+    if (data[key].last_changed > 0 && !data[key].viewed) {
       diffsDetected += 1;
     }
   });


### PR DESCRIPTION
Followup to https://github.com/gethomepage/homepage/pull/2401

Context at https://github.com/gethomepage/homepage/pull/2401#issuecomment-1853092022

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
