### PR TITLE
BUG - Disk sizes for the glances and resources widgets are reporting incorrect sizes

### DIFF
--- a/src/components/widgets/glances/glances.jsx
+++ b/src/components/widgets/glances/glances.jsx
@@ -132,9 +132,9 @@ export default function Widget({ options }) {
         <Resource
           key={`disk_${disk.mnt_point ?? disk.device_name}`}
           icon={FiHardDrive}
-          value={t("common.bytes", { value: disk.free })}
+          value={t("common.bytes", { value: disk.free, binary: true })}
           label={t("glances.free")}
-          expandedValue={t("common.bytes", { value: disk.size })}
+          expandedValue={t("common.bytes", { value: disk.size, binary: true })}
           expandedLabel={t("glances.total")}
           percentage={disk.percent}
           expanded={options.expanded}

--- a/src/components/widgets/resources/disk.jsx
+++ b/src/components/widgets/resources/disk.jsx
@@ -36,9 +36,9 @@ export default function Disk({ options, expanded, refresh = 1500 }) {
   return (
     <Resource
       icon={FiHardDrive}
-      value={t("common.bytes", { value: data.drive.available })}
+      value={t("common.bytes", { value: data.drive.available, binary: true })}
       label={t("resources.free")}
-      expandedValue={t("common.bytes", { value: data.drive.size })}
+      expandedValue={t("common.bytes", { value: data.drive.size, binary: true })}
       expandedLabel={t("resources.total")}
       percentage={percent}
       expanded={expanded}


### PR DESCRIPTION
 The sizes are reported in bytes and need the binary: flag set to true so that the values are divided by 1024 and not 1000. The memory widgets were already doing this but the disk widgets missed this option.

## Proposed change

<!--
Glances and resources widgets need to set the binary: true option for disk sizes.
-->

## Type of change

<!--
Fix for disk sizes for glances and resources widgets
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
