### PR TITLE
Feature: add stash widget (#2238)

### DIFF
--- a/docs/widgets/services/stash.md
+++ b/docs/widgets/services/stash.md
@@ -1,0 +1,20 @@
+---
+title: Stash
+description: Stash Widget Configuration
+---
+
+Learn more about [Stash](https://github.com/stashapp/stash).
+
+Find your API key from inside Stash at `Settings > Security > API Key`. Note that the API key is only required if your Stash instance has login credentials.
+
+Allowed fields: `["scenes", "scenesPlayed", "playCount", "playDuration", "sceneSize", "sceneDuration", "images", "imageSize", "galleries", "performers", "studios", "movies", "tags", "oCount"]`.
+
+If more than 4 fields are provided, only the first 4 are displayed.
+
+```yaml
+widget:
+  type: stash
+  url: http://stash.host.or.ip
+  key: stashapikey
+  fields: ["scenes", "images"] # optional - default fields shown
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -124,6 +124,7 @@ nav:
       - widgets/services/scrutiny.md
       - widgets/services/sonarr.md
       - widgets/services/speedtest-tracker.md
+      - widgets/services/stash.md
       - widgets/services/syncthing-relay-server.md
       - widgets/services/tailscale.md
       - widgets/services/tdarr.md

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -836,5 +836,21 @@
         "notifications": "Notifications",
         "issues": "Issues",
         "pulls": "Pull Requests"
+    },
+    "stash": {
+        "scenes": "Scenes",
+        "scenesPlayed": "Scenes Played",
+        "playCount": "Total Plays",
+        "playDuration": "Time Watched",
+        "sceneSize": "Scenes Size",
+        "sceneDuration": "Scenes Duration",
+        "images": "Images",
+        "imageSize": "Images Size",
+        "galleries": "Galleries",
+        "performers": "Performers",
+        "studios": "Studios",
+        "movies": "Movies",
+        "tags": "Tags",
+        "oCount": "O Count"
     }
 }

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -97,6 +97,7 @@ const components = {
   scrutiny: dynamic(() => import("./scrutiny/component")),
   sonarr: dynamic(() => import("./sonarr/component")),
   speedtest: dynamic(() => import("./speedtest/component")),
+  stash: dynamic(() => import("./stash/component")),
   strelaysrv: dynamic(() => import("./strelaysrv/component")),
   tailscale: dynamic(() => import("./tailscale/component")),
   tautulli: dynamic(() => import("./tautulli/component")),

--- a/src/widgets/stash/component.jsx
+++ b/src/widgets/stash/component.jsx
@@ -39,11 +39,17 @@ export default function Component({ service }) {
       <Block label="stash.scenesPlayed" value={t("common.number", { value: stats.scenes_played })} />
       <Block label="stash.playCount" value={t("common.number", { value: stats.total_play_count })} />
       <Block label="stash.playDuration" value={t("common.uptime", { value: stats.total_play_duration })} />
-      <Block label="stash.sceneSize" value={t("common.bbytes", { value: stats.scenes_size, maximumFractionDigits: 1 })} />
+      <Block
+        label="stash.sceneSize"
+        value={t("common.bbytes", { value: stats.scenes_size, maximumFractionDigits: 1 })}
+      />
       <Block label="stash.sceneDuration" value={t("common.uptime", { value: stats.scenes_duration })} />
 
       <Block label="stash.images" value={t("common.number", { value: stats.image_count })} />
-      <Block label="stash.imageSize" value={t("common.bbytes", { value: stats.images_size, maximumFractionDigits: 1 })} />
+      <Block
+        label="stash.imageSize"
+        value={t("common.bbytes", { value: stats.images_size, maximumFractionDigits: 1 })}
+      />
 
       <Block label="stash.galleries" value={t("common.number", { value: stats.gallery_count })} />
       <Block label="stash.performers" value={t("common.number", { value: stats.performer_count })} />

--- a/src/widgets/stash/component.jsx
+++ b/src/widgets/stash/component.jsx
@@ -1,0 +1,56 @@
+import { useTranslation } from "next-i18next";
+
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+
+  const { widget } = service;
+  const { data: stats, error: stashError } = useWidgetAPI(widget, "stats");
+
+  if (stashError) {
+    return <Container service={service} error={stashError} />;
+  }
+
+  if (!stats) {
+    return (
+      <Container service={service}>
+        <Block label="stash.scenes" />
+        <Block label="stash.images" />
+      </Container>
+    );
+  }
+
+  // Provide a default if not set in the config
+  if (!widget.fields) {
+    widget.fields = ["scenes", "images"];
+  }
+
+  // Limit to a maximum of 4 at a time
+  if (widget.fields.length > 4) {
+    widget.fields = widget.fields.slice(0, 4);
+  }
+
+  return (
+    <Container service={service}>
+      <Block label="stash.scenes" value={t("common.number", { value: stats.scene_count })} />
+      <Block label="stash.scenesPlayed" value={t("common.number", { value: stats.scenes_played })} />
+      <Block label="stash.playCount" value={t("common.number", { value: stats.total_play_count })} />
+      <Block label="stash.playDuration" value={t("common.uptime", { value: stats.total_play_duration })} />
+      <Block label="stash.sceneSize" value={t("common.bbytes", { value: stats.scenes_size, maximumFractionDigits: 1 })} />
+      <Block label="stash.sceneDuration" value={t("common.uptime", { value: stats.scenes_duration })} />
+
+      <Block label="stash.images" value={t("common.number", { value: stats.image_count })} />
+      <Block label="stash.imageSize" value={t("common.bbytes", { value: stats.images_size, maximumFractionDigits: 1 })} />
+
+      <Block label="stash.galleries" value={t("common.number", { value: stats.gallery_count })} />
+      <Block label="stash.performers" value={t("common.number", { value: stats.performer_count })} />
+      <Block label="stash.studios" value={t("common.number", { value: stats.studio_count })} />
+      <Block label="stash.movies" value={t("common.number", { value: stats.movie_count })} />
+      <Block label="stash.tags" value={t("common.number", { value: stats.tag_count })} />
+      <Block label="stash.oCount" value={t("common.number", { value: stats.total_o_count })} />
+    </Container>
+  );
+}

--- a/src/widgets/stash/widget.js
+++ b/src/widgets/stash/widget.js
@@ -1,4 +1,4 @@
-import {asJson} from "utils/proxy/api-helpers";
+import { asJson } from "utils/proxy/api-helpers";
 import genericProxyHandler from "utils/proxy/handlers/generic";
 
 const widget = {
@@ -32,7 +32,7 @@ const widget = {
           }
         }`
       }),
