### PR TITLE
Added documentation for pfSense API token auth

### DIFF
--- a/docs/widgets/services/pfsense.md
+++ b/docs/widgets/services/pfsense.md
@@ -21,9 +21,9 @@ Allowed fields: `["load", "memory", "temp", "wanStatus", "wanIP", "disk"]` (maxi
 widget:
   type: pfsense
   url: http://pfsense.host.or.ip:port
-  username: user # optional- use if avoiding api keys (headers)
-  password: pass # optional- use if avoiding api keys (headers)
-  headers: # for use with API keys instead of username/password
+  username: user # optional- for use instead of headers/Authorization (API keys)
+  password: pass # optional- for use instead of headers/Authorization (API keys)
+  headers: # optional- for use with API keys instead of username/password
     Authorization: client_id client_token
   wan: igb0
 ```

--- a/docs/widgets/services/pfsense.md
+++ b/docs/widgets/services/pfsense.md
@@ -9,7 +9,7 @@ This widget requires the installation of the [pfsense-api](https://github.com/ja
 
 Once pfSense API is installed, you can set the API to be read-only in System > API > Settings.
 
-There are two currently supported authentication modes: 'Local Database' and 'API Token'. To for 'Local Database', use the `username` and `password` fields with the credentials of a pfSense admin user. For 'API Token', utilize the `headers` parameter as shown below. When generating a new key, the client_token will be shown once at the top of the page in an alert box and the client_id will be shown at the bottom of the page. 
+There are two currently supported authentication modes: 'Local Database' and 'API Token'. To for 'Local Database', use the `username` and `password` fields with the credentials of a pfSense admin user. For 'API Token', utilize the `headers` parameter as shown below. When generating a new key, the client_token will be shown once at the top of the page in an alert box and the client_id will be at the bottom of the page. Do not use both `headers` and `username`/`password`.
 
 WAN interface to monitor can be defined by updating the `wan` param.
 
@@ -21,9 +21,9 @@ Allowed fields: `["load", "memory", "temp", "wanStatus", "wanIP", "disk"]` (maxi
 widget:
   type: pfsense
   url: http://pfsense.host.or.ip:port
-  username: user # only if not utilizing headers
-  password: pass # only if not utilizing headers
-  headers: # use this instead of username and password
+  username: user # optional- use if avoiding api keys (headers)
+  password: pass # optional- use if avoiding api keys (headers)
+  headers: # use this instead of username and password with API keys
     Authorization: client_id client_token
   wan: igb0
 ```

--- a/docs/widgets/services/pfsense.md
+++ b/docs/widgets/services/pfsense.md
@@ -11,7 +11,7 @@ Once pfSense API is installed, you can set the API to be read-only in System > A
 
 There are two currently supported authentication modes: 'Local Database' and 'API Token'. To for 'Local Database', use the `username` and `password` fields with the credentials of a pfSense admin user. For 'API Token', utilize the `headers` parameter as shown below. When generating a new key, the client_token will be shown once at the top of the page in an alert box and the client_id will be at the bottom of the page. Do not use both `headers` and `username`/`password`.
 
-WAN interface to monitor can be defined by updating the `wan` param.
+The interface to monitor is defined by updating the `wan` param. It should be referenced as it is shown under Interfaces > Assignments in the 'Network port' column next to the MAC address.
 
 Load is returned instead of cpu utilization. This is a limitation in the pfSense API due to the complexity of this calculation. This may become available in future versions.
 
@@ -23,7 +23,7 @@ widget:
   url: http://pfsense.host.or.ip:port
   username: user # optional- use if avoiding api keys (headers)
   password: pass # optional- use if avoiding api keys (headers)
-  headers: # use this instead of username and password with API keys
+  headers: # for use with API keys instead of username/password
     Authorization: client_id client_token
   wan: igb0
 ```

--- a/docs/widgets/services/pfsense.md
+++ b/docs/widgets/services/pfsense.md
@@ -11,7 +11,7 @@ Once pfSense API is installed, you can set the API to be read-only in System > A
 
 There are two currently supported authentication modes: 'Local Database' and 'API Token'. To for 'Local Database', use the `username` and `password` fields with the credentials of a pfSense admin user. For 'API Token', utilize the `headers` parameter as shown below. When generating a new key, the client_token will be shown once at the top of the page in an alert box and the client_id will be at the bottom of the page. Do not use both `headers` and `username`/`password`.
 
-The interface to monitor is defined by updating the `wan` param. It should be referenced as it is shown under Interfaces > Assignments in the 'Network port' column next to the MAC address.
+The interface to monitor is defined by updating the `wan` parameter. It should be referenced as it is shown under Interfaces > Assignments in the 'Network port' column next to the MAC address.
 
 Load is returned instead of cpu utilization. This is a limitation in the pfSense API due to the complexity of this calculation. This may become available in future versions.
 

--- a/docs/widgets/services/pfsense.md
+++ b/docs/widgets/services/pfsense.md
@@ -9,7 +9,7 @@ This widget requires the installation of the [pfsense-api](https://github.com/ja
 
 Once pfSense API is installed, you can set the API to be read-only in System > API > Settings.
 
-Currently the only supported authentication mode is 'Local Database'.
+There are two currently supported authentication modes: 'Local Database' and 'API Token'. To for 'Local Database', use the `username` and `password` fields with the credentials of a pfSense admin user. For 'API Token', utilize the `headers` parameter as shown below. When generating a new key, the client_token will be shown once at the top of the page in an alert box and the client_id will be shown at the bottom of the page. 
 
 WAN interface to monitor can be defined by updating the `wan` param.
 
@@ -21,7 +21,9 @@ Allowed fields: `["load", "memory", "temp", "wanStatus", "wanIP", "disk"]` (maxi
 widget:
   type: pfsense
   url: http://pfsense.host.or.ip:port
-  username: user
-  password: pass
+  username: user # only if not utilizing headers
+  password: pass # only if not utilizing headers
+  headers: # use this instead of username and password
+    Authorization: client_id client_token
   wan: igb0
 ```


### PR DESCRIPTION
## Proposed change

Found that there was a way to utilize the headers widget field for api key authentication in the pfsense plugin instead of requiring use of user/pass. 

I would consider removing the user/pass parts from the documentation altogether (especially if it clutters the docs), but I left it in for now. 

Also cleared up some other information that me and other users got caught up on. 

<!-- Closes # (issue) -->

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [?] New feature (non-breaking change which adds functionality) (not really because it was already easily possible with existing codebase)
- [x] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [ ] ~~If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).~~
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] ~~If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.~~
