### PR TITLE
Enhancement: allow api auth with moonraker service

### DIFF
--- a/docs/widgets/services/moonraker.md
+++ b/docs/widgets/services/moonraker.md
@@ -12,3 +12,13 @@ widget:
   type: moonraker
   url: http://moonraker.host.or.ip:port
 ```
+
+
+If your moonraker instance has an active authorization and your homepage ip isn't whitelisted you need to add your api key ([Authorization Documentation](https://moonraker.readthedocs.io/en/latest/web_api/#authorization)).
+
+```yaml
+widget:
+  type: moonraker
+  url: http://moonraker.host.or.ip:port
+  key: api_keymoonraker
+```

--- a/docs/widgets/services/moonraker.md
+++ b/docs/widgets/services/moonraker.md
@@ -13,7 +13,6 @@ widget:
   url: http://moonraker.host.or.ip:port
 ```
 
-
 If your moonraker instance has an active authorization and your homepage ip isn't whitelisted you need to add your api key ([Authorization Documentation](https://moonraker.readthedocs.io/en/latest/web_api/#authorization)).
 
 ```yaml

--- a/src/widgets/moonraker/widget.js
+++ b/src/widgets/moonraker/widget.js
@@ -1,8 +1,8 @@
-import genericProxyHandler from "utils/proxy/handlers/generic";
+import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
 
 const widget = {
   api: "{url}/printer/objects/query?{endpoint}",
-  proxyHandler: genericProxyHandler,
+  proxyHandler: credentialedProxyHandler,
 
   mappings: {
     print_stats: {


### PR DESCRIPTION
## Proposed change

Changed the genericProxyHandler to use the credentialedProxyHandler for moonraker instances that uses authorization by API keys.
With the genericProxyHandler you get a 401 unauthorized error on those instances.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
