### PR TITLE
Add support for prefix in customapi

### DIFF
--- a/docs/widgets/services/customapi.md
+++ b/docs/widgets/services/customapi.md
@@ -93,7 +93,7 @@ mappings:
 
 ## Data Transformation
 
-You can manipulate data with the following tools `remap`, `scale` and `suffix`, for example:
+You can manipulate data with the following tools `remap`, `scale`, `prefix` and `suffix`, for example:
 
 ```yaml
 - field: key4
@@ -111,6 +111,10 @@ You can manipulate data with the following tools `remap`, `scale` and `suffix`, 
   format: float
   scale: 0.001 # can be number or string e.g. 1/16
   suffix: kW
+- field: key6
+  label: Cost
+  format: float
+  prefix: "£"
 ```
 
 ## Custom Headers

--- a/src/widgets/customapi/component.jsx
+++ b/src/widgets/customapi/component.jsx
@@ -90,6 +90,11 @@ function formatValue(t, mapping, rawValue) {
     // nothing
   }
 
+  // Apply fixed prefix.
+  const prefix = mapping?.prefix;
+  if (prefix) {
+    value = `${prefix}${value}`;
+  }
   // Apply fixed suffix.
   const suffix = mapping?.suffix;
   if (suffix) {


### PR DESCRIPTION
## Proposed change

Add the ability to add a fixed prefix to customapi fields, similar to the existing `suffix` support. An example usecase for this is in the docs change based around rendering float currency values.

Closes https://github.com/gethomepage/homepage/discussions/2677

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
