### PR TITLE
Set the widget.fields with a cacluated default if not configured by the user

### DIFF
--- a/docs/widgets/services/unifi-controller.md
+++ b/docs/widgets/services/unifi-controller.md
@@ -11,7 +11,9 @@ You can display general connectivity status from your Unifi (Network) Controller
 
 An optional 'site' parameter can be supplied, if it is not the widget will use the default site for the controller.
 
-Allowed fields: `["uptime", "wan", "lan_users", "wlan_users"]`.
+Allowed fields: `["uptime", "wan", "lan", "lan_users", "lan_devices", "wlan" "wlan_users", "wlan_devices" ]`.
+
+If more than 4 fields are provided, only the first 4 are displayed.
 
 ```yaml
 widget:
@@ -22,4 +24,4 @@ widget:
   site: Site Name # optional
 ```
 
-_Added in v0.4.18, updated in 0.6.7_
+_Added in v0.4.18, updated in 0.8.7_

--- a/src/widgets/unifi/component.jsx
+++ b/src/widgets/unifi/component.jsx
@@ -52,22 +52,40 @@ export default function Component({ service }) {
     );
   }
 
+  // If fields are not configured, set the dynamically determined fields.
+  if (!widget.fields) {
+    widget.fields = [];
+    if (uptime) {
+      widget.fields.push("unifi.uptime");
+    }
+    if (wan.show) {
+      widget.fields.push("unifi.wan");
+    }
+    if (lan.show && !wlan.show) {
+      widget.fields.push("unifi.lan_users");
+      widget.fields.push("unifi.lan");
+    }
+    if (wlan.show) {
+      widget.fields.push("unifi.wlan_users");
+    }
+    if (wlan.show && !lan.show) {
+      widget.fields.push("unifi.wlan_devices");
+      widget.fields.push("unifi.wlan");
+    }
+  }
+  // Limit to the first 4 available
+  widget.fields = widget.fields.slice(0, 4);
+
   return (
     <Container service={service}>
-      {uptime && <Block label="unifi.uptime" value={uptime} />}
-      {wan.show && <Block label="unifi.wan" value={wan.status === "ok" ? t("unifi.up") : t("unifi.down")} />}
-
-      {lan.show && <Block label="unifi.lan_users" value={t("common.number", { value: lan.num_user })} />}
-      {lan.show && !wlan.show && (
-        <Block label="unifi.lan_devices" value={t("common.number", { value: lan.num_adopted })} />
-      )}
-      {lan.show && !wlan.show && <Block label="unifi.lan" value={lan.up ? t("unifi.up") : t("unifi.down")} />}
-
-      {wlan.show && <Block label="unifi.wlan_users" value={t("common.number", { value: wlan.num_user })} />}
-      {wlan.show && !lan.show && (
-        <Block label="unifi.wlan_devices" value={t("common.number", { value: wlan.num_adopted })} />
-      )}
-      {wlan.show && !lan.show && <Block label="unifi.wlan" value={wlan.up ? t("unifi.up") : t("unifi.down")} />}
+      <Block label="unifi.uptime" value={uptime} />
+      <Block label="unifi.wan" value={wan.status === "ok" ? t("unifi.up") : t("unifi.down")} />
+      <Block label="unifi.lan_users" value={t("common.number", { value: lan.num_user })} />
+      <Block label="unifi.lan_devices" value={t("common.number", { value: lan.num_adopted })} />
+      <Block label="unifi.lan" value={lan.up ? t("unifi.up") : t("unifi.down")} />
+      <Block label="unifi.wlan_users" value={t("common.number", { value: wlan.num_user })} />
+      <Block label="unifi.wlan_devices" value={t("common.number", { value: wlan.num_adopted })} />
+      <Block label="unifi.wlan" value={wlan.up ? t("unifi.up") : t("unifi.down")} />
     </Container>
   );
 }


### PR DESCRIPTION
If no fields are configured, set the calculated defaults.  Limit the field count to 4.  Always provide the data as is common practice in widgets.

## Proposed change

- Always return the data calculated to bring the widget in line with standard practice
- Ensure that widget.fields is provided with a default set of values (calculated to result in the same behavior as previously existed) if none are in the configuration
- Limit the number of fields to 4

Closes #2771

## Type of change


- [ ] New service widget
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [X] If applicable, I have added corresponding documentation changes.
- [X] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [X] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
