### PR TITLE
Enhancement: Jackett password support

### DIFF
--- a/docs/widgets/services/jackett.md
+++ b/docs/widgets/services/jackett.md
@@ -5,7 +5,7 @@ description: Jackett Widget Configuration
 
 Learn more about [Jackett](https://github.com/Jackett/Jackett).
 
-Jackett must not have any authentication for the widget to work.
+If Jackett has an admin password set, you must set the `password` field for the widget to work.
 
 Allowed fields: `["configured", "errored"]`.
 
@@ -14,4 +14,5 @@ widget:
   type: jackett
   url: http://jackett.host.or.ip
   key: jackettapikey
+  password: JackettAdminPassword
 ```

--- a/docs/widgets/services/jackett.md
+++ b/docs/widgets/services/jackett.md
@@ -13,6 +13,5 @@ Allowed fields: `["configured", "errored"]`.
 widget:
   type: jackett
   url: http://jackett.host.or.ip
-  key: jackettapikey
   password: JackettAdminPassword
 ```

--- a/src/utils/proxy/http.js
+++ b/src/utils/proxy/http.js
@@ -103,7 +103,7 @@ export async function httpProxy(url, params = {}) {
 
   try {
     const [status, contentType, data, responseHeaders] = await request;
-    return [status, contentType, data, responseHeaders];
+    return [status, contentType, data, responseHeaders, params];
   } catch (err) {
     logger.error(
       "Error calling %s//%s%s%s...",

--- a/src/utils/proxy/jackett.js
+++ b/src/utils/proxy/jackett.js
@@ -1,0 +1,22 @@
+import { httpProxy } from "utils/proxy/http";
+import { formatApiCall } from "utils/proxy/api-helpers";
+
+export async function fetchJackettCookie(widget, loginURL) {
+  const url = new URL(formatApiCall(loginURL, widget));
+  const loginData = `password=${encodeURIComponent(widget.password)}`;
+  const [status, , , , params] = await httpProxy(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded'
+    },
+    body: loginData,
+  });
+
+  if (status === 200 && params && params.headers && params.headers.Cookie) {
+    const cookieValue = params.headers.Cookie;
+    return cookieValue;
+  } else {
+    logger.error("Failed to fetch Jackett cookie, status: %d", status);
+    return null;
+  }
+}

--- a/src/widgets/jackett/widget.js
+++ b/src/widgets/jackett/widget.js
@@ -1,8 +1,9 @@
-import genericProxyHandler from "utils/proxy/handlers/generic";
+import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
 
 const widget = {
   api: "{url}/api/v2.0/{endpoint}?apikey={key}&configured=true",
-  proxyHandler: genericProxyHandler,
+  proxyHandler: credentialedProxyHandler,
+  loginURL: "{url}/UI/Dashboard",
 
   mappings: {
     indexers: {

--- a/src/widgets/jackett/widget.js
+++ b/src/widgets/jackett/widget.js
@@ -1,7 +1,7 @@
 import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
 
 const widget = {
-  api: "{url}/api/v2.0/{endpoint}?apikey={key}&configured=true",
+  api: "{url}/api/v2.0/{endpoint}?configured=true",
   proxyHandler: credentialedProxyHandler,
   loginURL: "{url}/UI/Dashboard",
 


### PR DESCRIPTION
## Proposed change

Used the method outlined in https://github.com/Jackett/Jackett/issues/5578#issuecomment-583744595 to make api requests when a password is specified. Has been tested and is working. Also updated the docs to remove mention of api-key as that is not used and the api requests work without it (in both cases when password is enabled and when it is not).

Closes #3097, #437, #1799, #2794, and #3115

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.