### PR TITLE
Use viewable count if it exists

### DIFF
--- a/src/widgets/tdarr/component.jsx
+++ b/src/widgets/tdarr/component.jsx
@@ -26,9 +26,19 @@ export default function Component({ service }) {
     );
   }
 
-  const queue = parseInt(tdarrData.table1Count, 10) + parseInt(tdarrData.table4Count, 10);
-  const processed = parseInt(tdarrData.table2Count, 10) + parseInt(tdarrData.table5Count, 10);
-  const errored = parseInt(tdarrData.table3Count, 10) + parseInt(tdarrData.table6Count, 10);
+  // use viewable count if it exists, which removes file count of any disabled libraries etc
+  // only shows items which are viewable in the tables in the UI
+
+  const table1Count = tdarrData.table1ViewableCount || tdarrData.table1Count;
+  const table2Count = tdarrData.table2ViewableCount || tdarrData.table2Count;
+  const table3Count = tdarrData.table3ViewableCount || tdarrData.table3Count;
+  const table4Count = tdarrData.table4ViewableCount || tdarrData.table4Count;
+  const table5Count = tdarrData.table5ViewableCount || tdarrData.table5Count;
+  const table6Count = tdarrData.table6ViewableCount || tdarrData.table6Count;
+
+  const queue = parseInt(table1Count, 10) + parseInt(table4Count, 10);
+  const processed = parseInt(table2Count, 10) + parseInt(table5Count, 10);
+  const errored = parseInt(table3Count, 10) + parseInt(table6Count, 10);
   const saved = parseFloat(tdarrData.sizeDiff, 10) * 1000000000;
 
   return (


### PR DESCRIPTION
## Proposed change

 Use viewable count if it exists, which removes file count of any disabled libraries etc
 Only shows items which are viewable in the tables in the UI.

If new data not available then use previous data.

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ x] Other (please explain)

Slight data change which fixes:

https://github.com/HaveAGitGat/Tdarr/issues/932

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
