### PR TITLE
Documentation: Adds sticky cookie note for k8s multiple replica setups

### DIFF
--- a/docs/installation/k8s.md
+++ b/docs/installation/k8s.md
@@ -361,3 +361,33 @@ spec:
                 port:
                   number: 3000
 ```
+
+### Multiple Replicas
+
+If you plan to deploy homepage with a replica count greater than 1, you may
+want to consider enabling sticky sessions on the homepage route. This will
+prevent unnecessary re-renders on page loads and window / tab focusing. The
+procedure for enabling sticky sessions depends on your Ingress controller. Below
+is an example using Traefik as the Ingress controller.
+
+```
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: homepage.example.com
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`homepage.example.com`)
+      services:
+        - kind: Service
+          name: homepage
+          port: 3000
+          sticky:
+            cookie:
+              httpOnly: true
+              secure: true
+              sameSite: none
+```


### PR DESCRIPTION
## Proposed change
I recently encountered an issue in k8s that caused homepage to reload 3-5 times each time the window or tab was blurred then re-focused. The issue wound up going away when I reduced my homepage replica count to 1. I was able to resolve the issue, while still keeping my replica count at 2, by enabling sticky sessions for the homepage route. This PR aims to document this finding for anyone else that might be experiencing the same issue.

Related thread: https://github.com/gethomepage/homepage/discussions/2305#discussioncomment-8781811
## Type of change
<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
