### PR TITLE
Add LOG_TARGETS environment variable to control log outputs

### DIFF
--- a/docs/configs/settings.md
+++ b/docs/configs/settings.md
@@ -406,6 +406,8 @@ By default the homepage logfile is written to the a `logs` subdirectory of the `
 logpath: /logfile/path
 ```
 
+By default, logs are sent both to `stdout` and to a file at the path specified. This can be changed by setting the `LOG_TARGETS` environment variable to one of `both` (default), `stdout` or `file`.
+
 ## Show Docker Stats
 
 You can show all docker stats expanded in `settings.yaml`:


### PR DESCRIPTION
Adds a config option to enable customisation of where homepage logs to. This is controlled through an environment variable `LOG_TARGETS` to complement the existing `LOG_LEVEL` variable. Options include `both` (default), `stdout` and `file`.

The default is "both" to preserve backwards compatibility.

This is useful in cases where logs are already collected from `stdout` by a central service, and thus the log file is redundant or otherwise requires logrotate.

## Type of change


- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
