### PR TITLE
Fix: field parsing can fail with docker labels

### DIFF
--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -453,7 +453,7 @@ export function cleanServiceGroups(groups) {
         let fieldsList = fields;
         if (typeof fields === "string") {
           try {
-            JSON.parse(fields);
+            fieldsList = JSON.parse(fields);
           } catch (e) {
             logger.error("Invalid fields list detected in config for service '%s'", service.name);
             fieldsList = null;


### PR DESCRIPTION
## Proposed change

```yaml
      - homepage.widget.type=gamedig
      - homepage.widget.url=udp://135.148.151.222:16261
      - homepage.widget.serverType=csgo
      - homepage.widget.fields=["status", "maxPlayers"]
```

<img width="764" alt="Screenshot 2024-03-10 at 10 24 45 PM" src="https://github.com/gethomepage/homepage/assets/4887959/0ac18046-6e9f-401e-bb08-7b54ea3a3f35">


Closes #3100

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
