### PR TITLE
Fix: Add formatting to Immich totals

### DIFF
--- a/src/widgets/immich/component.jsx
+++ b/src/widgets/immich/component.jsx
@@ -30,9 +30,9 @@ export default function Component({ service }) {
 
   return (
     <Container service={service}>
-      <Block label="immich.users" value={immichData.usageByUser.length} />
-      <Block label="immich.photos" value={immichData.photos} />
-      <Block label="immich.videos" value={immichData.videos} />
+      <Block label="immich.users" value={t("common.number", { value: immichData.usageByUser.length })} />
+      <Block label="immich.photos" value={t("common.number", { value: immichData.photos })} />
+      <Block label="immich.videos" value={t("common.number", { value: immichData.videos })} />
       <Block
         label="immich.storage"
         value={


### PR DESCRIPTION
## Proposed change

Make use of formatting tools to format the totals for Users, Images and Videos that Immich provide.

From
<img width="740" alt="image" src="https://github.com/gethomepage/homepage/assets/81699395/23139320-cd7c-4f17-a95d-6075fddd6dc8">
to
<img width="498" alt="image" src="https://github.com/gethomepage/homepage/assets/81699395/66541137-8530-4477-ba9f-7e57b4142c11">


## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
