### PR TITLE
added api key authentication

### DIFF
--- a/src/utils/proxy/handlers/generic.js
+++ b/src/utils/proxy/handlers/generic.js
@@ -25,7 +25,9 @@ export default async function genericProxyHandler(req, res, map) {
 
       const headers = req.extraHeaders ?? widget.headers ?? {};
 
-      if (widget.username && widget.password) {
+      if (widget.key) {
+        headers.Authorization = `${widget.key}`;
+      } else if (widget.username && widget.password) {
         headers.Authorization = `Basic ${Buffer.from(`${widget.username}:${widget.password}`).toString("base64")}`;
       }
 


### PR DESCRIPTION
This might work, though my dev env is hosed and I'm unable to test it

## Proposed change

This should allow for the [pfsense widget](https://gethomepage.dev/latest/widgets/services/pfsense/) to be used with an api key, but I am having trouble getting a dev environment working (pnpm troubles). 

Sorry that I cannot do more at this time, but I figured I would throw this out there to see if someone else is able to test/regression test this. 

## Type of change

Additional functionality to widgets, specifically allowing for http auth that uses an API key instead of the b64 basicauth. 

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.    ***NOT YET, AWAITING SOMEONE THAT CAN TEST AND TEST REGRESSION***
- [X] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [X] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.       ***NOT YET, AWAITING SOMEONE THAT CAN TEST AND TEST REGRESSION***
