### PR TITLE
Enhancement: tab complete for search suggestions

### DIFF
--- a/src/components/quicklaunch.jsx
+++ b/src/components/quicklaunch.jsx
@@ -43,8 +43,7 @@ export default function QuickLaunch({
     }, 200); // delay a little for animations
   }, [close, setSearchString, setCurrentItemIndex, setSearchSuggestions]);
 
-  function handleSearchChange(event) {
-    const rawSearchString = event.target.value.toLowerCase();
+  function updateSearch(rawSearchString) {
     try {
       if (!/.+[.:].+/g.test(rawSearchString)) throw new Error(); // basic test for probably a url
       let urlString = rawSearchString;
@@ -54,6 +53,11 @@ export default function QuickLaunch({
       setUrl(null);
     }
     setSearchString(rawSearchString);
+  }
+
+  function handleSearchChange(event) {
+    const rawSearchString = event.target.value.toLowerCase();
+    updateSearch(rawSearchString);
   }
 
   function handleSearchKeyDown(event) {
@@ -70,6 +74,9 @@ export default function QuickLaunch({
       event.preventDefault();
     } else if (event.key === "ArrowUp" && currentItemIndex > 0) {
       setCurrentItemIndex(currentItemIndex - 1);
+      event.preventDefault();
+    } else if (event.key === "Tab" && results[currentItemIndex].type === "searchSuggestion") {
+      updateSearch(results[currentItemIndex].name);
       event.preventDefault();
     }
   }

--- a/src/components/quicklaunch.jsx
+++ b/src/components/quicklaunch.jsx
@@ -75,7 +75,7 @@ export default function QuickLaunch({
     } else if (event.key === "ArrowUp" && currentItemIndex > 0) {
       setCurrentItemIndex(currentItemIndex - 1);
       event.preventDefault();
-    } else if (event.key === "Tab" && results[currentItemIndex].type === "searchSuggestion") {
+    } else if (event.key === "Tab" && results[currentItemIndex]?.type === "searchSuggestion") {
       updateSearch(results[currentItemIndex].name);
       event.preventDefault();
     }

--- a/src/components/widgets/search/search.jsx
+++ b/src/components/widgets/search/search.jsx
@@ -119,6 +119,13 @@ export default function Search({ options }) {
     };
   }, [selectedProvider, options, query, searchSuggestions]);
 
+  const handleSearchKeyDown = (event) => {
+    if (event.key === "Tab") {
+      // TODO: add actual tab complete
+      event.preventDefault();
+    }
+  };
+
   const submitCallback = useCallback(
     (value) => {
       const q = encodeURIComponent(value);
@@ -167,6 +174,7 @@ export default function Search({ options }) {
               autoComplete="off"
               // eslint-disable-next-line jsx-a11y/no-autofocus
               autoFocus={options.focus}
+              onKeyDown={handleSearchKeyDown}
             />
             <Listbox
               as="div"

--- a/src/components/widgets/search/search.jsx
+++ b/src/components/widgets/search/search.jsx
@@ -123,6 +123,10 @@ export default function Search({ options }) {
     if (event.key === "Tab") {
       event.preventDefault();
 
+      if (!(options.showSearchSuggestions && (selectedProvider.suggestionUrl || options.suggestionUrl))) {
+        return;
+      }
+
       const list = document.getElementById("comboboxOptions").getElementsByTagName("li");
       if (list.length === 0) {
         return;

--- a/src/components/widgets/search/search.jsx
+++ b/src/components/widgets/search/search.jsx
@@ -121,8 +121,19 @@ export default function Search({ options }) {
 
   const handleSearchKeyDown = (event) => {
     if (event.key === "Tab") {
-      // TODO: add actual tab complete
       event.preventDefault();
+
+      const list = document.getElementById("comboboxOptions").getElementsByTagName("li");
+      if (list.length === 0) {
+        return;
+      }
+
+      for (let i = 0; i < list.length; i += 1) {
+        const item = list.item(i);
+        if (item.getAttribute("data-headlessui-state") === "active") {
+          setQuery(item.textContent);
+        }
+      }
     }
   };
 
@@ -233,7 +244,10 @@ export default function Search({ options }) {
             </Listbox>
 
             {searchSuggestions[1]?.length > 0 && (
-              <Combobox.Options className="mt-1 rounded-md bg-theme-50 dark:bg-theme-800 border border-theme-300 dark:border-theme-200/30 cursor-pointer shadow-lg">
+              <Combobox.Options
+                className="mt-1 rounded-md bg-theme-50 dark:bg-theme-800 border border-theme-300 dark:border-theme-200/30 cursor-pointer shadow-lg"
+                id="comboboxOptions"
+              >
                 <div className="p-1 bg-white/50 dark:bg-white/10 text-theme-900/90 dark:text-white/90 text-xs">
                   <Combobox.Option key={query} value={query} />
                   {searchSuggestions[1].map((suggestion) => (


### PR DESCRIPTION
## Proposed change

This PR adds *Tab Completion* for search suggestions to the quick launch and the search widget.

Unfortunately, the implementation for the search widget is not the greatest.
It uses the `getElementById`, `getElementsByTagName`  and `getAttribute` DOM APIs to check which suggestion is currently selected in the dropdown. I couldn't find another way because the *HeadlessUI* *Combobox* does not expose the currently selected item in the dropdown. 



<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well updates to the docs for the new widget.
-->

Closes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
