### PR TITLE
Enhancement: support multiple checks for healthchecks widget

### DIFF
--- a/docs/widgets/services/healthchecks.md
+++ b/docs/widgets/services/healthchecks.md
@@ -3,16 +3,21 @@ title: Health checks
 description: Health checks Widget Configuration
 ---
 
+Specify a single check by including the `uuid` field or show the total 'up' and 'down' for all
+checks by leaving off the `uuid` field.
+
 To use the Health Checks widget, you first need to generate an API key.
 
 1. In your project, go to project Settings on the navigation bar.
 2. Click on API key (read-only) and then click _Create_.
 3. Copy the API key that is generated for you.
 
+Allowed fields: `["status", "last_ping"]` for single checks, `["up", "down"]` for total stats.
+
 ```yaml
 widget:
   type: healthchecks
   url: http://healthchecks.host.or.ip:port
   key: <YOUR_API_KEY>
-  uuid: <YOUR_CHECK_UUID> # optional, if not present group statistics is shown
+  uuid: <CHECK_UUID> # optional, if not included total statistics for all checks is shown
 ```

--- a/docs/widgets/services/healthchecks.md
+++ b/docs/widgets/services/healthchecks.md
@@ -3,18 +3,16 @@ title: Health checks
 description: Health checks Widget Configuration
 ---
 
-To use the Health Checks widget, you first need to generate an API key. To do this, follow these steps:
+To use the Health Checks widget, you first need to generate an API key.
 
-1. Go to Settings in your check dashboard.
+1. In your project, go to project Settings on the navigation bar.
 2. Click on API key (read-only) and then click _Create_.
 3. Copy the API key that is generated for you.
-
-Allowed fields: `["status", "last_ping"]`.
 
 ```yaml
 widget:
   type: healthchecks
   url: http://healthchecks.host.or.ip:port
   key: <YOUR_API_KEY>
-  uuid: <YOUR_CHECK_UUID>
+  uuid: <YOUR_CHECK_UUID> # optional, if not present group statistics is shown
 ```

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -491,9 +491,9 @@
     },
     "healthchecks": {
         "new": "New",
-        "up": "Online",
+        "up": "Up",
         "grace": "In Grace Period",
-        "down": "Offline",
+        "down": "Down",
         "paused": "Paused",
         "status": "Status",
         "last_ping": "Last Ping",

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -397,6 +397,9 @@ export function cleanServiceGroups(groups) {
           // glances, customapi, iframe
           refreshInterval,
 
+          // healthchecks
+          uuid,
+
           // iframe
           allowFullscreen,
           allowPolicy,
@@ -433,9 +436,6 @@ export function cleanServiceGroups(groups) {
 
           // unifi
           site,
-
-          // healthchecks
-          uuid,
         } = cleanedService.widget;
 
         let fieldsList = fields;

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -433,6 +433,9 @@ export function cleanServiceGroups(groups) {
 
           // unifi
           site,
+
+          // healthchecks
+          uuid,
         } = cleanedService.widget;
 
         let fieldsList = fields;
@@ -535,6 +538,9 @@ export function cleanServiceGroups(groups) {
           if (maxEvents) cleanedService.widget.maxEvents = maxEvents;
           if (previousDays) cleanedService.widget.previousDays = previousDays;
           if (showTime) cleanedService.widget.showTime = showTime;
+        }
+        if (type === "healthchecks") {
+          if (uuid !== undefined) cleanedService.widget.uuid = uuid;
         }
       }
 

--- a/src/widgets/healthchecks/component.jsx
+++ b/src/widgets/healthchecks/component.jsx
@@ -27,6 +27,23 @@ function formatDate(dateString) {
   return new Intl.DateTimeFormat(i18n.language, dateOptions).format(date);
 }
 
+function countStatus(data) {
+  let upCount = 0;
+  let downCount = 0;
+
+  if (data.checks) {
+    data.checks.forEach((check) => {
+      if (check.status === "up") {
+        upCount += 1;
+      } else if (check.status === "down") {
+        downCount += 1;
+      }
+    });
+  }
+
+  return { upCount, downCount };
+}
+
 export default function Component({ service }) {
   const { t } = useTranslation();
   const { widget } = service;
@@ -46,13 +63,26 @@ export default function Component({ service }) {
     );
   }
 
+  const hasUuid = widget?.uuid;
+
+  const { upCount, downCount } = countStatus(data);
+
   return (
     <Container service={service}>
-      <Block label="healthchecks.status" value={t(`healthchecks.${data.status}`)} />
-      <Block
-        label="healthchecks.last_ping"
-        value={data.last_ping ? formatDate(data.last_ping) : t("healthchecks.never")}
-      />
+      {hasUuid ? (
+        <>
+          <Block label="healthchecks.status" value={t(`healthchecks.${data.status}`)} />
+          <Block
+            label="healthchecks.last_ping"
+            value={data.last_ping ? formatDate(data.last_ping) : t("healthchecks.never")}
+          />
+        </>
+      ) : (
+        <>
+          <Block label="healthchecks.up" value={upCount} />
+          <Block label="healthchecks.down" value={downCount} />
+        </>
+      )}
     </Container>
   );
 }

--- a/src/widgets/healthchecks/widget.js
+++ b/src/widgets/healthchecks/widget.js
@@ -1,13 +1,12 @@
 import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
 
 const widget = {
-  api: "{url}/api/v2/{endpoint}/{uuid}",
+  api: "{url}/api/v3/{endpoint}/{uuid}",
   proxyHandler: credentialedProxyHandler,
 
   mappings: {
     checks: {
       endpoint: "checks",
-      validate: ["status", "last_ping"],
     },
   },
 };


### PR DESCRIPTION
## Summary

I use Healthchecks in my homelab and manage multiple checks. While I am grateful for the initial development work outlined [here](https://github.com/gethomepage/homepage/pull/1023), I believe the initial approach could not have been the most effective. The reason being that having a widget for a single check often falls too short. I agree with the sentiments expressed in other [comments](https://github.com/gethomepage/homepage/pull/1023#issuecomment-1586332373) and the associated [feature request](https://github.com/gethomepage/homepage/discussions/2411). The widget would be vastly improved if it could display the total number of "ups" and "downs."

Other changes:

- I also got [confused](https://github.com/gethomepage/homepage/discussions/2566) about the terms "Online"/"Offline" that don't exist in the original application. I have opted to rename them as "Up"/"Down," aligning with the original terminology.

- I replaced the API endpoint from `v2` to `v3` as it's the most recent, see [here](https://healthchecks.io/docs/api/).

![image](https://github.com/gethomepage/homepage/assets/25015317/28ff08e0-2d71-446f-b150-db53453df1d7)

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (**breaking** change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
