### PR TITLE
Fix: Added margin left to greeting widget for screen size of sm and above

### DIFF
--- a/src/components/widgets/greeting/greeting.jsx
+++ b/src/components/widgets/greeting/greeting.jsx
@@ -17,7 +17,7 @@ export default function Greeting({ options }) {
     return (
       <Container options={options} additionalClassNames="information-widget-greeting">
         <Raw>
-          <span className={`text-theme-800 dark:text-theme-200 mr-3 ${textSizes[options.text_size || "xl"]}`}>
+          <span className={`text-theme-800 dark:text-theme-200 sm:ml-2 mr-3 ${textSizes[options.text_size || "xl"]}`}>
             {options.text}
           </span>
         </Raw>


### PR DESCRIPTION
## Proposed change
The margin left for greeting widget was not present.

Before:
![greeting-before](https://github.com/smolpaw/homepage/assets/35697471/f76f72a7-db32-474f-a4ea-b88690d750bd)

After:
![greeting-after](https://github.com/smolpaw/homepage/assets/35697471/90ee1ad9-3425-45f3-9970-bb24b0d0c485)

The `sm` breakpoint ensures the style doesn't take effect for mobile devices as they don't have this issue

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
