### PR TITLE
Add the ability of specifying credentialed service widget headers

### DIFF
--- a/src/utils/proxy/handlers/credentialed.js
+++ b/src/utils/proxy/handlers/credentialed.js
@@ -20,9 +20,8 @@ export default async function credentialedProxyHandler(req, res, map) {
     if (widget) {
       const url = new URL(formatApiCall(widgets[widget.type].api, { endpoint, ...widget }));
 
-      const headers = {
-        "Content-Type": "application/json",
-      };
+      const headers = req.extraHeaders ?? widget.headers ?? {};
+      headers["Content-Type"] = "application/json";
 
       if (widget.type === "coinmarketcap") {
         headers["X-CMC_PRO_API_KEY"] = `${widget.key}`;


### PR DESCRIPTION
## Introduction

Let's say you have setup your Proxmox server to be accessible from the internet, but you restricted it's access with Cloudflare Zero Trust and you have setup a Service Token for the Proxmox Application.

A Service Token allows you to **BYPASS** your otherwise protected Proxmox Authentication Identity providers (such as Google for example) so that automated tools, scripts or bots can reach your Application.

Now, if on the same network (pve node & homepage) you can set your proxmox widget url to point to your local pve node ip and everything should work just fine, _BUT_ if your pve node is somewhere on the internet and is protected by Cloudflare Zero Trust, in order for the widget to work you will have to connect to it using the a Service Token.

## Proposed change

I propose having the ability of specifying credentialed service widget headers, just like the CustomAPI service widget does it, making a proxmix service look something like this:

```
- My First Group:
    - Proxmox:
        icon: proxmox.png
        href: https://proxmox.domain.com
        description: Proxmox Virtual Environment
        widget:
          type: proxmox
          url: https://proxmox.domain.com
          username: api@pam!hub
          password: 7dcdc28c-713c-3e25-bbc0-2e86abc666b3
          headers:
            CF-Access-Client-Id: d4dd54e0adb92f986c6c9a426666a99x.access
            CF-Access-Client-Secret: 4ad1abc6668e2f42e23a928x8232x21fe94513bf1c9b4fddf111b7b0xxx5a3bc
```

Closes #2756

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
