### PR TITLE
allow whitespace in env var replacement

### DIFF
--- a/src/utils/config/config.js
+++ b/src/utils/config/config.js
@@ -59,11 +59,11 @@ export function substituteEnvironmentVars(str) {
     const cachedVars = getCachedEnvironmentVars();
     cachedVars.forEach(([key, value]) => {
       if (key.startsWith(homepageVarPrefix)) {
-        result = result.replaceAll(`{{${key}}}`, value);
+        result = result.replaceAll(new RegExp(`{{\\s*${key}\\s*}}`, "g"), value);
       } else if (key.startsWith(homepageFilePrefix)) {
         const filename = value;
         const fileContents = readFileSync(filename, "utf8");
-        result = result.replaceAll(`{{${key}}}`, fileContents);
+        result = result.replaceAll(new RegExp(`{{\\s*${key}\\s*}}`, "g"), fileContents);
       }
     });
   }


### PR DESCRIPTION


## Proposed change

Currently the env var replacement argument is `{{${key}}}`, and does not allow white spaces in the placeholders. e.g.
`{{HOMEPAGE_VAR_FOO}}` works
`{{ HOMEPAGE_VAR_FOO }}` does not

will allow adding env var placeholders  with surrounding white space.

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
