### PR TITLE
Fix: omada widget missing switches field, enforce default and max fields

### DIFF
--- a/src/widgets/omada/component.jsx
+++ b/src/widgets/omada/component.jsx
@@ -17,12 +17,20 @@ export default function Component({ service }) {
     return <Container service={service} error={omadaAPIError} />;
   }
 
+  if (!widget.fields) {
+    widget.fields = ["connectedAp", "activeUser", "alerts", "connectedGateway"];
+  } else if (widget.fields?.length > 4) {
+    widget.fields = widget.fields.slice(0, 4);
+  }
+
   if (!omadaData) {
     return (
       <Container service={service}>
         <Block label="omada.connectedAp" />
         <Block label="omada.activeUser" />
         <Block label="omada.alerts" />
+        <Block label="omada.connectedGateway" />
+        <Block label="omada.connectedSwitches" />
       </Container>
     );
   }
@@ -32,9 +40,8 @@ export default function Component({ service }) {
       <Block label="omada.connectedAp" value={t("common.number", { value: omadaData.connectedAp })} />
       <Block label="omada.activeUser" value={t("common.number", { value: omadaData.activeUser })} />
       <Block label="omada.alerts" value={t("common.number", { value: omadaData.alerts })} />
-      {omadaData.connectedGateways > 0 && (
-        <Block label="omada.connectedGateway" value={t("common.number", { value: omadaData.connectedGateways })} />
-      )}
+      <Block label="omada.connectedGateway" value={t("common.number", { value: omadaData.connectedGateways })} />
+      <Block label="omada.connectedSwitches" value={t("common.number", { value: omadaData.connectedSwitches })} />
     </Container>
   );
 }


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well updates to the docs for the new widget.
-->

Closes #3045
Closes #3046

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
