### PR TITLE
Fix: role requirement in Kavita documentation

### DIFF
--- a/docs/widgets/services/kavita.md
+++ b/docs/widgets/services/kavita.md
@@ -5,7 +5,7 @@ description: Kavita Widget Configuration
 
 Learn more about [Kavita](https://github.com/Kareadita/Kavita).
 
-Uses the same username and password used to login from the web.
+Uses the same admin role username and password used to login from the web.
 
 Allowed fields: `["seriesCount", "totalFiles"]`.
 


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well updates to the docs for the new widget.
-->

The Kavita widget requires that a Kavita user must at least have the roles of **Admin** and **Login**, otherwise a call to the API server stats endpoint fails and the widget returns **NaN** in both fields.

This minor documentation change hightlights the requirement for the **Admin** role.

Tested on:
- Homepage v0.8.7 (latest)
- Kavita v0.7.13.0 (latest)

Closes #2797

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
