### PR TITLE
Feature: Netdata service widget

### DIFF
--- a/docs/widgets/services/netdata.md
+++ b/docs/widgets/services/netdata.md
@@ -1,0 +1,12 @@
+---
+title: Netdata
+description: Netdata Widget Configuration
+---
+
+Allowed fields: `["warnings", "criticals"]`.
+
+```yaml
+widget:
+  type: Netdata
+  url: http://netdata.host.or.ip
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,7 @@ nav:
       - widgets/services/moonraker.md
       - widgets/services/mylar.md
       - widgets/services/navidrome.md
+      - widgets/services/netdata.md
       - widgets/services/nextcloud.md
       - widgets/services/nextdns.md
       - widgets/services/nginx-proxy-manager.md

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -795,5 +795,9 @@
         "digitalRelease": "Digital release",
         "noEventsToday": "No events for today!",
         "noEventsFound": "No events found"
+    },
+    "netdata": {
+      "warnings": "Warnings",
+      "criticals": "Criticals"
     }
 }

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -58,6 +58,7 @@ const components = {
   moonraker: dynamic(() => import("./moonraker/component")),
   mylar: dynamic(() => import("./mylar/component")),
   navidrome: dynamic(() => import("./navidrome/component")),
+  netdata: dynamic(() => import("./netdata/component")),
   nextcloud: dynamic(() => import("./nextcloud/component")),
   nextdns: dynamic(() => import("./nextdns/component")),
   npm: dynamic(() => import("./npm/component")),

--- a/src/widgets/netdata/component.jsx
+++ b/src/widgets/netdata/component.jsx
@@ -1,0 +1,33 @@
+import { useTranslation } from "next-i18next";
+
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+
+  const { widget } = service;
+
+  const { data: netdataData, error: netdataError } = useWidgetAPI(widget, "info");
+
+  if (netdataError) {
+    return <Container service={service} error={netdataError} />;
+  }
+
+  if (!netdataData) {
+    return (
+      <Container service={service}>
+        <Block label="netdata.warnings" />
+        <Block label="netdata.criticals" />
+      </Container>
+    );
+  }
+
+  return (
+    <Container service={service}>
+      <Block label="netdata.warnings" value={t("common.number", { value: netdataData.alarms.warning })} />
+      <Block label="netdata.criticals" value={t("common.number", { value: netdataData.alarms.critical })} />
+    </Container>
+  );
+}

--- a/src/widgets/netdata/widget.js
+++ b/src/widgets/netdata/widget.js
@@ -1,0 +1,14 @@
+import genericProxyHandler from "utils/proxy/handlers/generic";
+
+const widget = {
+  api: "{url}/api/v1/{endpoint}",
+  proxyHandler: genericProxyHandler,
+
+  mappings: {
+    info: {
+      endpoint: "info",
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -50,6 +50,7 @@ import mjpeg from "./mjpeg/widget";
 import moonraker from "./moonraker/widget";
 import mylar from "./mylar/widget";
 import navidrome from "./navidrome/widget";
+import netdata from "./netdata/widget";
 import nextcloud from "./nextcloud/widget";
 import nextdns from "./nextdns/widget";
 import npm from "./npm/widget";
@@ -155,6 +156,7 @@ const widgets = {
   moonraker,
   mylar,
   navidrome,
+  netdata,
   nextcloud,
   nextdns,
   npm,


### PR DESCRIPTION
## Proposed change

This change introduces a (very simple) Netdata widget that pulls data from the locally exposed API. I used the Adguard Home widget as a base.

![image](https://github.com/gethomepage/homepage/assets/37925797/2dcdfdbc-b45e-4dc3-90a9-0d4301701981)

The user will be able to add the widget to the services.yaml file using the following configuration:

```yaml
widget:
    type: Netdata
    url: http://netdata.host.or.ip
  ```

Relates to https://github.com/gethomepage/homepage/discussions/1217

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [x] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
