### PR TITLE
Documentation: fix abandoned PiAlert repo

### DIFF
--- a/docs/widgets/services/pialert.md
+++ b/docs/widgets/services/pialert.md
@@ -3,9 +3,9 @@ title: PiAlert
 description: PiAlert Widget Configuration
 ---
 
-Learn more about [PiAlert](https://github.com/pucherot/Pi.Alert).
+Learn more about [PiAlert](https://github.com/jokob-sk/Pi.Alert).
 
-Widget for [PiAlert](https://github.com/jokob-sk/Pi.Alert).
+Note that [pucherot/PiAlert](https://github.com/pucherot/Pi.Alert) has been abandoned and might not work properly.
 
 Allowed fields: `["total", "connected", "new_devices", "down_alerts"]`.
 


### PR DESCRIPTION
Unlike other widgets, PiAlert has one line for "learn more about ..." and another line for "widget for ...", where the first PiAlert is pointed to the abandoned repo. The second line is the actual repo for the widget.


## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well updates to the docs for the new widget.
-->

Instead of putting the abandoned repo after learn more about like other widgets, the actual actively devleoped one is used, also a note of the original repo that has been abandoned was added.

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
