### PR TITLE
Enhancement: extend hdhomerun widget

### DIFF
--- a/docs/widgets/services/hdhomerun.md
+++ b/docs/widgets/services/hdhomerun.md
@@ -5,7 +5,7 @@ description: HDHomerun Widget Configuration
 
 Learn more about [HDHomerun](https://www.silicondust.com/support/downloads/).
 
-Allowed fields: `["channels", "hd", "tunerCount", "channelNumber", "channelNetwork", "signalStrength", "signalQuality", "symbolQuality, "networkRate", "clientIP" ]`.
+Allowed fields: `["channels", "hd", "tunerCount", "channelNumber", "channelNetwork", "signalStrength", "signalQuality", "symbolQuality", "networkRate", "clientIP" ]`.
 
 If more than 4 fields are provided, only the first 4 are displayed. The
 order that fields are configured is preserved for display.

--- a/docs/widgets/services/hdhomerun.md
+++ b/docs/widgets/services/hdhomerun.md
@@ -3,12 +3,18 @@ title: HDHomerun
 description: HDHomerun Widget Configuration
 ---
 
-Learn more about [HDHomerun](https://www.silicondust.com/support/downloads/).
+[HDHomerun](https://www.silicondust.com/support/downloads/)
 
-Allowed fields: `["channels", "hd"]`.
+Allowed fields: `["channels", "hd", "tunerCount", "channelNumber", "channelNetwork", "signalStrength", "signalQuality", "symbolQuality, "networkRate", "clientIP" ]`.
+
+If more than 4 fields are provided, only the first 4 are displayed. The
+order that fields are configured is preserved for display.
 
 ```yaml
+tuner: 0 # optional - defaults to 0, used for tuner-specific fields
 widget:
   type: hdhomerun
   url: http://hdhomerun.host.or.ip
+  refreshInterval: 10000 # optional - minimum of 1 sec, default of 10s
+  fields: ["channels", "hd"] # optional - default fields shown
 ```

--- a/docs/widgets/services/hdhomerun.md
+++ b/docs/widgets/services/hdhomerun.md
@@ -3,7 +3,7 @@ title: HDHomerun
 description: HDHomerun Widget Configuration
 ---
 
-[HDHomerun](https://www.silicondust.com/support/downloads/)
+Learn more about [HDHomerun](https://www.silicondust.com/support/downloads/).
 
 Allowed fields: `["channels", "hd", "tunerCount", "channelNumber", "channelNetwork", "signalStrength", "signalQuality", "symbolQuality, "networkRate", "clientIP" ]`.
 
@@ -11,10 +11,9 @@ If more than 4 fields are provided, only the first 4 are displayed. The
 order that fields are configured is preserved for display.
 
 ```yaml
-tuner: 0 # optional - defaults to 0, used for tuner-specific fields
 widget:
   type: hdhomerun
   url: http://hdhomerun.host.or.ip
-  refreshInterval: 10000 # optional - minimum of 1 sec, default of 10s
+  tuner: 0 # optional - defaults to 0, used for tuner-specific fields
   fields: ["channels", "hd"] # optional - default fields shown
 ```

--- a/docs/widgets/services/hdhomerun.md
+++ b/docs/widgets/services/hdhomerun.md
@@ -7,8 +7,7 @@ Learn more about [HDHomerun](https://www.silicondust.com/support/downloads/).
 
 Allowed fields: `["channels", "hd", "tunerCount", "channelNumber", "channelNetwork", "signalStrength", "signalQuality", "symbolQuality", "networkRate", "clientIP" ]`.
 
-If more than 4 fields are provided, only the first 4 are displayed. The
-order that fields are configured is preserved for display.
+If more than 4 fields are provided, only the first 4 are displayed.
 
 ```yaml
 widget:

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -536,14 +536,14 @@
     "hdhomerun": {
         "channels": "Channels",
         "hd": "HD",
-	"tunerCount": "Tuners",
-	"channelNumber": "Channel",
-	"channelNetwork": "Network",
-	"signalStrength": "Strength",
-	"signalQuality": "Quality",
-	"symbolQuality": "Quality",
-	"networkRate": "Bitrate",
-	"clientIP": "Client"
+        "tunerCount": "Tuners",
+        "channelNumber": "Channel",
+        "channelNetwork": "Network",
+        "signalStrength": "Strength",
+        "signalQuality": "Quality",
+        "symbolQuality": "Quality",
+        "networkRate": "Bitrate",
+        "clientIP": "Client"
     },
     "scrutiny": {
         "passed": "Passed",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -535,7 +535,15 @@
     },
     "hdhomerun": {
         "channels": "Channels",
-        "hd": "HD"
+        "hd": "HD",
+	"tunerCount": "Tuners",
+	"channelNumber": "Channel",
+	"channelNetwork": "Network",
+	"signalStrength": "Strength",
+	"signalQuality": "Quality",
+	"symbolQuality": "Quality",
+	"networkRate": "Bitrate",
+	"clientIP": "Client"
     },
     "scrutiny": {
         "passed": "Passed",

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -398,6 +398,9 @@ export function cleanServiceGroups(groups) {
           // glances, customapi, iframe
           refreshInterval,
 
+          // hdhomerun
+          tuner,
+
           // healthchecks
           uuid,
 
@@ -540,6 +543,9 @@ export function cleanServiceGroups(groups) {
           if (previousDays) cleanedService.widget.previousDays = previousDays;
           if (showTime) cleanedService.widget.showTime = showTime;
           if (timezone) cleanedService.widget.timezone = timezone;
+        }
+        if (type === "hdhomerun") {
+          if (tuner !== undefined) cleanedService.widget.tuner = tuner;
         }
         if (type === "healthchecks") {
           if (uuid !== undefined) cleanedService.widget.uuid = uuid;

--- a/src/widgets/hdhomerun/component.jsx
+++ b/src/widgets/hdhomerun/component.jsx
@@ -48,8 +48,8 @@ function generateDefinitions(channelsData, statusData, tuner) {
 }
 
 export default function Component({ service }) {
-  const { widget, tuner = 0 } = service;
-  const { refreshInterval = 10000, fields = ["channels", "hd"] } = widget;
+  const { widget } = service;
+  const { tuner = 0, refreshInterval = 10000, fields = ["channels", "hd"] } = widget;
 
   const { data: channelsData, error: channelsError } = useWidgetAPI(widget, "lineup", {
     refreshInterval: Math.max(1000, refreshInterval),

--- a/src/widgets/hdhomerun/component.jsx
+++ b/src/widgets/hdhomerun/component.jsx
@@ -2,16 +2,68 @@ import Container from "components/services/widget/container";
 import Block from "components/services/widget/block";
 import useWidgetAPI from "utils/proxy/use-widget-api";
 
+function generateDefinitions(channelsData, statusData, tuner) {
+  return {
+    channels: {
+      label: "hdhomerun.channels",
+      value: channelsData?.length,
+    },
+    hd: {
+      label: "hdhomerun.hd",
+      value: channelsData?.filter((channel) => channel.HD === 1)?.length,
+    },
+    tunerCount: {
+      label: "hdhomerun.tunerCount",
+      value: `${statusData?.filter((num) => num.VctNumber != null).length ?? 0} / ${statusData?.length ?? 0}`,
+    },
+    channelNumber: {
+      label: "hdhomerun.channelNumber",
+      value: statusData[tuner]?.VctNumber ?? null,
+    },
+    channelNetwork: {
+      label: "hdhomerun.channelNetwork",
+      value: statusData[tuner]?.VctName ?? null,
+    },
+    signalStrength: {
+      label: "hdhomerun.signalStrength",
+      value: statusData[tuner]?.SignalStrengthPercent ?? null,
+    },
+    signalQuality: {
+      label: "hdhomerun.signalQuality",
+      value: statusData[tuner]?.SignalQualityPercent ?? null,
+    },
+    symbolQuality: {
+      label: "hdhomerun.symbolQuality",
+      value: statusData[tuner]?.SymbolQualityPercent ?? null,
+    },
+    clientIP: {
+      label: "hdhomerun.clientIP",
+      value: statusData[tuner]?.TargetIP ?? null,
+    },
+    networkRate: {
+      label: "hdhomerun.networkRate",
+      value: statusData[tuner]?.NetworkRate ?? null,
+    },
+  };
+}
+
 export default function Component({ service }) {
-  const { widget } = service;
+  const { widget, tuner = 0 } = service;
+  const { refreshInterval = 10000, fields = ["channels", "hd"] } = widget;
 
-  const { data: channelsData, error: channelsError } = useWidgetAPI(widget, "lineup");
+  const { data: channelsData, error: channelsError } = useWidgetAPI(widget, "lineup", {
+    refreshInterval: Math.max(1000, refreshInterval),
+  });
+  const { data: statusData, error: statusError } = useWidgetAPI(widget, "status", {
+    refreshInterval: Math.max(1000, refreshInterval),
+  });
 
-  if (channelsError) {
-    return <Container service={service} error={channelsError} />;
+  if (channelsError || statusError) {
+    const finalError = channelsError ?? statusError;
+    return <Container service={service} error={finalError} />;
   }
 
-  if (!channelsData) {
+  if (!channelsData || !statusData) {
     return (
       <Container service={service}>
         <Block label="hdhomerun.channels" />
@@ -20,12 +72,17 @@ export default function Component({ service }) {
     );
   }
 
-  const hdChannels = channelsData?.filter((channel) => channel.HD === 1);
+  const definitions = generateDefinitions(channelsData, statusData, tuner);
 
   return (
     <Container service={service}>
-      <Block label="hdhomerun.channels" value={channelsData.length} />
-      <Block label="hdhomerun.hd" value={hdChannels.length} />
+      {fields.slice(0, 4).map((field) => (
+        <Block
+          key={field}
+          label={definitions[Object.keys(definitions).filter((id) => id === field)].label}
+          value={definitions[Object.keys(definitions).filter((id) => id === field)].value}
+        />
+      ))}
     </Container>
   );
 }

--- a/src/widgets/hdhomerun/widget.js
+++ b/src/widgets/hdhomerun/widget.js
@@ -8,6 +8,9 @@ const widget = {
     lineup: {
       endpoint: "lineup.json",
     },
+    status: {
+      endpoint: "status.json",
+    },
   },
 };
 


### PR DESCRIPTION
## Proposed change

 - maintain the previous behavior if no new configuration is done
 - define additional available fields and present the data in order configured
   - global: "tunerCount"
   - per-tuner: "channelNumber", "channelNetwork", "signalStrength", "signalQuality", "symbolQuality", "networkRate", "clientIP"
 - add handling for refreshInterval
 - update docs

An example of two instances of the widget with the fields configured to be `fields: [ "channels", "hd", "tunerCount" ]` and `fields: [ "clientIP", "channelNumber", "channelNetwork", "signalQuality" ]` respectively:

![image](https://github.com/gethomepage/homepage/assets/1891490/d6f41b60-e496-425d-b39f-c5211cacd5c2)




Closes #772

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [X] If applicable, I have added corresponding documentation changes.
- [X] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [X] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
