### PR TITLE
Fix: info widget gaps

### DIFF
--- a/src/components/widgets/widget/container.jsx
+++ b/src/components/widgets/widget/container.jsx
@@ -16,7 +16,7 @@ export function getAllClasses(options, additionalClassNames = "") {
     }
 
     return classNames(
-      "flex flex-col justify-center ml-2 mr-2",
+      "flex flex-col justify-center",
       "mt-2 m:mb-0 rounded-md shadow-md shadow-theme-900/10 dark:shadow-theme-900/20 bg-theme-100/20 dark:bg-white/5 p-2 pl-3 pr-3",
       additionalClassNames,
     );
@@ -24,7 +24,7 @@ export function getAllClasses(options, additionalClassNames = "") {
 
   let widgetAlignedClasses = "flex flex-col max-w:full sm:basis-auto self-center grow-0 flex-wrap";
   if (options?.style?.isRightAligned) {
-    widgetAlignedClasses = "flex flex-col justify-center first:ml-auto ml-2 mr-2 ";
+    widgetAlignedClasses = "flex flex-col justify-center";
   }
 
   return classNames(widgetAlignedClasses, additionalClassNames);

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -161,10 +161,10 @@ function Index({ initialSettings, fallback }) {
 
 const headerStyles = {
   boxed:
-    "m-6 mb-0 sm:m-9 sm:mb-0 rounded-md shadow-md shadow-theme-900/10 dark:shadow-theme-900/20 bg-theme-100/20 dark:bg-white/5 p-3",
-  underlined: "m-6 mb-0 sm:m-9 sm:mb-1 border-b-2 pb-4 border-theme-800 dark:border-theme-200/50",
-  clean: "m-6 mb-0 sm:m-9 sm:mb-0",
-  boxedWidgets: "m-6 mb-0 sm:m-9 sm:mb-0 sm:mt-1",
+    "m-5 mb-0 sm:m-9 sm:mb-0 rounded-md shadow-md shadow-theme-900/10 dark:shadow-theme-900/20 bg-theme-100/20 dark:bg-white/5 p-3",
+  underlined: "m-5 mb-0 sm:m-9 sm:mb-1 border-b-2 pb-4 border-theme-800 dark:border-theme-200/50",
+  clean: "m-5 mb-0 sm:m-9 sm:mb-0",
+  boxedWidgets: "m-5 mb-0 sm:m-9 sm:mb-0 sm:mt-1",
 };
 
 function Home({ initialSettings }) {
@@ -282,7 +282,7 @@ function Home({ initialSettings }) {
     return (
       <>
         {tabs.length > 0 && (
-          <div key="tabs" id="tabs" className="m-6 sm:m-9 sm:mt-4 sm:mb-0">
+          <div key="tabs" id="tabs" className="m-5 sm:m-9 sm:mt-4 sm:mb-0">
             <ul
               className={classNames(
                 "sm:flex rounded-md bg-theme-100/20 dark:bg-white/5",
@@ -415,11 +415,7 @@ function Home({ initialSettings }) {
               `backdrop-blur${settings.cardBlur.length ? "-" : ""}${settings.cardBlur}`,
           )}
         >
-          <div
-            id="widgets-wrap"
-            style={{ width: "calc(100% + 1rem)" }}
-            className={classNames("flex flex-row w-full flex-wrap justify-between -ml-2 -mr-2")}
-          >
+          <div id="widgets-wrap" className={classNames("flex flex-row w-full flex-wrap justify-between gap-x-2")}>
             {widgets && (
               <>
                 {widgets
@@ -436,7 +432,7 @@ function Home({ initialSettings }) {
                   id="information-widgets-right"
                   className={classNames(
                     "m-auto flex flex-wrap grow sm:basis-auto justify-between md:justify-end",
-                    headerStyle === "boxedWidgets" ? "sm:ml-4" : "sm:ml-2",
+                    "m-auto flex flex-wrap grow sm:basis-auto justify-between md:justify-end gap-x-2",
                   )}
                 >
                   {widgets


### PR DESCRIPTION
## Proposed change

<img width="1576" alt="Screenshot 2024-02-29 at 11 25 34 PM" src="https://github.com/gethomepage/homepage/assets/4887959/b4dedf3f-1efb-4a51-aea8-7ec56ca6bc98">
<img width="1569" alt="Screenshot 2024-02-29 at 11 26 22 PM" src="https://github.com/gethomepage/homepage/assets/4887959/eb049b68-ea9b-42ef-be2c-87d9d4a1e733">
<img width="1582" alt="Screenshot 2024-02-29 at 11 29 07 PM" src="https://github.com/gethomepage/homepage/assets/4887959/db2408aa-547d-42e3-8f36-edd61735c3d6">
<img width="1632" alt="Screenshot 2024-02-29 at 11 34 30 PM" src="https://github.com/gethomepage/homepage/assets/4887959/6ece74df-1ecd-4415-a7d7-317f2745e436">

Supersedes #3037

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
