### PR TITLE
Enhancement: extend TrueNAS widget and add info widget

### DIFF
--- a/docs/widgets/info/truenas.md
+++ b/docs/widgets/info/truenas.md
@@ -1,0 +1,19 @@
+---
+title: TrueNAS
+description: TrueNAS Information Widget Configuration
+---
+
+_(Find the TrueNAS service widget [here](../services/truenas.md))_
+
+The TrueNAS widget allows you to monitor the resources (CPU/memory) of your TrueNAS hosts, and is designed to match the `kubernetes` info widget. You can have multiple instances by adding another configuration block.
+
+```yaml
+- truenas:
+    url: http://host.or.ip:port
+    username: user # not required if using api key
+    password: pass # not required if using api key
+    key: yourtruenasapikey # not required if using username / password
+    label: My TrueNAS # optional
+    icon: si-truenas # optional, defaults to si-truenas
+    refresh: 5000 # optional, in ms
+```

--- a/docs/widgets/services/truenas.md
+++ b/docs/widgets/services/truenas.md
@@ -9,6 +9,8 @@ Allowed fields: `["load", "uptime", "alerts"]`.
 
 To create an API Key, follow [the official TrueNAS documentation](https://www.truenas.com/docs/scale/scaletutorials/toptoolbar/managingapikeys/).
 
+A detailed pool listing is disabled by default, but can be enabled with the `enablePools` option.
+
 ```yaml
 widget:
   type: truenas
@@ -16,4 +18,5 @@ widget:
   username: user # not required if using api key
   password: pass # not required if using api key
   key: yourtruenasapikey # not required if using username / password
+  enablePools: true # optional, defaults to false
 ```

--- a/src/components/widgets/kubernetes/node.jsx
+++ b/src/components/widgets/kubernetes/node.jsx
@@ -1,13 +1,9 @@
-import { FaMemory } from "react-icons/fa";
-import { FiAlertTriangle, FiCpu, FiServer } from "react-icons/fi";
+import { FiAlertTriangle, FiServer } from "react-icons/fi";
 import { SiKubernetes } from "react-icons/si";
-import { useTranslation } from "next-i18next";
 
-import UsageBar from "../resources/usage-bar";
+import ServiceResource from "../resources/serviceResource";
 
 export default function Node({ type, options, data }) {
-  const { t } = useTranslation();
-
   function icon() {
     if (type === "cluster") {
       return <SiKubernetes className="text-theme-800 dark:text-theme-200 w-5 h-5" />;
@@ -19,42 +15,13 @@ export default function Node({ type, options, data }) {
   }
 
   return (
-    <div className="flex flex-col max-w:full sm:basis-auto self-center grow-0 flex-wrap ml-4">
-      <div className="flex flex-row self-center flex-wrap justify-between">
-        <div className="flex-none flex flex-row items-center mr-3 py-1.5">
-          {icon()}
-          <div className="flex flex-col ml-3 text-left min-w-[85px]">
-            <div className="text-theme-800 dark:text-theme-200 text-xs flex flex-row justify-between">
-              <div className="pl-0.5">
-                {t("common.number", {
-                  value: data?.cpu?.percent ?? 0,
-                  style: "unit",
-                  unit: "percent",
-                  maximumFractionDigits: 0,
-                })}
-              </div>
-              <FiCpu className="text-theme-800 dark:text-theme-200 w-3 h-3" />
-            </div>
-            <UsageBar percent={data?.cpu?.percent ?? 0} />
-            <div className="text-theme-800 dark:text-theme-200 text-xs flex flex-row justify-between">
-              <div className="pl-0.5">
-                {t("common.bytes", {
-                  value: data?.memory?.free ?? 0,
-                  maximumFractionDigits: 0,
-                  binary: true,
-                })}
-              </div>
-              <FaMemory className="text-theme-800 dark:text-theme-200 w-3 h-3" />
-            </div>
-            <UsageBar percent={data?.memory?.percent} />
-            {options.showLabel && (
-              <div className="pt-1 text-center text-theme-800 dark:text-theme-200 text-xs">
-                {type === "cluster" ? options.label : data.name}
-              </div>
-            )}
-          </div>
-        </div>
-      </div>
-    </div>
+    <ServiceResource
+      icon={icon()}
+      label={options.showLabel && options.label}
+      cpuPercent={data?.cpu?.percent}
+      memFree={data?.memory?.free}
+      memPercent={data?.memory?.percent}
+      error={data?.error}
+    />
   );
 }

--- a/src/components/widgets/resources/serviceResource.jsx
+++ b/src/components/widgets/resources/serviceResource.jsx
@@ -1,0 +1,66 @@
+import { useTranslation } from "next-i18next";
+import { FiCpu, FiServer } from "react-icons/fi";
+import { FaMemory } from "react-icons/fa";
+
+import Error from "../widget/error";
+
+import UsageBar from "./usage-bar";
+
+/**
+ * Represents a service resource with optional details.
+ *
+ * @param {Object} props - The properties of the service resource.
+ * @param {JSX.Element} [props.icon] - The JSX element representing the icon.
+ * @param {string} [props.label] - The label describing the service resource.
+ * @param {number} [props.cpuPercent] - The CPU usage percentage.
+ * @param {number} [props.memFree] - The amount of free memory.
+ * @param {number} [props.memPercent] - The memory usage percentage.
+ * @param {any} [props.error] - Any additional error information.
+ *
+ * @returns {JSX.Element} - The JSX element representing the service resource.
+ */
+export default function ServiceResource({ icon, label, cpuPercent, memFree, memPercent, error }) {
+  const { t } = useTranslation();
+
+  const widgetIcon = icon ?? <FiServer className="text-theme-800 dark:text-theme-200 w-5 h-5" />;
+
+  if (error) {
+    return <Error />;
+  }
+
+  return (
+    <div className="flex flex-col max-w:full sm:basis-auto self-center grow-0 flex-wrap ml-4">
+      <div className="flex flex-row self-center flex-wrap justify-between">
+        <div className="flex-none flex flex-row items-center mr-3 py-1.5">
+          <div className="flex-none w-5 h-5">{widgetIcon}</div>
+          <div className="flex flex-col ml-3 text-left min-w-[85px]">
+            <div className="text-theme-800 dark:text-theme-200 text-xs flex flex-row justify-between">
+              <div className="pl-0.5">
+                {t("common.number", {
+                  value: cpuPercent ?? 0,
+                  style: "unit",
+                  unit: "percent",
+                  maximumFractionDigits: 0,
+                })}
+              </div>
+              <FiCpu className="text-theme-800 dark:text-theme-200 w-3 h-3" />
+            </div>
+            <UsageBar percent={cpuPercent ?? 0} />
+            <div className="text-theme-800 dark:text-theme-200 text-xs flex flex-row justify-between">
+              <div className="pl-0.5">
+                {t("common.bytes", {
+                  value: memFree ?? 0,
+                  maximumFractionDigits: 0,
+                  binary: true,
+                })}
+              </div>
+              <FaMemory className="text-theme-800 dark:text-theme-200 w-3 h-3" />
+            </div>
+            <UsageBar percent={memPercent ?? 0} />
+            {label && <div className="pt-1 text-center text-theme-800 dark:text-theme-200 text-xs">{label}</div>}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/widgets/truenas/pool.jsx
+++ b/src/components/widgets/truenas/pool.jsx
@@ -1,0 +1,31 @@
+import classNames from "classnames";
+import prettyBytes from "pretty-bytes";
+
+export default function Pool({ name, free, used, warning }) {
+  const total = free + used;
+  const usedPercent = Math.round((used / total) * 100);
+  const statusColor = warning ? "bg-yellow-500" : "bg-green-500";
+
+  return (
+    <div className="flex flex-row text-theme-700 dark:text-theme-200 items-center text-xs relative h-5 w-full rounded-md bg-theme-200/50 dark:bg-theme-900/20 mt-1">
+      <div
+        className="absolute h-5 rounded-md bg-theme-200 dark:bg-theme-900/40 z-0"
+        style={{
+          width: `${usedPercent}%`,
+        }}
+      />
+      <span className="ml-2 h-2 w-2">
+        <span className={classNames("block w-2 h-2 rounded", statusColor)} />
+      </span>
+      <div className="text-xs z-10 self-center ml-2 relative h-4 grow mr-2">
+        <div className="absolute w-full whitespace-nowrap text-ellipsis overflow-hidden text-left">{name}</div>
+      </div>
+      <div className="self-center text-xs flex justify-end mr-1.5 pl-1 z-10 text-ellipsis overflow-hidden whitespace-nowrap">
+        <span>
+          {prettyBytes(used)} / {prettyBytes(total)}
+        </span>
+        <span className="pl-2 w-12 text-center">({usedPercent}%)</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/widgets/truenas/pool.jsx
+++ b/src/components/widgets/truenas/pool.jsx
@@ -14,7 +14,7 @@ export default function Pool({ name, free, used, warning }) {
           width: `${usedPercent}%`,
         }}
       />
-      <span className="ml-2 h-2 w-2">
+      <span className="ml-2 h-2 w-2 z-10">
         <span className={classNames("block w-2 h-2 rounded", statusColor)} />
       </span>
       <div className="text-xs z-10 self-center ml-2 relative h-4 grow mr-2">

--- a/src/components/widgets/truenas/truenas.jsx
+++ b/src/components/widgets/truenas/truenas.jsx
@@ -1,0 +1,38 @@
+import useSWR from "swr";
+import { useTranslation } from "next-i18next";
+
+import Error from "../widget/error";
+import ServiceResource from "../resources/serviceResource";
+
+import ResolvedIcon from "components/resolvedicon";
+
+export default function Widget({ options }) {
+  const { i18n } = useTranslation();
+  const { icon: iconVal, label, refresh } = options;
+
+  const { data, error } = useSWR(
+    `/api/widgets/truenas?${new URLSearchParams({ lang: i18n.language, ...options }).toString()}`,
+    {
+      refreshInterval: refresh ?? 5000,
+    },
+  );
+
+  const icon = <ResolvedIcon icon={iconVal ?? "si-truenas"} />;
+
+  if (error || data?.error) {
+    return <Error options={options} />;
+  }
+
+  const memUsagePercent = Math.round(((data?.memory?.used ?? 0) / (data?.memory?.total ?? 1)) * 100);
+
+  return (
+    <ServiceResource
+      icon={icon}
+      label={label}
+      cpuPercent={data?.cpu?.load}
+      memFree={data?.memory?.free}
+      memPercent={memUsagePercent}
+      error={data?.error}
+    />
+  );
+}

--- a/src/components/widgets/widget.jsx
+++ b/src/components/widgets/widget.jsx
@@ -15,6 +15,7 @@ const widgetMappings = {
   openmeteo: dynamic(() => import("components/widgets/openmeteo/openmeteo")),
   longhorn: dynamic(() => import("components/widgets/longhorn/longhorn")),
   kubernetes: dynamic(() => import("components/widgets/kubernetes/kubernetes")),
+  truenas: dynamic(() => import("components/widgets/truenas/truenas")),
 };
 
 export default function Widget({ widget, style }) {

--- a/src/pages/api/widgets/truenas.js
+++ b/src/pages/api/widgets/truenas.js
@@ -1,0 +1,90 @@
+import { httpProxy } from "utils/proxy/http";
+import createLogger from "utils/logger";
+import { getPrivateWidgetOptions } from "utils/config/widget-helpers";
+
+const logger = createLogger("truenas");
+
+async function retrieveFromTruenasAPI(privateWidgetOptions, endpoint, method, body) {
+  let errorMessage;
+  const url = privateWidgetOptions?.url;
+  if (!url) {
+    errorMessage = "Missing Truenas URL";
+    logger.error(errorMessage);
+    throw new Error(errorMessage);
+  }
+
+  const apiUrl = `${url}/api/v2.0/${endpoint}`;
+  const headers = {
+    "Accept-Encoding": "application/json",
+  };
+  if (privateWidgetOptions.username && privateWidgetOptions.password) {
+    headers.Authorization = `Basic ${Buffer.from(
+      `${privateWidgetOptions.username}:${privateWidgetOptions.password}`,
+    ).toString("base64")}`;
+  } else if (privateWidgetOptions.key) {
+    headers.Authorization = `Bearer ${privateWidgetOptions.key}`;
+  } else {
+    errorMessage = "Missing TrueNAS credentials";
+    logger.error(errorMessage);
+    throw new Error(errorMessage);
+  }
+  const params = { method, headers, body };
+
+  const [status, , data] = await httpProxy(apiUrl, params);
+
+  if (status === 401) {
+    errorMessage = `Authorization failure getting data from TrueNAS API. Data: ${data.toString()}`;
+    logger.error(errorMessage);
+    throw new Error(errorMessage);
+  }
+
+  if (status !== 200) {
+    errorMessage = `HTTP ${status} getting data from TrueNAS API. Data: ${data.toString()}`;
+    logger.error(errorMessage);
+    throw new Error(errorMessage);
+  }
+
+  return JSON.parse(Buffer.from(data).toString());
+}
+
+export default async function handler(req, res) {
+  const { index } = req.query;
+
+  const privateWidgetOptions = await getPrivateWidgetOptions("truenas", index);
+
+  try {
+    const systemInfo = await retrieveFromTruenasAPI(privateWidgetOptions, "system/info");
+    const memoryInfo = await retrieveFromTruenasAPI(
+      privateWidgetOptions,
+      "reporting/get_data",
+      "POST",
+      JSON.stringify({
+        graphs: [{ name: "memory" }],
+        reporting_query: {
+          start: Math.round((new Date() - 30000) / 1000), // 30 seconds ago
+          end: "NOW",
+          aggregate: true,
+        },
+      }),
+    );
+
+    const [used, free, cached, buffered] = memoryInfo?.[0]?.aggregations?.mean || [];
+
+    const data = {
+      cpu: {
+        load: systemInfo?.loadavg?.[0],
+      },
+      memory: {
+        used,
+        free,
+        cached,
+        buffered,
+        total: used + free, // Using used + free instead of total memory to match TrueNAS dashboard
+      },
+    };
+
+    return res.status(200).send(data);
+  } catch (e) {
+    return res.status(400).json({ error: e.message });
+  }
+}

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -438,6 +438,9 @@ export function cleanServiceGroups(groups) {
           // sonarr, radarr
           enableQueue,
 
+          // truenas
+          enablePools,
+
           // unifi
           site,
         } = cleanedService.widget;
@@ -506,6 +509,9 @@ export function cleanServiceGroups(groups) {
         }
         if (["sonarr", "radarr"].includes(type)) {
           if (enableQueue !== undefined) cleanedService.widget.enableQueue = JSON.parse(enableQueue);
+        }
+        if (type === "truenas") {
+          if (enablePools !== undefined) cleanedService.widget.enablePools = JSON.parse(enablePools);
         }
         if (["diskstation", "qnap"].includes(type)) {
           if (volume) cleanedService.widget.volume = volume;

--- a/src/utils/proxy/handlers/credentialed.js
+++ b/src/utils/proxy/handlers/credentialed.js
@@ -70,6 +70,7 @@ export default async function credentialedProxyHandler(req, res, map) {
         withCredentials: true,
         credentials: "include",
         headers,
+        body: req.body,
       });
 
       let resultData = data;

--- a/src/widgets/truenas/component.jsx
+++ b/src/widgets/truenas/component.jsx
@@ -3,6 +3,7 @@ import { useTranslation } from "next-i18next";
 import Container from "components/services/widget/container";
 import Block from "components/services/widget/block";
 import useWidgetAPI from "utils/proxy/use-widget-api";
+import Pool from "components/widgets/truenas/pool";
 
 export default function Component({ service }) {
   const { t } = useTranslation();
@@ -11,9 +12,10 @@ export default function Component({ service }) {
 
   const { data: alertData, error: alertError } = useWidgetAPI(widget, "alerts");
   const { data: statusData, error: statusError } = useWidgetAPI(widget, "status");
+  const { data: poolsData, error: poolsError } = useWidgetAPI(widget, "pools");
 
-  if (alertError || statusError) {
-    const finalError = alertError ?? statusError;
+  if (alertError || statusError || poolsError) {
+    const finalError = alertError ?? statusError ?? poolsError;
     return <Container service={service} error={finalError} />;
   }
 
@@ -27,11 +29,19 @@ export default function Component({ service }) {
     );
   }
 
+  const enablePools = widget?.enablePools && Array.isArray(poolsData) && poolsData.length > 0;
+
   return (
-    <Container service={service}>
-      <Block label="truenas.load" value={t("common.number", { value: statusData.loadavg[0] })} />
-      <Block label="truenas.uptime" value={t("common.uptime", { value: statusData.uptime_seconds })} />
-      <Block label="truenas.alerts" value={t("common.number", { value: alertData.pending })} />
-    </Container>
+    <>
+      <Container service={service}>
+        <Block label="truenas.load" value={t("common.number", { value: statusData.loadavg[0] })} />
+        <Block label="truenas.uptime" value={t("common.uptime", { value: statusData.uptime_seconds })} />
+        <Block label="truenas.alerts" value={t("common.number", { value: alertData.pending })} />
+      </Container>
+      {enablePools &&
+        poolsData.map((pool) => (
+          <Pool key={pool.id} name={pool.name} free={pool.free} used={pool.used} warning={pool.warning} />
+        ))}
+    </>
   );
 }

--- a/src/widgets/truenas/proxy.js
+++ b/src/widgets/truenas/proxy.js
@@ -1,0 +1,29 @@
+import getServiceWidget from "utils/config/service-helpers";
+import createLogger from "utils/logger";
+import genericProxyHandler from "utils/proxy/handlers/generic";
+import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
+
+const logger = createLogger("truenasProxyHandler");
+
+export default async function truenasProxyHandler(req, res, map) {
+  const { group, service } = req.query;
+
+  if (group && service) {
+    const widgetOpts = await getServiceWidget(group, service);
+    let handler;
+    if (widgetOpts.username && widgetOpts.password) {
+      handler = genericProxyHandler;
+    } else if (widgetOpts.key) {
+      handler = credentialedProxyHandler;
+    }
+
+    if (handler) {
+      return handler(req, res, map);
+    }
+
+    logger.error("Error getting data from Truenas: Username / password or API key required");
+    return res.status(500).json({ error: "Username / password or API key required" });
+  }
+
+  return res.status(500).json({ error: "Error parsing widget request" });
+}

--- a/src/widgets/truenas/widget.js
+++ b/src/widgets/truenas/widget.js
@@ -1,32 +1,10 @@
-import { jsonArrayFilter } from "utils/proxy/api-helpers";
-import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
-import genericProxyHandler from "utils/proxy/handlers/generic";
-import getServiceWidget from "utils/config/service-helpers";
+import truenasProxyHandler from "./proxy";
+
+import { asJson, jsonArrayFilter } from "utils/proxy/api-helpers";
 
 const widget = {
   api: "{url}/api/v2.0/{endpoint}",
-  proxyHandler: async (req, res, map) => {
-    // choose proxy handler based on widget settings
-    const { group, service } = req.query;
-
-    if (group && service) {
-      const widgetOpts = await getServiceWidget(group, service);
-      let handler;
-      if (widgetOpts.username && widgetOpts.password) {
-        handler = genericProxyHandler;
-      } else if (widgetOpts.key) {
-        handler = credentialedProxyHandler;
-      }
-
-      if (handler) {
-        return handler(req, res, map);
-      }
-
-      return res.status(500).json({ error: "Username / password or API key required" });
-    }
-
-    return res.status(500).json({ error: "Error parsing widget request" });
-  },
+  proxyHandler: truenasProxyHandler,
 
   mappings: {
     alerts: {
@@ -38,6 +16,19 @@ const widget = {
     status: {
       endpoint: "system/info",
       validate: ["loadavg", "uptime_seconds"],
+    },
+    pools: {
+      endpoint: "pool",
+      map: (data) =>
+        asJson(data).map((entry) => ({
+          id: entry.name,
+          name: entry.name,
+          status: entry.status,
+          healthy: entry.healthy,
+          used: entry.allocated,
+          size: entry.size,
+          free: entry.free,
+        })),
     },
   },
 };


### PR DESCRIPTION
## Proposed change

- Maintain the previous behavior with previous configuration
- Add new optional parameter for `enablePools` that when enabled will display each Pool in the TrueNAS instance with its disk usage, and a status indicator
- Add new information widget for TrueNAS that when configured will show the system resources for your TrueNAS instance mirroring the display of the Kubernetes information widget
- Refactor existing Kubernetes information widget into a reusable component for future use (no change to Kubernetes functionality or UI/UX)

Below is an example of the new `enablePools` option for the existing service widget

<img width="984" alt="image" src="https://github.com/gethomepage/homepage/assets/9381594/8efef587-6f29-426c-896b-3e41e0c16803">

Below is an example of the new `truenas` information widget

![image](https://github.com/gethomepage/homepage/assets/9381594/fb0925eb-f50b-418e-9ba1-4aee43b2b789)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [X] Other (please explain) - New information widget

## Checklist:

- [X] If applicable, I have added corresponding documentation changes.
- [X] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [X] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [X] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
