### PR TITLE
Enhancement: Add fields to qbittorrent widget

### DIFF
--- a/docs/widgets/services/qbittorrent.md
+++ b/docs/widgets/services/qbittorrent.md
@@ -5,7 +5,9 @@ description: qBittorrent Widget Configuration
 
 Uses the same username and password used to login from the web.
 
-Allowed fields: `["leech", "download", "seed", "upload"]`.
+Allowed fields: `["leech", "download", "seed", "upload", "total", "error",
+"checking", "moving", "activeDl", "activeUl", "active", "paused", "queued",
+"stalled"]`.
 
 ```yaml
 widget:

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -203,7 +203,17 @@
         "download": "Download",
         "upload": "Upload",
         "leech": "Leech",
-        "seed": "Seed"
+        "seed": "Seed",
+        "total": "Total",
+        "error": "Error",
+        "checking": "Checking",
+        "moving": "Moving",
+        "activeUl": "Active Uploads",
+        "activeDl": "Active Downloads",
+        "active": "Active",
+        "paused": "Paused",
+        "queued": "Queued",
+        "stalled": "Stalled"
     },
     "qnap": {
         "cpuUsage": "CPU Usage",

--- a/src/widgets/qbittorrent/component.jsx
+++ b/src/widgets/qbittorrent/component.jsx
@@ -15,6 +15,17 @@ export default function Component({ service }) {
     return <Container service={service} error={torrentError} />;
   }
 
+  // Default fields
+  if (widget.fields === null || widget.fields.length === 0) {
+    widget.fields = ["leech", "download", "seed", "upload"];
+  }
+
+  const MAX_ALLOWED_FIELDS = 4;
+  // Limits max number of displayed fields
+  if (widget.fields != null && widget.fields.length > MAX_ALLOWED_FIELDS) {
+    widget.fields = widget.fields.slice(0, MAX_ALLOWED_FIELDS);
+  }
+
   if (!torrentData) {
     return (
       <Container service={service}>
@@ -22,6 +33,16 @@ export default function Component({ service }) {
         <Block label="qbittorrent.download" />
         <Block label="qbittorrent.seed" />
         <Block label="qbittorrent.upload" />
+        <Block label="qbittorrent.total" />
+        <Block label="qbittorrent.error" />
+        <Block label="qbittorrent.checking" />
+        <Block label="qbittorrent.moving" />
+        <Block label="qbittorrent.activeUl" />
+        <Block label="qbittorrent.activeDl" />
+        <Block label="qbittorrent.active" />
+        <Block label="qbittorrent.paused" />
+        <Block label="qbittorrent.queued" />
+        <Block label="qbittorrent.stalled" />
       </Container>
     );
   }
@@ -29,6 +50,15 @@ export default function Component({ service }) {
   let rateDl = 0;
   let rateUl = 0;
   let completed = 0;
+  let error = 0;
+  let checking = 0;
+  let moving = 0;
+  let activeUl = 0;
+  let activeDl = 0;
+  let active = 0;
+  let paused = 0;
+  let queued = 0;
+  let stalled = 0;
 
   for (let i = 0; i < torrentData.length; i += 1) {
     const torrent = torrentData[i];
@@ -37,9 +67,55 @@ export default function Component({ service }) {
     if (torrent.progress === 1) {
       completed += 1;
     }
+    switch (torrent.state) {
+      case "error":
+      case "missingFiles":
+      case "unknown":
+        error += 1;
+        break;
+
+      case "checkingResumeData":
+      case "checkingUP":
+      case "checkingDL":
+        checking += 1;
+        break;
+
+      case "moving":
+        moving += 1;
+        break;
+
+      case "uploading":
+        active += 1;
+        activeUl += 1;
+        break;
+
+      case "downloading":
+        active += 1;
+        activeDl += 1;
+        break;
+
+      case "pausedUP":
+      case "pausedDL":
+        paused += 1;
+        break;
+
+      case "stalledUP":
+      case "stalledDL":
+        stalled += 1;
+        break;
+
+      case "queuedUP":
+      case "queuedDL":
+        queued += 1;
+        break;
+
+      default:
+        break;
+    }
   }
 
   const leech = torrentData.length - completed;
+  const total = torrentData.length;
 
   return (
     <Container service={service}>
@@ -47,6 +123,16 @@ export default function Component({ service }) {
       <Block label="qbittorrent.download" value={t("common.bibyterate", { value: rateDl, decimals: 1 })} />
       <Block label="qbittorrent.seed" value={t("common.number", { value: completed })} />
       <Block label="qbittorrent.upload" value={t("common.bibyterate", { value: rateUl, decimals: 1 })} />
+      <Block label="qbittorrent.total" value={t("common.number", { value: total })} />
+      <Block label="qbittorrent.error" value={t("common.number", { value: error })} />
+      <Block label="qbittorrent.checking" value={t("common.number", { value: checking })} />
+      <Block label="qbittorrent.moving" value={t("common.number", { value: moving })} />
+      <Block label="qbittorrent.activeUl" value={t("common.number", { value: activeUl })} />
+      <Block label="qbittorrent.activeDl" value={t("common.number", { value: activeDl })} />
+      <Block label="qbittorrent.active" value={t("common.number", { value: active })} />
+      <Block label="qbittorrent.paused" value={t("common.number", { value: paused })} />
+      <Block label="qbittorrent.queued" value={t("common.number", { value: queued })} />
+      <Block label="qbittorrent.stalled" value={t("common.number", { value: stalled })} />
     </Container>
   );
 }


### PR DESCRIPTION
## Proposed change

total: number of all torrents
error: number of torrents with error
checking: number of torrents that are being checked
moving: number of torrents that are being moved
activeUl: number of torrents that are actively seeding
activeDl: number of torrents  that are actively downloading
active: number of torrents with traffic (activeUl+activeDl)
paused: number of paused torrents
queued: number of queued torrents 
stalled: number of stalled torrents 

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