-      map: (data) => asJson(data).data.stats
+      map: (data) => asJson(data).data.stats,
     },
   },
 };

--- a/src/widgets/stash/widget.js
+++ b/src/widgets/stash/widget.js
@@ -1,0 +1,40 @@
+import {asJson} from "utils/proxy/api-helpers";
+import genericProxyHandler from "utils/proxy/handlers/generic";
+
+const widget = {
+  api: "{url}/{endpoint}?apikey={key}",
+  proxyHandler: genericProxyHandler,
+
+  mappings: {
+    stats: {
+      method: "POST",
+      endpoint: "graphql",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        query: `{
+          stats {
+            scene_count
+            scenes_size
+            scenes_duration
+            image_count
+            images_size
+            gallery_count
+            performer_count
+            studio_count
+            movie_count
+            tag_count
+            total_o_count
+            total_play_duration
+            total_play_count
+            scenes_played
+          }
+        }`
+      }),
+      map: (data) => asJson(data).data.stats
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/stash/widget.js
+++ b/src/widgets/stash/widget.js
@@ -30,7 +30,7 @@ const widget = {
             total_play_count
             scenes_played
           }
-        }`
+        }`,
       }),
       map: (data) => asJson(data).data.stats,
     },

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -89,6 +89,7 @@ import sabnzbd from "./sabnzbd/widget";
 import scrutiny from "./scrutiny/widget";
 import sonarr from "./sonarr/widget";
 import speedtest from "./speedtest/widget";
+import stash from "./stash/widget";
 import strelaysrv from "./strelaysrv/widget";
 import tailscale from "./tailscale/widget";
 import tautulli from "./tautulli/widget";
@@ -201,6 +202,7 @@ const widgets = {
   scrutiny,
   sonarr,
   speedtest,
+  stash,
   strelaysrv,
   tailscale,
   tautulli,


### PR DESCRIPTION
## Proposed change

Adds a new widget for the [Stash](https://github.com/stashapp/stash) app with a number of fields matching their in-built stats page as suggested in the original widget request #2238. Though I understand if this is rejected or needs to be adjusted due to it being an adult/18+ oriented app.

![image](https://github.com/gethomepage/homepage/assets/6865942/173027a1-7304-4d5d-960d-2b5703929d31)


<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well updates to the docs for the new widget.
-->

Closes #2238

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [x] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
