### PR TITLE
Fix: iCal integration fails with all-day events

### DIFF
--- a/src/widgets/calendar/integrations/ical.jsx
+++ b/src/widgets/calendar/integrations/ical.jsx
@@ -53,8 +53,8 @@ export default function Integration({ config, params, setEvents, hideErrors, tim
 
       const eventToAdd = (date, i, type) => {
         // When the 'dtend' is not defined (one-day all-day event), 'dtend' should be the same as 'dtstart'.
-        const {dtstart} = event;
-        const dtend = ('dtend' in event) ? event.dtend : dtstart;
+        const { dtstart } = event;
+        const dtend = 'dtend' in event ? event.dtend : dtstart;
 
         const duration = dtend.value - dtstart.value;
         const days = duration === 0 ? 1 : duration / (1000 * 60 * 60 * 24);

--- a/src/widgets/calendar/integrations/ical.jsx
+++ b/src/widgets/calendar/integrations/ical.jsx
@@ -52,7 +52,11 @@ export default function Integration({ config, params, setEvents, hideErrors, tim
       }
 
       const eventToAdd = (date, i, type) => {
-        const duration = event.dtend.value - event.dtstart.value;
+        // When the 'dtend' is not defined (one-day all-day event), 'dtend' should be the same as 'dtstart'.
+        const {dtstart} = event;
+        const dtend = ('dtend' in event) ? event.dtend : dtstart;
+
+        const duration = dtend.value - dtstart.value;
         const days = duration / (1000 * 60 * 60 * 24);
 
         const eventDate = timezone ? DateTime.fromJSDate(date, { zone: timezone }) : DateTime.fromJSDate(date);
@@ -60,7 +64,7 @@ export default function Integration({ config, params, setEvents, hideErrors, tim
         for (let j = 0; j < days; j += 1) {
           // See https://github.com/gethomepage/homepage/issues/2753 uid is not stable
           // assumption is that the event is the same if the start, end and title are all the same
-          const hash = simpleHash(`${event?.dtstart?.value}${event?.dtend?.value}${title}${i}${j}${type}}`);
+          const hash = simpleHash(`${dtstart?.value}${dtend?.value}${title}${i}${j}${type}}`);
           eventsToAdd[hash] = {
             title,
             date: eventDate.plus({ days: j }),

--- a/src/widgets/calendar/integrations/ical.jsx
+++ b/src/widgets/calendar/integrations/ical.jsx
@@ -52,12 +52,10 @@ export default function Integration({ config, params, setEvents, hideErrors, tim
       }
 
       const eventToAdd = (date, i, type) => {
-        // When the 'dtend' is not defined (one-day all-day event), 'dtend' should be the same as 'dtstart'.
-        const { dtstart } = event;
-        const dtend = 'dtend' in event ? event.dtend : dtstart;
+        // 'dtend' is null for all-day events
+        const { dtstart, dtend = { value: 0 } } = event;
 
-        const duration = dtend.value - dtstart.value;
-        const days = duration === 0 ? 1 : duration / (1000 * 60 * 60 * 24);
+        const days = dtend.value === 0 ? 1 : (dtend.value - dtstart.value) / (1000 * 60 * 60 * 24);
 
         const eventDate = timezone ? DateTime.fromJSDate(date, { zone: timezone }) : DateTime.fromJSDate(date);
 

--- a/src/widgets/calendar/integrations/ical.jsx
+++ b/src/widgets/calendar/integrations/ical.jsx
@@ -57,7 +57,7 @@ export default function Integration({ config, params, setEvents, hideErrors, tim
         const dtend = ('dtend' in event) ? event.dtend : dtstart;
 
         const duration = dtend.value - dtstart.value;
-        const days = duration / (1000 * 60 * 60 * 24);
+        const days = duration === 0 ? 1 : duration / (1000 * 60 * 60 * 24);
 
         const eventDate = timezone ? DateTime.fromJSDate(date, { zone: timezone }) : DateTime.fromJSDate(date);
 


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well updates to the docs for the new widget.
-->

This PR fixes a issue of iCal integration.

For the one-day event with Google Calendar, the `dtend` would not defined.  So the error appeared.
This PR fixes about it: when `dtend` is not defined, set it as same as `dtstart`.

And also, if `dtend` and `dtstart` are the same, set duration to `1`;

Closes #2882

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
