### PR TITLE
Fix: search opens when losing focus, prevent unnecessary search API calls

### DIFF
--- a/src/components/quicklaunch.jsx
+++ b/src/components/quicklaunch.jsx
@@ -120,7 +120,7 @@ export default function QuickLaunch({
         });
 
         if (showSearchSuggestions && searchProvider.suggestionUrl) {
-          if (searchString.trim() !== searchSuggestions[0]) {
+          if (searchString.trim() !== searchSuggestions[0]?.trim()) {
             fetch(
               `/api/search/searchSuggestion?query=${encodeURIComponent(searchString)}&providerName=${
                 searchProvider.name ?? "Custom"

--- a/src/components/widgets/search/search.jsx
+++ b/src/components/widgets/search/search.jsx
@@ -167,6 +167,7 @@ export default function Search({ options }) {
               autoComplete="off"
               // eslint-disable-next-line jsx-a11y/no-autofocus
               autoFocus={options.focus}
+              onBlur={(e) => e.preventDefault()}
             />
             <Listbox
               as="div"

--- a/src/components/widgets/search/search.jsx
+++ b/src/components/widgets/search/search.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, Fragment } from "react";
+import { useState, useEffect, useCallback, Fragment, useRef } from "react";
 import { useTranslation } from "next-i18next";
 import { FiSearch } from "react-icons/fi";
 import { SiDuckduckgo, SiMicrosoftbing, SiGoogle, SiBaidu, SiBrave } from "react-icons/si";
@@ -71,6 +71,9 @@ export function getStoredProvider() {
 export default function Search({ options }) {
   const { t } = useTranslation();
 
+  const searchProviderButton = useRef();
+  const comboboxOptions = useRef();
+
   const availableProviderIds = getAvailableProviderIds(options);
 
   const [query, setQuery] = useState("");
@@ -120,11 +123,8 @@ export default function Search({ options }) {
   }, [selectedProvider, options, query, searchSuggestions]);
 
   const handleSearchKeyDown = (event) => {
-    if (
-      event.key === "Tab" &&
-      document.getElementById("comboboxOptions")?.getAttribute("data-headlessui-state") === "open"
-    ) {
-      document.getElementById("searchProviderButton").focus();
+    if (event.key === "Tab" && comboboxOptions.current?.getAttribute("data-headlessui-state") === "open") {
+      searchProviderButton.current.focus();
       event.preventDefault();
     }
   };
@@ -194,7 +194,7 @@ export default function Search({ options }) {
                   text-white font-medium text-sm
                   bg-theme-600/40 dark:bg-white/10
                   focus:ring-theme-500 dark:focus:ring-white/50"
-                  id="searchProviderButton"
+                  ref={searchProviderButton}
                 >
                   <selectedProvider.icon className="text-white w-3 h-3" />
                   <span className="sr-only">{t("search.search")}</span>
@@ -240,7 +240,7 @@ export default function Search({ options }) {
             {searchSuggestions[1]?.length > 0 && (
               <Combobox.Options
                 className="mt-1 rounded-md bg-theme-50 dark:bg-theme-800 border border-theme-300 dark:border-theme-200/30 cursor-pointer shadow-lg"
-                id="comboboxOptions"
+                ref={comboboxOptions}
               >
                 <div className="p-1 bg-white/50 dark:bg-white/10 text-theme-900/90 dark:text-white/90 text-xs">
                   <Combobox.Option key={query} value={query} />

--- a/src/components/widgets/search/search.jsx
+++ b/src/components/widgets/search/search.jsx
@@ -119,6 +119,12 @@ export default function Search({ options }) {
     };
   }, [selectedProvider, options, query, searchSuggestions]);
 
+  const handleSearchKeyDown = (event) => {
+    if (event.key === "Tab") {
+      event.preventDefault();
+    }
+  };
+
   const submitCallback = useCallback(
     (value) => {
       const q = encodeURIComponent(value);
@@ -168,6 +174,7 @@ export default function Search({ options }) {
               // eslint-disable-next-line jsx-a11y/no-autofocus
               autoFocus={options.focus}
               onBlur={(e) => e.preventDefault()}
+              onKeyDown={handleSearchKeyDown}
             />
             <Listbox
               as="div"

--- a/src/components/widgets/search/search.jsx
+++ b/src/components/widgets/search/search.jsx
@@ -120,7 +120,10 @@ export default function Search({ options }) {
   }, [selectedProvider, options, query, searchSuggestions]);
 
   const handleSearchKeyDown = (event) => {
-    if (event.key === "Tab") {
+    if (
+      event.key === "Tab" &&
+      document.getElementById("comboboxOptions")?.getAttribute("data-headlessui-state") === "open"
+    ) {
       event.preventDefault();
     }
   };
@@ -233,7 +236,10 @@ export default function Search({ options }) {
             </Listbox>
 
             {searchSuggestions[1]?.length > 0 && (
-              <Combobox.Options className="mt-1 rounded-md bg-theme-50 dark:bg-theme-800 border border-theme-300 dark:border-theme-200/30 cursor-pointer shadow-lg">
+              <Combobox.Options
+                className="mt-1 rounded-md bg-theme-50 dark:bg-theme-800 border border-theme-300 dark:border-theme-200/30 cursor-pointer shadow-lg"
+                id="comboboxOptions"
+              >
                 <div className="p-1 bg-white/50 dark:bg-white/10 text-theme-900/90 dark:text-white/90 text-xs">
                   <Combobox.Option key={query} value={query} />
                   {searchSuggestions[1].map((suggestion) => (

--- a/src/components/widgets/search/search.jsx
+++ b/src/components/widgets/search/search.jsx
@@ -124,6 +124,7 @@ export default function Search({ options }) {
       event.key === "Tab" &&
       document.getElementById("comboboxOptions")?.getAttribute("data-headlessui-state") === "open"
     ) {
+      document.getElementById("searchProviderButton").focus();
       event.preventDefault();
     }
   };
@@ -193,6 +194,7 @@ export default function Search({ options }) {
                   text-white font-medium text-sm
                   bg-theme-600/40 dark:bg-white/10
                   focus:ring-theme-500 dark:focus:ring-white/50"
+                  id="searchProviderButton"
                 >
                   <selectedProvider.icon className="text-white w-3 h-3" />
                   <span className="sr-only">{t("search.search")}</span>


### PR DESCRIPTION
## Proposed change

This PR fixes two bugs with the search suggestion.

- The search box opened the search URL when loosing focus.
- The suggestion API kept getting called without the search changing.

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well updates to the docs for the new widget.
-->

Closes #2866 

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
