### PR TITLE
Enhancement: fritzbox uptime display

### DIFF
--- a/src/widgets/fritzbox/component.jsx
+++ b/src/widgets/fritzbox/component.jsx
@@ -17,10 +17,12 @@ const formatUptime = (timestamp) => {
   if (days) {
     uptimeStr += `${days}d`;
   }
-  if (hours || days) {
+  if (days || hours) {
     uptimeStr += `${format(hours)}h`;
   }
-  uptimeStr += `${format(minutes)}m`;
+  if (days || hours || minutes) {
+    uptimeStr += `${format(minutes)}m`;
+  }
   if (!days) {
     uptimeStr += `${format(seconds)}s `;
   }

--- a/src/widgets/fritzbox/component.jsx
+++ b/src/widgets/fritzbox/component.jsx
@@ -10,7 +10,7 @@ const formatUptime = (timestamp) => {
   const days = Math.floor(timestamp / (3600 * 24));
   const hours = Math.floor((timestamp % (3600 * 24)) / 3600);
   const minutes = Math.floor((timestamp % 3600) / 60);
-  const seconds = timestamp % 60;
+  const seconds = Math.floor(timestamp % 60);
   const format = (num) => String(num).padStart(2, "0");
 
   let uptimeStr = "";

--- a/src/widgets/fritzbox/component.jsx
+++ b/src/widgets/fritzbox/component.jsx
@@ -7,15 +7,25 @@ import useWidgetAPI from "utils/proxy/use-widget-api";
 export const fritzboxDefaultFields = ["connectionStatus", "uptime", "maxDown", "maxUp"];
 
 const formatUptime = (timestamp) => {
-  const hours = Math.floor(timestamp / 3600);
+  const days = Math.floor(timestamp / (3600 * 24));
+  const hours = Math.floor((timestamp % (3600 * 24)) / 3600);
   const minutes = Math.floor((timestamp % 3600) / 60);
   const seconds = timestamp % 60;
+  const format = (num) => String(num).padStart(2, "0");
 
-  const hourDuration = hours > 0 ? `${hours}h` : "00h";
-  const minDuration = minutes > 0 ? `${minutes}m` : "00m";
-  const secDuration = seconds > 0 ? `${seconds}s` : "00s";
+  let uptimeStr = "";
+  if (days) {
+    uptimeStr += `${days}d`;
+  }
+  if (hours || days) {
+    uptimeStr += `${format(hours)}h`;
+  }
+  uptimeStr += `${format(minutes)}m`;
+  if (!days) {
+    uptimeStr += `${format(seconds)}s `;
+  }
 
-  return hourDuration + minDuration + secDuration;
+  return uptimeStr;
 };
 
 export default function Component({ service }) {

--- a/src/widgets/fritzbox/component.jsx
+++ b/src/widgets/fritzbox/component.jsx
@@ -6,21 +6,21 @@ import useWidgetAPI from "utils/proxy/use-widget-api";
 
 export const fritzboxDefaultFields = ["connectionStatus", "uptime", "maxDown", "maxUp"];
 
-const formatUptime = (timestamp) => {
-  const days = Math.floor(timestamp / (3600 * 24));
-  const hours = Math.floor((timestamp % (3600 * 24)) / 3600);
-  const minutes = Math.floor((timestamp % 3600) / 60);
-  const seconds = Math.floor(timestamp % 60);
+const formatUptime = (uptimeInSeconds) => {
+  const days = Math.floor(uptimeInSeconds / (3600 * 24));
+  const hours = Math.floor((uptimeInSeconds % (3600 * 24)) / 3600);
+  const minutes = Math.floor((uptimeInSeconds % 3600) / 60);
+  const seconds = Math.floor(uptimeInSeconds) % 60;
   const format = (num) => String(num).padStart(2, "0");
 
   let uptimeStr = "";
   if (days) {
     uptimeStr += `${days}d`;
   }
-  if (days || hours) {
+  if (uptimeInSeconds >= 3600) {
     uptimeStr += `${format(hours)}h`;
   }
-  if (days || hours || minutes) {
+  if (uptimeInSeconds >= 60) {
     uptimeStr += `${format(minutes)}m`;
   }
   if (!days) {

--- a/src/widgets/fritzbox/proxy.js
+++ b/src/widgets/fritzbox/proxy.js
@@ -50,12 +50,12 @@ export default async function fritzboxProxyHandler(req, res) {
   const serviceWidget = await getServiceWidget(group, service);
 
   if (!serviceWidget) {
-    res.status(500).json({ error: "Service widget not found" });
+    res.status(500).json({ error: { message: "Service widget not found" } });
     return;
   }
 
   if (!serviceWidget.url) {
-    res.status(500).json({ error: "Service widget url not configured" });
+    res.status(500).json({ error: { message: "Service widget url not configured" } });
     return;
   }
 
@@ -91,6 +91,6 @@ export default async function fritzboxProxyHandler(req, res) {
       });
     })
     .catch((error) => {
-      res.status(500).json({ error: error.message });
+      res.status(500).json({ error: { message: error.message } });
     });
 }


### PR DESCRIPTION
## Proposed change

- The uptime will be shown shown in days when it reaches 24 hours (mentioned by @FurkanVG [here](https://github.com/gethomepage/homepage/pull/2387#issuecomment-1850131870)) 
- Seconds will be hidden when days are shown to save space
- Days, hours & minutes will not be shown, if the uptime is not high enough
- Error messages are now returned correctly from the proxy, so that they will be displayed in the frontend

### Screenshots
Seconds:
![s](https://github.com/gethomepage/homepage/assets/4954274/3e856662-b2c3-4da9-94c6-90fd1d8a2924)

Minutes & Seconds:
![ms](https://github.com/gethomepage/homepage/assets/4954274/35ac493c-1b15-4936-9822-5238f48b3444)

Hours, Minutes & Seconds:
![hms](https://github.com/gethomepage/homepage/assets/4954274/a287f55e-894f-4e51-98c7-14fdbceeb9da)

Days, Hours & Minutes:
![dhm](https://github.com/gethomepage/homepage/assets/4954274/44388e0a-1f9b-4e1d-a1ad-f40a06ca75f8)

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [x] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
