### PR TITLE
Change: default merge pihole blocked fields

### DIFF
--- a/docs/widgets/services/pihole.md
+++ b/docs/widgets/services/pihole.md
@@ -9,6 +9,8 @@ As of v2022.12 [PiHole requires the use of an API key](https://pi-hole.net/blog/
 
 Allowed fields: `["queries", "blocked", "blocked_percent", "gravity"]`.
 
+Note: by default the "blocked" and "blocked_percent" fields are merged e.g. "1,234 (15%)" but explicitly including the "blocked_percent" field will change them to display separately.
+
 ```yaml
 widget:
   type: pihole
@@ -16,4 +18,4 @@ widget:
   key: yourpiholeapikey # optional
 ```
 
-_Added in v0.1.0, updated in v0.6.18_
+_Added in v0.1.0, updated in v0.8.9_

--- a/src/widgets/pihole/component.jsx
+++ b/src/widgets/pihole/component.jsx
@@ -15,6 +15,10 @@ export default function Component({ service }) {
     return <Container service={service} error={piholeError} />;
   }
 
+  if (!widget.fields) {
+    widget.fields = ["queries", "blocked", "gravity"];
+  }
+
   if (!piholeData) {
     return (
       <Container service={service}>
@@ -26,10 +30,15 @@ export default function Component({ service }) {
     );
   }
 
+  let blockedValue = `${t("common.number", { value: parseInt(piholeData.ads_blocked_today, 10) })}`;
+  if (!widget.fields.includes("blocked_percent")) {
+    blockedValue += ` (${t("common.percent", { value: parseFloat(piholeData.ads_percentage_today.toPrecision(3)) })})`;
+  }
+
   return (
     <Container service={service}>
       <Block label="pihole.queries" value={t("common.number", { value: parseInt(piholeData.dns_queries_today, 10) })} />
-      <Block label="pihole.blocked" value={t("common.number", { value: parseInt(piholeData.ads_blocked_today, 10) })} />
+      <Block label="pihole.blocked" value={blockedValue} />
       <Block
         label="pihole.blocked_percent"
         value={t("common.percent", { value: parseFloat(piholeData.ads_percentage_today.toPrecision(3)) })}


### PR DESCRIPTION
## Proposed change

Shoulda thought of this before. If user specifies `blocked_percent` still show it, otherwise just merge it.

Default:
<img width="439" alt="Screenshot 2024-03-04 at 11 02 16 AM" src="https://github.com/gethomepage/homepage/assets/4887959/3611f7c4-43e6-4669-a8b8-768303f6a3a3">

with `blocked_percent` field specified:
<img width="448" alt="Screenshot 2024-03-04 at 11 02 50 AM" src="https://github.com/gethomepage/homepage/assets/4887959/bbef85a7-8680-497e-a63d-1f1e3ac5e940">


Closes #3064
Closes #2473
Closes #2426

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [x] Other (please explain): change

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
