### PR TITLE
Fix: truncate long process names in Glances widget

### DIFF
--- a/src/widgets/glances/metrics/process.jsx
+++ b/src/widgets/glances/metrics/process.jsx
@@ -62,7 +62,7 @@ export default function Component({ service }) {
             <div key={item.pid} className="text-[0.75rem] h-[0.8rem]">
               <div className="flex items-center">
                 <div className="w-3 h-3 mr-1.5 opacity-50">{statusMap[item.status]}</div>
-                <div className="opacity-75 grow">{item.name}</div>
+                <div className="opacity-75 grow truncate">{item.name}</div>
                 <div className="opacity-25 w-14 text-right">{item.cpu_percent.toFixed(1)}%</div>
                 <div className="opacity-25 w-14 text-right">
                   {t("common.bytes", {


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well updates to the docs for the new widget.
-->

Currently when using the Glances process widget, the process name could overflow given the text is too long, especially on smaller laptops. The screenshot was taken on a 13-inch MacBook in the fullscreen with a reasonable layout standard.
![WX20240307-145510@2x](https://github.com/gethomepage/homepage/assets/55668018/46c50185-6320-4071-a986-593e3ab2924e)

By adding `truncate` to CSS, it prevents overflow with the maximum information provided. Although there is still a misalignment issue, it is caused by `grow` and can not be fixed with CSS only.
![20240307145831](https://github.com/gethomepage/homepage/assets/55668018/7c4ebb4d-9193-4b93-8507-75da98199ef6)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
