### PR TITLE
Add refresh interval to EspHome

### DIFF
--- a/docs/widgets/services/esphome.md
+++ b/docs/widgets/services/esphome.md
@@ -13,4 +13,5 @@ Allowed fields: `["total", "online", "offline", "unknown"]`.
 widget:
   type: esphome
   url: http://esphome.host.or.ip:port
+  refreshInterval: 30000 # optional - in milliseconds, defaults to 30s. Minimal allowed: 10000.
 ```

--- a/src/widgets/esphome/component.jsx
+++ b/src/widgets/esphome/component.jsx
@@ -4,11 +4,17 @@ import Block from "components/services/widget/block";
 import Container from "components/services/widget/container";
 import useWidgetAPI from "utils/proxy/use-widget-api";
 
+const defaultInterval = 30000;
+const minRefreshInterval = 10000;
+
 export default function Component({ service }) {
   const { t } = useTranslation();
 
   const { widget } = service;
-  const { data: resultData, error: resultError } = useWidgetAPI(widget);
+  const { refreshInterval = defaultInterval } = widget;
+  const { data: resultData, error: resultError } = useWidgetAPI(widget, "devices", {
+    refreshInterval: Math.max(minRefreshInterval, refreshInterval),
+  });
 
   if (resultError) {
     return <Container service={service} error={resultError} />;


### PR DESCRIPTION
## Proposed change

This adds a `refreshInterval` to the EspHome widget (As the device states that are being monitored are expected to change from time to time).

This was something I missed in #2986.


## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
