### PR TITLE
Fix: remove date time load delay

### DIFF
--- a/src/components/widgets/datetime/datetime.jsx
+++ b/src/components/widgets/datetime/datetime.jsx
@@ -23,6 +23,7 @@ export default function DateTime({ options }) {
 
   useEffect(() => {
     const dateFormat = new Intl.DateTimeFormat(dateLocale, { ...format });
+    setDate(dateFormat.format(new Date()));
     const interval = setInterval(() => {
       setDate(dateFormat.format(new Date()));
     }, 1000);


### PR DESCRIPTION
Howdy!

This small change should allow the date time to pop up on the initial page load and not after a one-second delay.

I'm just now getting into homepage in my homelab, and I am very interested in using and improving it any way I can.