### PR TITLE
Add requestBody as option for customapi widget

### DIFF
--- a/docs/widgets/services/customapi.md
+++ b/docs/widgets/services/customapi.md
@@ -16,6 +16,7 @@ widget:
   password: password # auth - optional
   method: GET # optional, e.g. POST
   headers: # optional, must be object, see below
+  requestBody: # optional, can be string or object, see below
   display: # optional, default to block, see below
   mappings:
     - field: key # needs to be YAML string or object
@@ -166,3 +167,16 @@ Pass custom headers using the `headers` option, for example:
 headers:
   X-API-Token: token
 ```
+
+## Custom Request Body
+
+Pass custom request body using the `requestBody` option in either a string or object format. Objects will automatically be converted to a JSON string.
+
+```yaml
+requestBody:
+  foo: bar
+# or
+requestBody: "{\"foo\":\"bar\"}"
+```
+
+Both formats result in `{"foo":"bar"}` being sent as the request body. Don't forget to set your `Content-Type` headers!

--- a/src/utils/proxy/handlers/generic.js
+++ b/src/utils/proxy/handlers/generic.js
@@ -35,6 +35,12 @@ export default async function genericProxyHandler(req, res, map) {
       };
       if (req.body) {
         params.body = req.body;
+      } else if (widget.requestBody) {
+        if (typeof widget.requestBody === "object") {
+          params.body = JSON.stringify(widget.requestBody);
+        } else {
+          params.body = widget.requestBody;
+        }
       }
 
       const [status, contentType, data] = await httpProxy(url, params);


### PR DESCRIPTION
## Proposed change

Add new optional `requestBody` option to `customapi` widget. This will allow accessing endpoints that might require filtering via request body instead of query params.

This new option will support objects or strings to allow for clean ways to write JSON request bodies or the ability to pass a raw body for non JSON formats.

![image](https://github.com/gethomepage/homepage/assets/9381594/62014b3c-9678-42fd-8d66-7e38104ab020)

Here is the services configuration I used:
```yaml
- Custom API:
    - POST No Body:
        widget:
          type: customapi
          url: https://api.mockfly.dev/mocks/febdbed3-d77d-4665-b94f-d12ffb0813a9/test
          method: POST
          headers:
            Content-Type: application/json
            Accept: application/json
          mappings:
            - field: msg
              label: Message
              format: text

    - POST Object Body:
        widget:
          type: customapi
          url: https://api.mockfly.dev/mocks/febdbed3-d77d-4665-b94f-d12ffb0813a9/test
          method: POST
          headers:
            Content-Type: application/json
            Accept: application/json
          requestBody:
            foo: bar
          mappings:
            - field: msg
              label: Message
              format: text

    - POST String Body:
        widget:
          type: customapi
          url: https://api.mockfly.dev/mocks/febdbed3-d77d-4665-b94f-d12ffb0813a9/test
          method: POST
          headers:
            Content-Type: application/json
            Accept: application/json
          requestBody: "{\"foo\": \"bar\"}"
          mappings:
            - field: msg
              label: Message
              format: text
```

You can use the mock API I set up for testing if you would like: https://api.mockfly.dev/mocks/febdbed3-d77d-4665-b94f-d12ffb0813a9/test

It has a 500 request limit so don't leave it polling for too long or it will stop working. If it receives a POST with a request body containing `{"foo":"bar"}` it returns `{"msg": "I am a POST with a body"}`, otherwise it returns `{"msg": "I am a POST with no body"}`

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well updates to the docs for the new widget.
-->

Closes #2313
Closes #2102

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [X] If applicable, I have added corresponding documentation changes.
- [X] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [X] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [X] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
