### PR TITLE
Update sabnzbd widget.js

### DIFF
--- a/src/widgets/sabnzbd/widget.js
+++ b/src/widgets/sabnzbd/widget.js
@@ -1,7 +1,7 @@
 import genericProxyHandler from "utils/proxy/handlers/generic";
 
 const widget = {
-  api: "{url}/api/?apikey={key}&output=json&mode={endpoint}",
+  api: "{url}/api?apikey={key}&output=json&mode={endpoint}",
   proxyHandler: genericProxyHandler,
 
   mappings: {


### PR DESCRIPTION
the sabnzbd widget is broken.  The additional slash causes this widget to fail.

this works:  http://host:port/api?apikey=***&mode=test&output=json
this does not:  http://host:port/api/?apikey=***&mode=test&output=json

## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well updates to the docs for the new widget.
-->

Closes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
