### PR TITLE
Fix: Incorrect Container/Block structure in Healthchecks widget

### DIFF
--- a/src/widgets/healthchecks/component.jsx
+++ b/src/widgets/healthchecks/component.jsx
@@ -63,26 +63,22 @@ export default function Component({ service }) {
     );
   }
 
-  const hasUuid = widget?.uuid;
+  const hasUuid = !!widget?.uuid;
 
   const { upCount, downCount } = countStatus(data);
 
-  return (
+  return hasUuid ? (
     <Container service={service}>
-      {hasUuid ? (
-        <>
-          <Block label="healthchecks.status" value={t(`healthchecks.${data.status}`)} />
-          <Block
-            label="healthchecks.last_ping"
-            value={data.last_ping ? formatDate(data.last_ping) : t("healthchecks.never")}
-          />
-        </>
-      ) : (
-        <>
-          <Block label="healthchecks.up" value={upCount} />
-          <Block label="healthchecks.down" value={downCount} />
-        </>
-      )}
+      <Block label="healthchecks.status" value={t(`healthchecks.${data.status}`)} />
+      <Block
+        label="healthchecks.last_ping"
+        value={data.last_ping ? formatDate(data.last_ping) : t("healthchecks.never")}
+      />
+    </Container>
+  ) : (
+    <Container service={service}>
+      <Block label="healthchecks.up" value={upCount} />
+      <Block label="healthchecks.down" value={downCount} />
     </Container>
   );
 }


### PR DESCRIPTION
## Proposed change

A recent [change](https://github.com/gethomepage/homepage/pull/2580) to Healthchecks widget added an `hasUuid` check to allow for multiple functionalities. Due to a quirky behavior of the `Container` and `Block` components, the block components must be directly nested underneath the `Container` component in order for the optional `fields` prop to be respected. 

This change fixes the conditional in the component while maintaining the current functionality.

![image](https://github.com/gethomepage/homepage/assets/27016794/139773a5-f700-4fe4-9134-ecd10aedf08f)


<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well updates to the docs for the new widget.
-->

Closes # N/A

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
