### PR TITLE
Add Plant-it Widget

### DIFF
--- a/docs/widgets/services/planit.md
+++ b/docs/widgets/services/planit.md
@@ -1,0 +1,13 @@
+---
+title: Plant-it
+description: Plant-it Widget Configuration
+---
+
+API key can be created from the REST API.
+
+```yaml
+widget:
+  type: plantit
+  url: http://plant-it.host.or.ip:port
+  key: plantit-api-key
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,7 @@ nav:
       - widgets/services/homebridge.md
       - widgets/services/iframe.md
       - widgets/services/immich.md
+      - widgets/services/plantit.md
       - widgets/services/jackett.md
       - widgets/services/jdownloader.md
       - widgets/services/jellyfin.md

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -825,5 +825,11 @@
     "netdata": {
       "warnings": "Warnings",
       "criticals": "Criticals"
+    },
+    "plantit": {
+        "events": "Events",
+        "plants": "Plants",
+        "photos": "Photos",
+        "species": "Species"
     }
 }

--- a/public/locales/it/common.json
+++ b/public/locales/it/common.json
@@ -803,5 +803,11 @@
     "netdata": {
         "warnings": "Warnings",
         "criticals": "Criticals"
+    },
+    "plantit": {
+        "events": "Eventi",
+        "plants": "Piante",
+        "species": "Specie",
+        "images": "Immagini"
     }
 }

--- a/src/utils/proxy/handlers/credentialed.js
+++ b/src/utils/proxy/handlers/credentialed.js
@@ -61,6 +61,8 @@ export default async function credentialedProxyHandler(req, res, map) {
         headers.Authorization = `Basic ${Buffer.from(`$:${widget.key}`).toString("base64")}`;
       } else if (widget.type === "glances") {
         headers.Authorization = `Basic ${Buffer.from(`${widget.username}:${widget.password}`).toString("base64")}`;
+      } else if (widget.type === "plantit") {
+        headers.Key = `${widget.key}`;
       } else {
         headers["X-API-Key"] = `${widget.key}`;
       }

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -41,6 +41,7 @@ const components = {
   homebridge: dynamic(() => import("./homebridge/component")),
   healthchecks: dynamic(() => import("./healthchecks/component")),
   immich: dynamic(() => import("./immich/component")),
+  plantit: dynamic(() => import("./plantit/component")),
   jackett: dynamic(() => import("./jackett/component")),
   jdownloader: dynamic(() => import("./jdownloader/component")),
   jellyfin: dynamic(() => import("./emby/component")),

--- a/src/widgets/plantit/component.jsx
+++ b/src/widgets/plantit/component.jsx
@@ -1,0 +1,37 @@
+import { useTranslation } from "next-i18next";
+
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+
+  const { widget } = service;
+
+  const { data: plantitData, error: plantitError } = useWidgetAPI(widget, "plantit");
+
+  if (plantitError) {
+    return <Container service={service} error={plantitError} />;
+  }
+
+  if (!plantitData) {
+    return (
+      <Container service={service}>
+        <Block label="plantit.events" />
+        <Block label="plantit.plants" />
+        <Block label="plantit.photos" />
+        <Block label="plantit.species" />
+      </Container>
+    );
+  }
+
+  return (
+    <Container service={service}>
+      <Block label="plantit.events" value={t("common.number", { value: plantitData.diaryEntryCount })} />
+      <Block label="plantit.plants" value={t("common.number", { value: plantitData.plantCount })} />
+      <Block label="plantit.photos" value={t("common.number", { value: plantitData.imageCount })} />
+      <Block label="plantit.species" value={t("common.number", { value: plantitData.botanicalInfoCount })} />
+    </Container>
+  );
+}

--- a/src/widgets/plantit/widget.js
+++ b/src/widgets/plantit/widget.js
@@ -1,0 +1,21 @@
+import { asJson } from "utils/proxy/api-helpers";
+import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
+
+const widget = {
+  api: "{url}/api/{endpoint}",
+  proxyHandler: credentialedProxyHandler,
+
+  mappings: {
+    plantit: {
+      endpoint: "stats",
+    },
+    map: (data) => ({
+      events: Object.values(asJson(data).diaryEntryCount).reduce((acc, i) => acc + i, 0),
+      plants: Object.values(asJson(data).plantCount).reduce((acc, i) => acc + i, 0),
+      photos: Object.values(asJson(data).imageCount).reduce((acc, i) => acc + i, 0),
+      species: Object.values(asJson(data).botanicalInfoCount).reduce((acc, i) => acc + i, 0),
+    }),
+  },
+};
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -34,6 +34,7 @@ import homeassistant from "./homeassistant/widget";
 import homebridge from "./homebridge/widget";
 import healthchecks from "./healthchecks/widget";
 import immich from "./immich/widget";
+import plantit from "./plantit/widget";
 import jackett from "./jackett/widget";
 import jellyseerr from "./jellyseerr/widget";
 import jdownloader from "./jdownloader/widget";
@@ -142,6 +143,7 @@ const widgets = {
   healthchecks,
   ical: calendar,
   immich,
+  plantit,
   jackett,
   jdownloader,
   jellyfin: emby,


### PR DESCRIPTION
Implements https://github.com/gethomepage/homepage/discussions/2723
## Type of change
- [X] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:
- [X] If applicable, I have added corresponding documentation changes.
- [X] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [X] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [X] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.




## Example:
<img width="408" alt="Screenshot 2024-01-21 at 14 08 55" src="https://github.com/gethomepage/homepage/assets/66636702/feaaa2f6-0a5d-41a0-b577-fcc0226545ff">

Example of usage:
```
- Plant-it:
    href: http://localhost:8085/
    description: 🪴 Self-hosted, open source gardening companion app
    widget:
      type: plantit
      url: http://localhost:8085
      key: 7QiFTqEdRguDhPNXxr83F8Obl6HpDTUTNg+7SUJdxn+s34kXfxhxHBTEA96w5NgnfS60so3XY/10YKrRXA6vow==
```

