### PR TITLE
Documentation: add optional auth to whatsupdocker documentation

### DIFF
--- a/docs/widgets/services/whatsupdocker.md
+++ b/docs/widgets/services/whatsupdocker.md
@@ -5,12 +5,12 @@ description: WhatsUpDocker Widget Configuration
 
 Learn more about [Whats Up Docker](https://github.com/fmartinou/whats-up-docker).
 
-Currently requires unauthenticated whatsupdocker instance.
-
 Allowed fields: `["monitoring", "updates"]`.
 
 ```yaml
 widget:
   type: whatsupdocker
   url: http://whatsupdocker:port
+  username: username  # optional
+  password: password  # optional
 ```


### PR DESCRIPTION
Tested and user/pass do indeed work

## Proposed change

Found that the widget does indeed support when the remote server uses authentication. Tested on desktop and mobile with both http & https. 

<!--
Please include a summary of the change. Screenshots and / or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant relevant API output as well updates to the docs for the new widget.
-->

Closes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [ ] ~~If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).~~
- [ ] ~~I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).~~
- [x] ~~If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.~~
