### PR TITLE
fix some wrong chinese translate

### DIFF
--- a/public/locales/zh-CN/common.json
+++ b/public/locales/zh-CN/common.json
@@ -68,8 +68,8 @@
         "wanted": "想看",
         "queued": "排队",
         "series": "系列",
-        "queue": "Queue",
-        "unknown": "Unknown"
+        "queue": "队列数",
+        "unknown": "未知"
     },
     "radarr": {
         "wanted": "想看",
@@ -77,7 +77,7 @@
         "movies": "电影",
         "missing": "丢失",
         "queue": "Queue",
-        "unknown": "Unknown"
+        "unknown": "未知"
     },
     "readarr": {
         "wanted": "订阅",
@@ -97,7 +97,7 @@
     "pihole": {
         "queries": "查询",
         "blocked": "阻止",
-        "gravity": "重力",
+        "gravity": "gravity",
         "blocked_percent": "拦截 %"
     },
     "speedtest": {
@@ -533,7 +533,7 @@
         "memoryusage": "内存",
         "freespace": "剩余空间",
         "activeusers": "活跃用户",
-        "numfiles": "Files",
+        "numfiles": "文件数",
         "numshares": "共享项目"
     },
     "kopia": {
@@ -564,14 +564,14 @@
     },
     "prometheus": {
         "targets_up": "目标上线",
-        "targets_down": "目标在线",
+        "targets_down": "目标下线",
         "targets_total": "总目标"
     },
     "minecraft": {
         "players": "玩家",
         "version": "版本",
         "status": "状态",
-        "up": "在线的",
+        "up": "在线",
         "down": "离线"
     },
     "ghostfolio": {


### PR DESCRIPTION
## Fix some wrong chinese tanslate

I found some translate error in chinese

## Type of change

- wrong chinese translate
  - `gravity` is a speicial mean, it can't just translate to `重力`
  - `targets_down` now translated as `目标在线`, but in chinese it mean is `targets_up`
  - `up` just mean online, in chinese it's `在线`. Not `在线的`
- add some translate
  - such as `numfiles`, `unknown`. just add chinese translate 

- [x] Documentation only

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
