### PR TITLE
Fix: iCal integration use event data hash instead of unstable uid

### DIFF
--- a/src/widgets/calendar/integrations/ical.jsx
+++ b/src/widgets/calendar/integrations/ical.jsx
@@ -7,6 +7,17 @@ import { RRule } from "rrule";
 import useWidgetAPI from "../../../utils/proxy/use-widget-api";
 import Error from "../../../components/services/widget/error";
 
+// https://gist.github.com/jlevy/c246006675becc446360a798e2b2d781
+function simpleHash(str) {
+  /* eslint-disable no-plusplus, no-bitwise */
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) - hash + str.charCodeAt(i)) | 0;
+  }
+  return (hash >>> 0).toString(36);
+  /* eslint-disable no-plusplus, no-bitwise */
+}
+
 export default function Integration({ config, params, setEvents, hideErrors, timezone }) {
   const { t } = useTranslation();
   const { data: icalData, error: icalError } = useWidgetAPI(config, config.name, {
@@ -47,7 +58,10 @@ export default function Integration({ config, params, setEvents, hideErrors, tim
         const eventDate = timezone ? DateTime.fromJSDate(date, { zone: timezone }) : DateTime.fromJSDate(date);
 
         for (let j = 0; j < days; j += 1) {
-          eventsToAdd[`${event?.uid?.value}${i}${j}${type}`] = {
+          // See https://github.com/gethomepage/homepage/issues/2753 uid is not stable
+          // assumption is that the event is the same if the start, end and title are all the same
+          const hash = simpleHash(`${event?.dtstart?.value}${event?.dtend?.value}${title}${i}${j}${type}}`);
+          eventsToAdd[hash] = {
             title,
             date: eventDate.plus({ days: j }),
             color: config?.color ?? "zinc",


### PR DESCRIPTION
## Proposed change

Im not certain if the calendar in the linked issue is improperly implementing the calendar spec (I'd guess so) but in that case the uid is not stable between pulls of the calendar. See diffs from pulling the calendar even seconds apart:

- https://github.com/gethomepage/homepage/assets/4887959/337cc4ff-c647-40e0-8edc-441d92d11e1b
- https://github.com/gethomepage/homepage/assets/4887959/f4c5213c-9596-4bd4-ada0-98a8f28d8a5a


Apparently this is not so uncommon https://stackoverflow.com/questions/38193837/how-to-handle-a-uid-of-an-ics-calednar-that-will-change-every-time-i-access-it

Solution is to hash the start/end/title & a couple other things. I tested with a few calendars out there including recurrence but as we've seen, calendars are messy...

<img width="758" alt="Screenshot 2024-01-26 at 12 49 19 AM" src="https://github.com/gethomepage/homepage/assets/4887959/bf969b3c-9e20-44fa-a658-c361c58e193e">
<img width="749" alt="Screenshot 2024-01-26 at 12 59 21 AM" src="https://github.com/gethomepage/homepage/assets/4887959/02877b0b-08f7-4fdb-b8bc-2fc63703a365">
<img width="754" alt="Screenshot 2024-01-26 at 1 05 00 AM" src="https://github.com/gethomepage/homepage/assets/4887959/8b976981-2f0e-4b6c-99f6-a3d2eaa0e2b9">


Closes #2753 

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
