### PR TITLE
The $PUID & $PGID env vars aren’t standard

### DIFF
--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -20,7 +20,7 @@ services:
 
 ### Running as non-root
 
-By default, the Homepage container runs as root. Homepage also supports running your container as non-root via the standard `PUID` and `PGID` environment variables. When using these variables, make sure that any volumes mounted in to the container have the correct ownership and permissions set.
+By default, the Homepage container runs as root. Homepage also supports running your container as non-root via the common `PUID` and `PGID` environment variables. When using these variables, make sure that any volumes mounted in to the container have the correct ownership and permissions set.
 
 _Using the docker socket directly is not the recommended method of integration and requires either running homepage as root or that the user be part of the docker group_
 


### PR DESCRIPTION
## Proposed change

The $PUID & $PGID env vars aren’t standard

They are conventions, and common ones, but not standard.

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
