### PR TITLE
Enhancement: support `instanceName` filtering for kubernetes auto-discovery deployment

### DIFF
--- a/docs/configs/kubernetes.md
+++ b/docs/configs/kubernetes.md
@@ -94,7 +94,9 @@ spec:
             pathType: Prefix
 ```
 
-When the Kubernetes cluster connection has been properly configured, this service will be automatically discovered and added to your Homepage. **You do not need to specify the `namespace` or `app` values, as they will be automatically inferred.** In case of multiple instances of homepage, instance annotation can be specified to limit to a specific instance, if no instance is provided, the service will be visible on all instances.
+When the Kubernetes cluster connection has been properly configured, this service will be automatically discovered and added to your Homepage. **You do not need to specify the `namespace` or `app` values, as they will be automatically inferred.** 
+
+If you are using multiple instances of homepage, an `instance` annotation can be specified to limit services to a specific instance. If no instance is provided, the service will be visible on all instances.
 
 ### Traefik IngressRoute support
 

--- a/docs/configs/kubernetes.md
+++ b/docs/configs/kubernetes.md
@@ -79,6 +79,7 @@ metadata:
     gethomepage.dev/widget.url: "https://emby.example.com"
     gethomepage.dev/pod-selector: ""
     gethomepage.dev/weight: 10 # optional
+    gethomepage.dev/instance: "public" # optional
 spec:
   rules:
     - host: emby.example.com
@@ -93,7 +94,7 @@ spec:
             pathType: Prefix
 ```
 
-When the Kubernetes cluster connection has been properly configured, this service will be automatically discovered and added to your Homepage. **You do not need to specify the `namespace` or `app` values, as they will be automatically inferred.**
+When the Kubernetes cluster connection has been properly configured, this service will be automatically discovered and added to your Homepage. **You do not need to specify the `namespace` or `app` values, as they will be automatically inferred.** In case of multiple instances of homepage, instance annotation can be specified to limit to a specific instance, if no instance is provided, the service will be visible on all instances.
 
 ### Traefik IngressRoute support
 
@@ -116,6 +117,7 @@ metadata:
     gethomepage.dev/widget.url: "https://emby.example.com"
     gethomepage.dev/pod-selector: ""
     gethomepage.dev/weight: 10 # optional
+    gethomepage.dev/instance: "public" # optional
 spec:
   entryPoints:
     - websecure

--- a/docs/configs/kubernetes.md
+++ b/docs/configs/kubernetes.md
@@ -94,7 +94,7 @@ spec:
             pathType: Prefix
 ```
 
-When the Kubernetes cluster connection has been properly configured, this service will be automatically discovered and added to your Homepage. **You do not need to specify the `namespace` or `app` values, as they will be automatically inferred.** 
+When the Kubernetes cluster connection has been properly configured, this service will be automatically discovered and added to your Homepage. **You do not need to specify the `namespace` or `app` values, as they will be automatically inferred.**
 
 If you are using multiple instances of homepage, an `instance` annotation can be specified to limit services to a specific instance. If no instance is provided, the service will be visible on all instances.
 

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -170,7 +170,7 @@ export async function servicesFromKubernetes() {
   const ANNOTATION_BASE = "gethomepage.dev";
   const ANNOTATION_WIDGET_BASE = `${ANNOTATION_BASE}/widget.`;
   const { instanceName } = getSettings();
-  
+
   checkAndCopyConfig("kubernetes.yaml");
 
   try {
@@ -239,7 +239,10 @@ export async function servicesFromKubernetes() {
     const services = ingressList.items
       .filter(
         (ingress) =>
-          ingress.metadata.annotations && ingress.metadata.annotations[`${ANNOTATION_BASE}/enabled`] === "true" && (!ingress.metadata.annotations[`${ANNOTATION_BASE}/instance`] || ingress.metadata.annotations[`${ANNOTATION_BASE}/instance`] === instanceName),
+          ingress.metadata.annotations &&
+          ingress.metadata.annotations[`${ANNOTATION_BASE}/enabled`] === "true" &&
+          (!ingress.metadata.annotations[`${ANNOTATION_BASE}/instance`] ||
+            ingress.metadata.annotations[`${ANNOTATION_BASE}/instance`] === instanceName),
       )
       .map((ingress) => {
         let constructedService = {

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -169,7 +169,8 @@ export async function checkCRD(kc, name) {
 export async function servicesFromKubernetes() {
   const ANNOTATION_BASE = "gethomepage.dev";
   const ANNOTATION_WIDGET_BASE = `${ANNOTATION_BASE}/widget.`;
-
+  const { instanceName } = getSettings();
+  
   checkAndCopyConfig("kubernetes.yaml");
 
   try {
@@ -238,7 +239,7 @@ export async function servicesFromKubernetes() {
     const services = ingressList.items
       .filter(
         (ingress) =>
-          ingress.metadata.annotations && ingress.metadata.annotations[`${ANNOTATION_BASE}/enabled`] === "true",
+          ingress.metadata.annotations && ingress.metadata.annotations[`${ANNOTATION_BASE}/enabled`] === "true" && (!ingress.metadata.annotations[`${ANNOTATION_BASE}/instance`] || ingress.metadata.annotations[`${ANNOTATION_BASE}/instance`] === instanceName),
       )
       .map((ingress) => {
         let constructedService = {


### PR DESCRIPTION
## Proposed change
Add another annotation to kubernetes discovery to allow user to specify for which instance is this supposed to be present for. If no instance provided then it works for all instances preserving current behaviour.

Closes #2487

## Type of change
- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
