### PR TITLE
Enhancement: initially collapsed option for layout groups

### DIFF
--- a/docs/configs/settings.md
+++ b/docs/configs/settings.md
@@ -239,6 +239,14 @@ layout:
     initiallyCollapsed: true
 ```
 
+This can also be set globaly using the `groupsInitiallyCollapsed` option.
+
+```yaml
+groupsInitiallyCollapsed: true
+```
+
+The value set on a group will overwrite the global setting.
+
 By default the feature is disabled.
 
 ### Use Equal Height Cards

--- a/docs/configs/settings.md
+++ b/docs/configs/settings.md
@@ -229,6 +229,18 @@ disableCollapse: true
 
 By default the feature is enabled.
 
+### Initially collapsed sections
+
+You can initially collapse sections by adding the `initiallyCollapsed` option to the layout group.
+
+```yaml
+layout:
+  Section A:
+    initiallyCollapsed: true
+```
+
+By default the feature is disabled.
+
 ### Use Equal Height Cards
 
 You can enable equal height cards for groups of services, this will make all cards in a row the same height.

--- a/src/components/bookmarks/group.jsx
+++ b/src/components/bookmarks/group.jsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useRef, useEffect } from "react";
 import classNames from "classnames";
 import { Disclosure, Transition } from "@headlessui/react";
 import { MdKeyboardArrowDown } from "react-icons/md";
@@ -9,6 +9,11 @@ import ResolvedIcon from "components/resolvedicon";
 
 export default function BookmarksGroup({ bookmarks, layout, disableCollapse }) {
   const panel = useRef();
+
+  useEffect(() => {
+    if (layout?.initiallyCollapsed) panel.current.style.height = `0`;
+  }, [layout]);
+
   return (
     <div
       key={bookmarks.name}
@@ -18,7 +23,7 @@ export default function BookmarksGroup({ bookmarks, layout, disableCollapse }) {
         layout?.header === false ? "flex-1 px-1 -my-1" : "flex-1 p-1",
       )}
     >
-      <Disclosure defaultOpen>
+      <Disclosure defaultOpen={!layout?.initiallyCollapsed ?? true}>
         {({ open }) => (
           <>
             {layout?.header !== false && (

--- a/src/components/bookmarks/group.jsx
+++ b/src/components/bookmarks/group.jsx
@@ -7,12 +7,12 @@ import ErrorBoundary from "components/errorboundry";
 import List from "components/bookmarks/list";
 import ResolvedIcon from "components/resolvedicon";
 
-export default function BookmarksGroup({ bookmarks, layout, disableCollapse }) {
+export default function BookmarksGroup({ bookmarks, layout, disableCollapse, groupsInitiallyCollapsed }) {
   const panel = useRef();
 
   useEffect(() => {
-    if (layout?.initiallyCollapsed) panel.current.style.height = `0`;
-  }, [layout]);
+    if (layout?.initiallyCollapsed ?? groupsInitiallyCollapsed) panel.current.style.height = `0`;
+  }, [layout, groupsInitiallyCollapsed]);
 
   return (
     <div
@@ -23,7 +23,7 @@ export default function BookmarksGroup({ bookmarks, layout, disableCollapse }) {
         layout?.header === false ? "flex-1 px-1 -my-1" : "flex-1 p-1",
       )}
     >
-      <Disclosure defaultOpen={!layout?.initiallyCollapsed ?? true}>
+      <Disclosure defaultOpen={!(layout?.initiallyCollapsed ?? groupsInitiallyCollapsed) ?? true}>
         {({ open }) => (
           <>
             {layout?.header !== false && (

--- a/src/components/services/group.jsx
+++ b/src/components/services/group.jsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useRef, useEffect } from "react";
 import classNames from "classnames";
 import { Disclosure, Transition } from "@headlessui/react";
 import { MdKeyboardArrowDown } from "react-icons/md";
@@ -8,6 +8,10 @@ import ResolvedIcon from "components/resolvedicon";
 
 export default function ServicesGroup({ group, services, layout, fiveColumns, disableCollapse, useEqualHeights }) {
   const panel = useRef();
+
+  useEffect(() => {
+    if (layout?.initiallyCollapsed) panel.current.style.height = `0`;
+  }, [layout, panel]);
 
   return (
     <div
@@ -19,7 +23,7 @@ export default function ServicesGroup({ group, services, layout, fiveColumns, di
         layout?.header === false ? "flex-1 px-1 -my-1" : "flex-1 p-1",
       )}
     >
-      <Disclosure defaultOpen>
+      <Disclosure defaultOpen={!layout?.initiallyCollapsed ?? true}>
         {({ open }) => (
           <>
             {layout?.header !== false && (

--- a/src/components/services/group.jsx
+++ b/src/components/services/group.jsx
@@ -6,12 +6,20 @@ import { MdKeyboardArrowDown } from "react-icons/md";
 import List from "components/services/list";
 import ResolvedIcon from "components/resolvedicon";
 
-export default function ServicesGroup({ group, services, layout, fiveColumns, disableCollapse, useEqualHeights }) {
+export default function ServicesGroup({
+  group,
+  services,
+  layout,
+  fiveColumns,
+  disableCollapse,
+  useEqualHeights,
+  groupsInitiallyCollapsed,
+}) {
   const panel = useRef();
 
   useEffect(() => {
-    if (layout?.initiallyCollapsed) panel.current.style.height = `0`;
-  }, [layout, panel]);
+    if (layout?.initiallyCollapsed ?? groupsInitiallyCollapsed) panel.current.style.height = `0`;
+  }, [layout, groupsInitiallyCollapsed]);
 
   return (
     <div
@@ -23,7 +31,7 @@ export default function ServicesGroup({ group, services, layout, fiveColumns, di
         layout?.header === false ? "flex-1 px-1 -my-1" : "flex-1 p-1",
       )}
     >
-      <Disclosure defaultOpen={!layout?.initiallyCollapsed ?? true}>
+      <Disclosure defaultOpen={!(layout?.initiallyCollapsed ?? groupsInitiallyCollapsed) ?? true}>
         {({ open }) => (
           <>
             {layout?.header !== false && (

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -311,6 +311,7 @@ function Home({ initialSettings }) {
                   fiveColumns={settings.fiveColumns}
                   disableCollapse={settings.disableCollapse}
                   useEqualHeights={settings.useEqualHeights}
+                  groupsInitiallyCollapsed={settings.groupsInitiallyCollapsed}
                 />
               ) : (
                 <BookmarksGroup
@@ -318,6 +319,7 @@ function Home({ initialSettings }) {
                   bookmarks={group}
                   layout={settings.layout?.[group.name]}
                   disableCollapse={settings.disableCollapse}
+                  groupsInitiallyCollapsed={settings.groupsInitiallyCollapsed}
                 />
               ),
             )}
@@ -333,6 +335,7 @@ function Home({ initialSettings }) {
                 layout={settings.layout?.[group.name]}
                 fiveColumns={settings.fiveColumns}
                 disableCollapse={settings.disableCollapse}
+                groupsInitiallyCollapsed={settings.groupsInitiallyCollapsed}
               />
             ))}
           </div>
@@ -345,6 +348,7 @@ function Home({ initialSettings }) {
                 bookmarks={group}
                 layout={settings.layout?.[group.name]}
                 disableCollapse={settings.disableCollapse}
+                groupsInitiallyCollapsed={settings.groupsInitiallyCollapsed}
               />
             ))}
           </div>
@@ -361,6 +365,7 @@ function Home({ initialSettings }) {
     settings.disableCollapse,
     settings.useEqualHeights,
     settings.cardBlur,
+    settings.groupsInitiallyCollapsed,
     initialSettings.layout,
   ]);
 


### PR DESCRIPTION
## Proposed change

This PR adds the possibility to let layout groups be initially collapsed.

This can be configured in the layout group as follows:

```yaml
layout:
  Section A:
    initiallyCollapsed: true
```
It defaults to false.

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well updates to the docs for the new widget.
-->

Closes #1636 

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
