### PR TITLE
Feature: OpenWRT service widget

### DIFF
--- a/docs/widgets/services/openwrt.md
+++ b/docs/widgets/services/openwrt.md
@@ -1,0 +1,54 @@
+---
+title: OpenWRT
+description: OpenWRT widget configuration
+---
+
+Learn more about [OpenWRT](https://openwrt.org/).
+
+Provides information from OpenWRT
+
+```yaml
+widget:
+  type: openwrt
+  url: http://host.or.ip
+  username: homepage
+  password: pass
+  interfaceName: eth0
+```
+
+## Interface
+
+Adding an interfaceName (e.g eth0) will display information for that particular device, otherwise it will display general system info.
+
+## Authorization
+
+In order for homepage to access the OpenWRT RPC endpoints you will need to [create an ACL](https://openwrt.org/docs/techref/ubus#acls) and [new user](https://openwrt.org/docs/techref/ubus#authentication) in OpenWRT.
+
+Create an ACL named `homepage.json` in `/usr/share/rpcd/acl.d/`, the following permissions will suffice:
+
+```
+{
+        "homepage": {
+                "description": "Homepage widget",
+                "read": {
+                        "ubus": {
+                                "network.interface.wan": ["status"],
+                                "network.interface.lan": ["status"],
+                                "network.device": ["status"]
+                                "system": ["info"]
+                        }
+                },
+        }
+}
+```
+
+Then add a user that will use that ACL in `/etc/config/rpc`:
+
+```config login
+        option username 'homepage'
+        option password '<password>'
+        list read homepage
+        list write '*'
+```
+
+This username and password will be used in Homepage's services.yaml to grant access.

--- a/docs/widgets/services/openwrt.md
+++ b/docs/widgets/services/openwrt.md
@@ -13,12 +13,12 @@ widget:
   url: http://host.or.ip
   username: homepage
   password: pass
-  interfaceName: eth0
+  interfaceName: eth0 # optional
 ```
 
 ## Interface
 
-Adding an interfaceName (e.g eth0) will display information for that particular device, otherwise it will display general system info.
+Setting `interfaceName` (e.g. eth0) will display information for that particular device, otherwise the widget will display general system info.
 
 ## Authorization
 

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -782,10 +782,9 @@
     },
     "openwrt": {
         "uptime": "Uptime",
-        "uptimeValue": "{{days}}d {{hours}}h {{minutes}}m {{seconds}}s",
-        "cpuLoad": "CPU Load Avg (5 mins)",
-        "up": "UP",
-        "down": "DOWN",
+        "cpuLoad": "CPU Load Avg (5m)",
+        "up": "Up",
+        "down": "Down",
         "bytesTx": "Transmitted",
         "bytesRx": "Received"
     },

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -780,6 +780,15 @@
         "passed": "Passed",
         "failed": "Failed"
     },
+    "openwrt": {
+        "uptime": "Uptime",
+        "uptimeValue": "{{days}}d {{hours}}h {{minutes}}m {{seconds}}s",
+        "cpuLoad": "CPU Load Avg (5 mins)",
+        "up": "UP",
+        "down": "DOWN",
+        "bytesTx": "Transmitted",
+        "bytesRx": "Received"
+    },
     "uptimerobot": {
         "status": "Status",
         "uptime": "Uptime",

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -426,6 +426,9 @@ export function cleanServiceGroups(groups) {
           // openmediavault
           method,
 
+          // openwrt
+          interfaceName,
+
           // opnsense, pfsense
           wan,
 
@@ -527,6 +530,9 @@ export function cleanServiceGroups(groups) {
         }
         if (type === "openmediavault") {
           if (method) cleanedService.widget.method = method;
+        }
+        if (type === "openwrt") {
+          if (interfaceName) cleanedService.widget.interfaceName = interfaceName;
         }
         if (type === "customapi") {
           if (mappings) cleanedService.widget.mappings = mappings;

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -71,6 +71,7 @@ const components = {
   opnsense: dynamic(() => import("./opnsense/component")),
   overseerr: dynamic(() => import("./overseerr/component")),
   openmediavault: dynamic(() => import("./openmediavault/component")),
+  openwrt: dynamic(() => import("./openwrt/component")),
   paperlessngx: dynamic(() => import("./paperlessngx/component")),
   pfsense: dynamic(() => import("./pfsense/component")),
   photoprism: dynamic(() => import("./photoprism/component")),

--- a/src/widgets/openwrt/component.jsx
+++ b/src/widgets/openwrt/component.jsx
@@ -1,0 +1,9 @@
+import Interface from "./methods/interface";
+import System from "./methods/system";
+
+export default function Component({ service }) {
+  if (service.widget.interfaceName) {
+    return <Interface service={service} />;
+  }
+  return <System service={service} />;
+}

--- a/src/widgets/openwrt/methods/interface.jsx
+++ b/src/widgets/openwrt/methods/interface.jsx
@@ -1,0 +1,37 @@
+import { useTranslation } from "next-i18next";
+
+import useWidgetAPI from "utils/proxy/use-widget-api";
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+  const { data, error } = useWidgetAPI(service.widget);
+
+  if (error) {
+    return <Container service={service} error={error} />;
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  const { up, bytesTx, bytesRx } = data;
+
+  return (
+    <Container service={service}>
+      <Block
+        label="widget.status"
+        value={
+          up ? (
+            <span className="text-green-500">{t("openwrt.up")}</span>
+          ) : (
+            <span className="text-red-500">{t("openwrt.down")}</span>
+          )
+        }
+      />
+      <Block label="openwrt.bytesTx" value={t("common.bytes", { value: bytesTx })} />
+      <Block label="openwrt.bytesRx" value={t("common.bytes", { value: bytesRx })} />
+    </Container>
+  );
+}

--- a/src/widgets/openwrt/methods/system.jsx
+++ b/src/widgets/openwrt/methods/system.jsx
@@ -1,0 +1,35 @@
+import { useTranslation } from "next-i18next";
+
+import useWidgetAPI from "utils/proxy/use-widget-api";
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+  const { data, error } = useWidgetAPI(service.widget);
+
+  if (error) {
+    return <Container service={service} error={error} />;
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  const { uptime, cpuLoad } = data;
+
+  return (
+    <Container service={service}>
+      <Block
+        label="openwrt.uptime"
+        value={t("openwrt.uptimeValue", {
+          days: Math.floor(uptime / 86400),
+          hours: Math.floor((uptime % 86400) / 3600),
+          minutes: Math.floor((uptime % 3600) / 60),
+          seconds: uptime % 60,
+        })}
+      />
+      <Block label="openwrt.cpuLoad" value={cpuLoad} />
+    </Container>
+  );
+}

--- a/src/widgets/openwrt/methods/system.jsx
+++ b/src/widgets/openwrt/methods/system.jsx
@@ -22,12 +22,7 @@ export default function Component({ service }) {
     <Container service={service}>
       <Block
         label="openwrt.uptime"
-        value={t("openwrt.uptimeValue", {
-          days: Math.floor(uptime / 86400),
-          hours: Math.floor((uptime % 86400) / 3600),
-          minutes: Math.floor((uptime % 3600) / 60),
-          seconds: uptime % 60,
-        })}
+        value={t("common.uptime", { value: uptime })}
       />
       <Block label="openwrt.cpuLoad" value={cpuLoad} />
     </Container>

--- a/src/widgets/openwrt/methods/system.jsx
+++ b/src/widgets/openwrt/methods/system.jsx
@@ -20,10 +20,7 @@ export default function Component({ service }) {
 
   return (
     <Container service={service}>
-      <Block
-        label="openwrt.uptime"
-        value={t("common.uptime", { value: uptime })}
-      />
+      <Block label="openwrt.uptime" value={t("common.uptime", { value: uptime })} />
       <Block label="openwrt.cpuLoad" value={cpuLoad} />
     </Container>
   );

--- a/src/widgets/openwrt/proxy.js
+++ b/src/widgets/openwrt/proxy.js
@@ -1,0 +1,132 @@
+import { sendJsonRpcRequest } from "utils/proxy/handlers/jsonrpc";
+import { formatApiCall } from "utils/proxy/api-helpers";
+import getServiceWidget from "utils/config/service-helpers";
+import createLogger from "utils/logger";
+import widgets from "widgets/widgets";
+
+const PROXY_NAME = "OpenWRTProxyHandler";
+const logger = createLogger(PROXY_NAME);
+const LOGIN_PARAMS = ["00000000000000000000000000000000", "session", "login"];
+const RPC_METHOD = "call";
+
+let authToken = "00000000000000000000000000000000";
+
+const PARAMS = {
+  system: ["system", "info", {}],
+  device: ["network.device", "status", {}],
+};
+
+async function getWidget(req) {
+  const { group, service } = req.query;
+
+  if (!group || !service) {
+    logger.debug("Invalid or missing service '%s' or group '%s'", service, group);
+    return null;
+  }
+
+  const widget = await getServiceWidget(group, service);
+
+  if (!widget) {
+    logger.debug("Invalid or missing widget for service '%s' in group '%s'", service, group);
+    return null;
+  }
+
+  return widget;
+}
+
+function isUnauthorized(data) {
+  const json = JSON.parse(data.toString());
+  return json?.error?.code === -32002;
+}
+
+async function login(url, username, password) {
+  const response = await sendJsonRpcRequest(url, RPC_METHOD, [...LOGIN_PARAMS, { username, password }]);
+
+  if (response[0] === 200) {
+    const responseData = JSON.parse(response[2]);
+    authToken = responseData[1].ubus_rpc_session;
+  }
+
+  return response;
+}
+
+async function fetchInterface(url, interfaceName) {
+  // eslint-disable-next-line no-unused-vars
+  const [_status, contentType, data] = await sendJsonRpcRequest(url, RPC_METHOD, [authToken, ...PARAMS.device]);
+  if (isUnauthorized(data)) {
+    return [401, contentType, data];
+  }
+  const response = JSON.parse(data.toString())[1];
+  const networkInterface = response[interfaceName];
+  if (!networkInterface) {
+    return [404, contentType, { error: "Interface not found" }];
+  }
+
+  const interfaceInfo = {
+    up: networkInterface.up,
+    bytesRx: networkInterface.statistics.rx_bytes,
+    bytesTx: networkInterface.statistics.tx_bytes,
+  };
+  return [200, contentType, interfaceInfo];
+}
+
+async function fetchSystem(url) {
+  // eslint-disable-next-line no-unused-vars
+  const [_status, contentType, data] = await sendJsonRpcRequest(url, RPC_METHOD, [authToken, ...PARAMS.system]);
+  if (isUnauthorized(data)) {
+    return [401, contentType, data];
+  }
+  const systemResponse = JSON.parse(data.toString())[1];
+  const response = {
+    uptime: systemResponse.uptime,
+    cpuLoad: systemResponse.load[1],
+  };
+  return [200, contentType, response];
+}
+
+async function fetchData(url, widget) {
+  let response;
+  if (widget.interfaceName) {
+    response = await fetchInterface(url, widget.interfaceName);
+  } else {
+    response = await fetchSystem(url);
+  }
+  return response;
+}
+
+export default async function proxyHandler(req, res) {
+  const { group, service } = req.query;
+
+  if (!group || !service) {
+    logger.debug("Invalid or missing service '%s' or group '%s'", service, group);
+    return res.status(400).json({ error: "Invalid proxy service type" });
+  }
+
+  const widget = await getWidget(req);
+
+  if (!widget) {
+    logger.debug("Invalid or missing widget for service '%s' in group '%s'", service, group);
+    return res.status(400).json({ error: "Invalid proxy service type" });
+  }
+
+  const api = widgets?.[widget.type]?.api;
+  const url = new URL(formatApiCall(api, { ...widget }));
+
+  let [status, contentType, data] = await fetchData(url, widget);
+
+  if (status === 401) {
+    // eslint-disable-next-line no-unused-vars
+    const [loginStatus, loginContentType, loginData] = await login(url, widget.username, widget.password);
+    if (loginStatus !== 200) {
+      return res.status(loginStatus).end(loginData);
+    }
+    // eslint-disable-next-line no-unused-vars
+    [status, contentType, data] = await fetchData(url, widget);
+
+    if (status === 401) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+  }
+
+  return res.status(200).end(JSON.stringify(data));
+}

--- a/src/widgets/openwrt/proxy.js
+++ b/src/widgets/openwrt/proxy.js
@@ -51,8 +51,7 @@ async function login(url, username, password) {
 }
 
 async function fetchInterface(url, interfaceName) {
-  // eslint-disable-next-line no-unused-vars
-  const [_status, contentType, data] = await sendJsonRpcRequest(url, RPC_METHOD, [authToken, ...PARAMS.device]);
+  const [, contentType, data] = await sendJsonRpcRequest(url, RPC_METHOD, [authToken, ...PARAMS.device]);
   if (isUnauthorized(data)) {
     return [401, contentType, data];
   }
@@ -71,8 +70,7 @@ async function fetchInterface(url, interfaceName) {
 }
 
 async function fetchSystem(url) {
-  // eslint-disable-next-line no-unused-vars
-  const [_status, contentType, data] = await sendJsonRpcRequest(url, RPC_METHOD, [authToken, ...PARAMS.system]);
+  const [, contentType, data] = await sendJsonRpcRequest(url, RPC_METHOD, [authToken, ...PARAMS.system]);
   if (isUnauthorized(data)) {
     return [401, contentType, data];
   }
@@ -112,16 +110,14 @@ export default async function proxyHandler(req, res) {
   const api = widgets?.[widget.type]?.api;
   const url = new URL(formatApiCall(api, { ...widget }));
 
-  let [status, contentType, data] = await fetchData(url, widget);
+  let [status, , data] = await fetchData(url, widget);
 
   if (status === 401) {
-    // eslint-disable-next-line no-unused-vars
-    const [loginStatus, loginContentType, loginData] = await login(url, widget.username, widget.password);
+    const [loginStatus, , loginData] = await login(url, widget.username, widget.password);
     if (loginStatus !== 200) {
       return res.status(loginStatus).end(loginData);
     }
-    // eslint-disable-next-line no-unused-vars
-    [status, contentType, data] = await fetchData(url, widget);
+    [status, , data] = await fetchData(url, widget);
 
     if (status === 401) {
       return res.status(401).json({ error: "Unauthorized" });

--- a/src/widgets/openwrt/widget.js
+++ b/src/widgets/openwrt/widget.js
@@ -1,0 +1,8 @@
+import proxyHandler from "./proxy";
+
+const widget = {
+  api: "{url}/ubus",
+  proxyHandler,
+};
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -63,6 +63,7 @@ import opendtu from "./opendtu/widget";
 import opnsense from "./opnsense/widget";
 import overseerr from "./overseerr/widget";
 import openmediavault from "./openmediavault/widget";
+import openwrt from "./openwrt/widget";
 import paperlessngx from "./paperlessngx/widget";
 import peanut from "./peanut/widget";
 import pfsense from "./pfsense/widget";
@@ -171,6 +172,7 @@ const widgets = {
   opnsense,
   overseerr,
   openmediavault,
+  openwrt,
   paperlessngx,
   peanut,
   pfsense,


### PR DESCRIPTION
## Proposed change


Adds a widget for OpenWRT integration
<img width="838" alt="Screenshot 2024-01-29 at 17 54 49" src="https://github.com/gethomepage/homepage/assets/38405106/017ec904-1493-4e26-90ff-c559598ff78f">

Allows for either system info or information on a particular interface (i.e eth0 for WAN) by adding that interface name as `interfaceName` in services.yaml


Closes #1509

## Type of change

Adds a new widget for OpenWRT

- [x] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x]  If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
