### PR TITLE
Fix quick launch not opening with accented characters, decoding of characters in suggestions

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -224,7 +224,10 @@ function Home({ initialSettings }) {
     function handleKeyDown(e) {
       if (e.target.tagName === "BODY" || e.target.id === "inner_wrapper") {
         if (
-          (e.key.length === 1 && e.key.match(/(\w|\s)/g) && !(e.altKey || e.ctrlKey || e.metaKey || e.shiftKey)) ||
+          (e.key.length === 1 &&
+            e.key.match(/(\w|\s|[à-ü]|[À-Ü])/g) &&
+            !(e.altKey || e.ctrlKey || e.metaKey || e.shiftKey)) ||
+          e.key.match(/([à-ü]|[À-Ü])/g) || // accented characters may require modifier keys
           (e.key === "v" && (e.ctrlKey || e.metaKey))
         ) {
           setSearching(true);

--- a/src/utils/proxy/cached-fetch.js
+++ b/src/utils/proxy/cached-fetch.js
@@ -12,7 +12,8 @@ export default async function cachedFetch(url, duration) {
     return cached;
   }
 
-  const data = await fetch(url).then((res) => res.json());
+  // wrapping text in JSON.parse to handle utf-8 issues
+  const data = JSON.parse(await fetch(url).then((res) => res.text()));
   cache.put(url, data, duration * 1000 * 60);
   return data;
 }


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well updates to the docs for the new widget.
-->

<img width="710" alt="Screenshot 2024-02-01 at 12 36 24 AM" src="https://github.com/gethomepage/homepage/assets/4887959/bc6912d2-deb3-47f3-9f02-0b08e5e92a00">
<img width="711" alt="Screenshot 2024-02-01 at 12 39 11 AM" src="https://github.com/gethomepage/homepage/assets/4887959/c41d0314-ad97-4ba9-98b8-db1dcbb003be">


Closes #2801

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
