### PR TITLE
Enhancement: support `LOG_TARGETS` environment variable

### DIFF
--- a/docs/configs/settings.md
+++ b/docs/configs/settings.md
@@ -406,6 +406,8 @@ By default the homepage logfile is written to the a `logs` subdirectory of the `
 logpath: /logfile/path
 ```
 
+By default, logs are sent both to `stdout` and to a file at the path specified. This can be changed by setting the `LOG_TARGETS` environment variable to one of `both` (default), `stdout` or `file`.
+
 ## Show Docker Stats
 
 You can show all docker stats expanded in `settings.yaml`:


### PR DESCRIPTION
## Proposed change

Homepage logs to both stdout and a logs directory by default. While the log file path [can be customised](https://gethomepage.dev/latest/configs/settings/#log-path), it’s not currently possible to disable the file logging completely.

In some situations, such as on Kubernetes or where Homepage is running under a service manager like systemd, it may be preferable to only output to stdout, as log aggregation/collection is handled more centrally.

This patch introduces support for the `LOG_TARGETS` environment variable, which has possible values of `both` (default), `stdout`, or `file`. If left unset, the default value of `both` behaves the same as the previous default - so this change should be backward compatible.

Closes #3067

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
