### PR TITLE
Feature: Added gatus uptime widget

### DIFF
--- a/docs/widgets/services/gatus.md
+++ b/docs/widgets/services/gatus.md
@@ -1,0 +1,12 @@
+---
+title: Gatus
+description: Gatus Widget Configuration
+---
+
+Allowed fields: `["up", "down", "uptime"]`.
+
+```yaml
+widget:
+  type: gatus
+  url: http://gatus.host.or.ip:port
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
       - widgets/services/freshrss.md
       - widgets/services/fritzbox.md
       - widgets/services/gamedig.md
+      - widgets/services/gatus.md
       - widgets/services/ghostfolio.md
       - widgets/services/glances.md
       - widgets/services/gluetun.md

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -694,6 +694,11 @@
         "targets_down": "Targets Down",
         "targets_total": "Total Targets"
     },
+    "gatus": {
+        "up": "Sites Up",
+        "down": "Sites Down",
+        "uptime": "Uptime"
+    },
     "ghostfolio": {
         "gross_percent_today": "Today",
         "gross_percent_1y": "One year",

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -29,6 +29,7 @@ const components = {
   freshrss: dynamic(() => import("./freshrss/component")),
   fritzbox: dynamic(() => import("./fritzbox/component")),
   gamedig: dynamic(() => import("./gamedig/component")),
+  gatus: dynamic(() => import("./gatus/component")),
   ghostfolio: dynamic(() => import("./ghostfolio/component")),
   glances: dynamic(() => import("./glances/component")),
   gluetun: dynamic(() => import("./gluetun/component")),

--- a/src/widgets/gatus/component.jsx
+++ b/src/widgets/gatus/component.jsx
@@ -1,0 +1,51 @@
+import { useTranslation } from "next-i18next";
+
+import Container from "components/services/widget/container";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+import Block from "components/services/widget/block";
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+
+  const { widget } = service;
+
+  const { data: statusData, error: statusError } = useWidgetAPI(widget, "status");
+
+  if (statusError) {
+    return <Container service={service} error={statusError} />;
+  }
+
+  if (!statusData) {
+    return (
+      <Container service={service}>
+        <Block label="gatus.up" />
+        <Block label="gatus.down" />
+        <Block label="gatus.uptime" />
+      </Container>
+    );
+  }
+
+  let sitesUp = 0;
+  let sitesDown = 0;
+  Object.values(statusData).forEach((site) => {
+    const lastResult = site.results[site.results.length - 1];
+    if (lastResult?.success === true) {
+      sitesUp += 1;
+    } else {
+      sitesDown += 1;
+    }
+  });
+
+  // Adapted from https://github.com/bastienwirtz/homer/blob/b7cd8f9482e6836a96b354b11595b03b9c3d67cd/src/components/services/UptimeKuma.vue#L105
+  const resultsList = Object.values(statusData).reduce((a, b) => a.concat(b.results), []);
+  const percent = resultsList.reduce((a, b) => a + (b?.success === true ? 1 : 0), 0) / resultsList.length;
+  const uptime = (percent * 100).toFixed(1);
+
+  return (
+    <Container service={service}>
+      <Block label="gatus.up" value={t("common.number", { value: sitesUp })} />
+      <Block label="gatus.down" value={t("common.number", { value: sitesDown })} />
+      <Block label="gatus.uptime" value={t("common.percent", { value: uptime })} />
+    </Container>
+  );
+}

--- a/src/widgets/gatus/widget.js
+++ b/src/widgets/gatus/widget.js
@@ -1,0 +1,15 @@
+// import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
+import genericProxyHandler from "utils/proxy/handlers/generic";
+
+const widget = {
+  api: "{url}/{endpoint}",
+  proxyHandler: genericProxyHandler,
+
+  mappings: {
+    status: {
+      endpoint: "api/v1/endpoints/statuses",
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -23,6 +23,7 @@ import flood from "./flood/widget";
 import freshrss from "./freshrss/widget";
 import fritzbox from "./fritzbox/widget";
 import gamedig from "./gamedig/widget";
+import gatus from "./gatus/widget";
 import ghostfolio from "./ghostfolio/widget";
 import glances from "./glances/widget";
 import gluetun from "./gluetun/widget";
@@ -128,6 +129,7 @@ const widgets = {
   freshrss,
   fritzbox,
   gamedig,
+  gatus,
   ghostfolio,
   glances,
   gluetun,


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well updates to the docs for the new widget.
-->

This change adds support for a [Gatus](https://github.com/TwiN/gatus) widget for uptime tracking. I used the existing Uptime-Kuma widget as a basis.

![image](https://github.com/gethomepage/homepage/assets/4346249/49851155-52af-40be-b401-f07df7beb3ca)

The user will be able to add the widget to the services.yaml file using the following configuration:

```yaml
widget:
    type: gatus
    url: http://gatus.host.or.ip:port
```

Relates to #2341

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [x] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
