### PR TITLE
CustomAPI changes: locale option for date & relativeDate format

### DIFF
--- a/docs/widgets/services/customapi.md
+++ b/docs/widgets/services/customapi.md
@@ -37,9 +37,17 @@ widget:
       locale: nl # optional
       dateStyle: long # optional - defaults to "long". Allowed values: `["full", "long", "medium", "short"]`.
       timeStyle: medium # optional - Allowed values: `["full", "long", "medium", "short"]`.
+    - field: key # needs to be YAML string or object
+      label: Field 5
+      format: relativeDate # optional - defaults to text
+      locale: nl # optional
+      style: short # optional - defaults to "long". Allowed values: `["long", "short", "narrow"]`.
+      numeric: auto # optional - defaults to "always". Allowed values `["always", "auto"]`.
 ```
 
-Supported formats for the values are `text`, `number`, `float`, `percent`, `bytes`, `bitrate` and `date`.
+Supported formats for the values are `text`, `number`, `float`, `percent`, `bytes`, `bitrate`, `date` and `relativeDate`.
+
+The `dateStyle` and `timeStyle` options of the `date` format are passed directly to [Intl.DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat) and the `style` and `numeric` options of `relativeDate` are passed to [Intl.RelativeTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/RelativeTimeFormat).
 
 ## Example
 

--- a/docs/widgets/services/customapi.md
+++ b/docs/widgets/services/customapi.md
@@ -34,6 +34,7 @@ widget:
     - field: key # needs to be YAML string or object
       label: Field 4
       format: date # optional - defaults to text
+      locale: nl # optional
       dateStyle: long # optional - defaults to "long". Allowed values: `["full", "long", "medium", "short"]`.
       timeStyle: medium # optional - Allowed values: `["full", "long", "medium", "short"]`.
 ```

--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -105,7 +105,7 @@ function relativeDate(date, formatter) {
   const units = ["second", "minute", "hour", "day", "week", "month", "year"];
 
   const delta = Math.round((date.getTime() - Date.now()) / 1000);
-  const unitIndex = cutoffs.findIndex(cutoff => cutoff > Math.abs(delta));
+  const unitIndex = cutoffs.findIndex((cutoff) => cutoff > Math.abs(delta));
   const divisor = unitIndex ? cutoffs[unitIndex - 1] : 1;
 
   return formatter.format(Math.floor(delta / divisor), units[unitIndex]);

--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -100,6 +100,17 @@ function uptime(uptimeInSeconds, i18next) {
   return (moDisplay + dDisplay + hDisplay + mDisplay + sDisplay).replace(/,\s*$/, "");
 }
 
+function relativeDate(date, formatter) {
+  const cutoffs = [60, 3600, 86400, 86400 * 7, 86400 * 30, 86400 * 365, Infinity];
+  const units = ["second", "minute", "hour", "day", "week", "month", "year"];
+
+  const delta = Math.round((date.getTime() - Date.now()) / 1000);
+  const unitIndex = cutoffs.findIndex(cutoff => cutoff > Math.abs(delta));
+  const divisor = unitIndex ? cutoffs[unitIndex - 1] : 1;
+
+  return formatter.format(Math.floor(delta / divisor), units[unitIndex]);
+}
+
 module.exports = {
   i18n: {
     defaultLocale: "en",
@@ -141,6 +152,9 @@ module.exports = {
         );
         i18next.services.formatter.add("date", (value, lng, options) =>
           new Intl.DateTimeFormat(lng, { ...options }).format(new Date(value)),
+        );
+        i18next.services.formatter.add("relativeDate", (value, lng, options) =>
+          relativeDate(new Date(value), new Intl.RelativeTimeFormat(lng, { ...options })),
         );
         i18next.services.formatter.add("uptime", (value, lng) => uptime(value, i18next));
       },

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -12,6 +12,7 @@
         "number": "{{value, number}}",
         "ms": "{{value, number}}",
         "date": "{{value, date}}",
+        "relativeDate": "{{value, relativeDate}}",
         "uptime": "{{value, uptime}}",
         "months": "mo",
         "days": "d",

--- a/src/widgets/customapi/component.jsx
+++ b/src/widgets/customapi/component.jsx
@@ -70,7 +70,7 @@ function formatValue(t, mapping, rawValue) {
       value = t("common.bitrate", { value });
       break;
     case "date":
-      value = t("common.date", { value, dateStyle: mapping?.dateStyle ?? "long", timeStyle: mapping?.timeStyle });
+      value = t("common.date", { value, lng: mapping?.locale, dateStyle: mapping?.dateStyle ?? "long", timeStyle: mapping?.timeStyle });
       break;
     case "text":
     default:

--- a/src/widgets/customapi/component.jsx
+++ b/src/widgets/customapi/component.jsx
@@ -72,6 +72,9 @@ function formatValue(t, mapping, rawValue) {
     case "date":
       value = t("common.date", { value, lng: mapping?.locale, dateStyle: mapping?.dateStyle ?? "long", timeStyle: mapping?.timeStyle });
       break;
+    case "relativeDate":
+      value = t("common.relativeDate", { value, lng: mapping?.locale, style: mapping?.style, numeric: mapping?.numeric });
+      break;
     case "text":
     default:
     // nothing

--- a/src/widgets/customapi/component.jsx
+++ b/src/widgets/customapi/component.jsx
@@ -70,10 +70,20 @@ function formatValue(t, mapping, rawValue) {
       value = t("common.bitrate", { value });
       break;
     case "date":
-      value = t("common.date", { value, lng: mapping?.locale, dateStyle: mapping?.dateStyle ?? "long", timeStyle: mapping?.timeStyle });
+      value = t("common.date", {
+        value,
+        lng: mapping?.locale,
+        dateStyle: mapping?.dateStyle ?? "long",
+        timeStyle: mapping?.timeStyle,
+      });
       break;
     case "relativeDate":
-      value = t("common.relativeDate", { value, lng: mapping?.locale, style: mapping?.style, numeric: mapping?.numeric });
+      value = t("common.relativeDate", {
+        value,
+        lng: mapping?.locale,
+        style: mapping?.style,
+        numeric: mapping?.numeric,
+      });
       break;
     case "text":
     default:


### PR DESCRIPTION
## Proposed change
- _[FIX]_ Added a `locale` option to the `date` format of the CustomAPI widget
- _[FEATURE]_ Added a new `relativeDate` format to the CustomAPI widget

Closes #2612

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.

**Note**  
When writing this PR, I initially did not see the requirement of having 5 up-votes for new features. As this PR contains both a bug fix and new feature and both changes are rather minimal, I still hope it will be accepted.
If you do not want to add the new feature because of said rule, let me know if I can still submit the locale option as a new PR _(and that will teach me to properly read guidelines before jumping in to code my requested features...)_.
