### PR TITLE
Fix bookmark shortcut for custom icons

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -376,7 +376,7 @@ function Home({ initialSettings }) {
         {settings.base && <base href={settings.base} />}
         {settings.favicon ? (
           <>
-            <link rel="icon" href={settings.favicon} />
+            <link rel="shortcut icon" href={settings.favicon} />
             <link rel="apple-touch-icon" sizes="180x180" href={settings.favicon} />
           </>
         ) : (


### PR DESCRIPTION

## Proposed change

`shortcut` was missing from the favicon header setup when using custom icons.
Closes # (issue)

## Type of change

- [ ] New service widget
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
