### PR TITLE
Fix: docker status labels colors

### DIFF
--- a/src/components/services/status.jsx
+++ b/src/components/services/status.jsx
@@ -54,7 +54,9 @@ export default function Status({ service, style }) {
 
   return (
     <div
-      className={`w-auto text-center overflow-hidden ${backgroundClass} rounded-b-[3px] docker-status`}
+      className={`w-auto text-center overflow-hidden ${backgroundClass} rounded-b-[3px] docker-status docker-status-${statusLabel
+        .toLowerCase()
+        .replace(" ", "-")}`}
       title={statusTitle}
     >
       {style !== "dot" ? (

--- a/src/components/services/status.jsx
+++ b/src/components/services/status.jsx
@@ -16,24 +16,25 @@ export default function Status({ service, style }) {
     colorClass = "text-rose-500/80";
   } else if (data) {
     if (data.status?.includes("running")) {
-      if (data.health === "starting") {
-        statusTitle = t("docker.starting");
-        colorClass = "text-blue-500/80";
-      }
-
-      if (data.health === "unhealthy") {
-        statusTitle = t("docker.unhealthy");
-        colorClass = "text-orange-400/50 dark:text-orange-400/80";
-      }
+      colorClass = "text-emerald-500/80";
 
       if (!data.health) {
         statusLabel = data.status.replace("running", t("docker.running"));
       } else {
         statusLabel = data.health === "healthy" ? t("docker.healthy") : data.health;
+
+        if (data.health === "starting") {
+          statusLabel = t("docker.starting");
+          colorClass = "text-blue-500/80";
+        }
+
+        if (data.health === "unhealthy") {
+          statusLabel = t("docker.unhealthy");
+          colorClass = "text-orange-400/50 dark:text-orange-400/80";
+        }
       }
 
       statusTitle = statusLabel;
-      colorClass = "text-emerald-500/80";
     }
 
     if (data.status === "not found" || data.status === "exited" || data.status?.startsWith("partial")) {
@@ -41,6 +42,7 @@ export default function Status({ service, style }) {
       else if (data.status === "exited") statusLabel = t("docker.exited");
       else statusLabel = data.status.replace("partial", t("docker.partial"));
       colorClass = "text-orange-400/50 dark:text-orange-400/80";
+      statusTitle = statusLabel;
     }
   }
 


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well updates to the docs for the new widget.
-->

This resolves the styling / inconsistency issues regarding docker status labels.

Closes #3027

In addition to the color issues stated in #3072, I've found some other inconsistencies regarding what statuses got translated or not and what would be set as the `statusTitle`. Those have also been touched in this PR. (Makes it easier to apply custom CSS Styling e.g. specifically for containers that have `exited` without touching containers of status `unknown`.


With styling fixed:
<img alt="homepage-demo-starting" src="https://github.com/gethomepage/homepage/assets/68224306/2f802cf1-39ba-4158-ba86-6872d8d13c55">
<img alt="homepage-demo-unhealthy" src="https://github.com/gethomepage/homepage/assets/68224306/43b1b8ff-8a41-4afb-ba4c-ac2cef15317e">


## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
