### PR TITLE
Documentation: Fix link formatting in Home Assistant service widget document

### DIFF
--- a/docs/widgets/services/homeassistant.md
+++ b/docs/widgets/services/homeassistant.md
@@ -18,7 +18,7 @@ The `custom` property will have no effect as long as the `fields` property is de
   - state labels and values can be user defined and may reference entity attributes in curly brackets
   - if no state label is defined it will default to `"{attributes.friendly_name}"`
   - if no state value is defined it will default to `"{state} {attributes.unit_of_measurement}"`
-- `template` will query the specified template, see (Home Assistant Templating)[https://www.home-assistant.io/docs/configuration/templating]
+- `template` will query the specified template, see [Home Assistant Templating](https://www.home-assistant.io/docs/configuration/templating)
   - if no template label is defined it will be empty
 
 ```yaml


### PR DESCRIPTION
## Proposed change
Changes link in `docs/widgets/services/homeassistant.md` to correct format. Previous format was `(description)[link]` which is incorrect.

## Type of change
- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
