### PR TITLE
Fix: Add alternative 'offline' status to EspHome widget

### DIFF
--- a/docs/widgets/services/esphome.md
+++ b/docs/widgets/services/esphome.md
@@ -7,7 +7,10 @@ Learn more about [ESPHome](https://esphome.io/).
 
 Show the number of ESPHome devices based on their state.
 
-Allowed fields: `["total", "online", "offline", "offline_alt", "unknown"]`.
+Allowed fields: `["total", "online", "offline", "offline_alt", "unknown"]` (maximum of 4).
+
+By default ESPHome will only mark devices as `offline` if their address cannot be pinged. If it has an invalid config or its name cannot be resolved (by DNS) its status will be marked as `unknown`.
+To group both `offline` and `unknown` devices together, users should use the `offline_alt` field instead. This sums all devices that are _not_ online together.
 
 ```yaml
 widget:

--- a/docs/widgets/services/esphome.md
+++ b/docs/widgets/services/esphome.md
@@ -7,7 +7,7 @@ Learn more about [ESPHome](https://esphome.io/).
 
 Show the number of ESPHome devices based on their state.
 
-Allowed fields: `["total", "online", "offline", "unknown"]`.
+Allowed fields: `["total", "online", "offline", "offline_alt", "unknown"]`.
 
 ```yaml
 widget:

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -109,6 +109,7 @@
     },
     "esphome": {
         "offline": "Offline",
+        "offline_alt": "Offline",
         "online": "Online",
         "total": "Total",
         "unknown": "Unknown"

--- a/src/widgets/esphome/component.jsx
+++ b/src/widgets/esphome/component.jsx
@@ -19,6 +19,7 @@ export default function Component({ service }) {
       <Container service={service}>
         <Block label="esphome.online" />
         <Block label="esphome.offline" />
+        <Block label="esphome.offline_alt" />
         <Block label="esphome.unknown" />
         <Block label="esphome.total" />
       </Container>
@@ -27,6 +28,7 @@ export default function Component({ service }) {
 
   const total = Object.keys(resultData).length;
   const online = Object.entries(resultData).filter(([, v]) => v === true).length;
+  const notOnline = Object.entries(resultData).filter(([, v]) => v !== true).length;
   const offline = Object.entries(resultData).filter(([, v]) => v === false).length;
   const unknown = Object.entries(resultData).filter(([, v]) => v === null).length;
 
@@ -34,6 +36,7 @@ export default function Component({ service }) {
     <Container service={service}>
       <Block label="esphome.online" value={t("common.number", { value: online })} />
       <Block label="esphome.offline" value={t("common.number", { value: offline })} />
+      <Block label="esphome.offline_alt" value={t("common.number", { value: notOnline })} />
       <Block label="esphome.unknown" value={t("common.number", { value: unknown })} />
       <Block label="esphome.total" value={t("common.number", { value: total })} />
     </Container>


### PR DESCRIPTION
## Proposed change

After deploying changes of #2986 in different use-cases it became clear that internal handling of EspHome device states can be somewhat inconsistent w.r.t. the offline devices. Some users may want any device that is _not online_ to be shown as offline, but others may need the distinction of when a device is proven to be offline (cannot be reached).

This PR adds an alternative `offline` state that essentially groups both marked offline and unknown together.

In the following example I have one device whose address can be resolved, but cannot be pinged and 2 devices that are not even resolved;

<img width="367" alt="homepage-esphome-altOfflineExample" src="https://github.com/gethomepage/homepage/assets/68224306/2ff3cd24-ca54-4329-895e-21b8e6d00ecc">

Configuration used in this example:
```yaml
    - ESPHome:
        icon: esphome.png
        widget:
            type: esphome
            url: http://localhost:6052
            fields:
                - online
                - offline
                - offline_alt
                - unknown
```

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
