### PR TITLE
Fix: Glances cpu & info widgets information

### DIFF
--- a/docs/widgets/services/glances.md
+++ b/docs/widgets/services/glances.md
@@ -19,7 +19,6 @@ widget:
   password: pass # optional if auth enabled in Glances
   metric: cpu
   diskUnits: bytes # optional, bytes (default) or bbytes. Only applies to disk
-  tempUnits: imperial # optional, metric (default) or imperial. Only applies to cpu
   refreshInterval: 5000 # optional - in milliseconds, defaults to 1000 or more, depending on the metric
   pointsLimit: 15 # optional, defaults to 15
 ```

--- a/docs/widgets/services/glances.md
+++ b/docs/widgets/services/glances.md
@@ -19,6 +19,9 @@ widget:
   password: pass # optional if auth enabled in Glances
   metric: cpu
   diskUnits: bytes # optional, bytes (default) or bbytes. Only applies to disk
+  tempUnits: imperial # optional, metric (default) or imperial. Only applies to cpu
+  refreshInterval: 5000 # optional - in milliseconds, defaults to 1000 or more, depending on the metric
+  pointsLimit: 15 # optional, defaults to 15
 ```
 
 _Please note, this widget does not need an `href`, `icon` or `description` on its parent service. To achieve the same effect as the examples above, see as an example:_

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -398,6 +398,7 @@ export function cleanServiceGroups(groups) {
           metric,
           pointsLimit,
           diskUnits,
+          tempUnits,
 
           // glances, customapi, iframe
           refreshInterval,
@@ -537,6 +538,7 @@ export function cleanServiceGroups(groups) {
           if (refreshInterval) cleanedService.widget.refreshInterval = refreshInterval;
           if (pointsLimit) cleanedService.widget.pointsLimit = pointsLimit;
           if (diskUnits) cleanedService.widget.diskUnits = diskUnits;
+          if (tempUnits) cleanedService.widget.tempUnits = tempUnits;
         }
         if (type === "mjpeg") {
           if (stream) cleanedService.widget.stream = stream;

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -398,7 +398,6 @@ export function cleanServiceGroups(groups) {
           metric,
           pointsLimit,
           diskUnits,
-          tempUnits,
 
           // glances, customapi, iframe
           refreshInterval,
@@ -538,7 +537,6 @@ export function cleanServiceGroups(groups) {
           if (refreshInterval) cleanedService.widget.refreshInterval = refreshInterval;
           if (pointsLimit) cleanedService.widget.pointsLimit = pointsLimit;
           if (diskUnits) cleanedService.widget.diskUnits = diskUnits;
-          if (tempUnits) cleanedService.widget.tempUnits = tempUnits;
         }
         if (type === "mjpeg") {
           if (stream) cleanedService.widget.stream = stream;

--- a/src/widgets/glances/metrics/cpu.jsx
+++ b/src/widgets/glances/metrics/cpu.jsx
@@ -12,61 +12,6 @@ const Chart = dynamic(() => import("../components/chart"), { ssr: false });
 
 const defaultPointsLimit = 15;
 const defaultInterval = 1000;
-const cpuSensorLabels = ["cpu_thermal", "Core", "Tctl"];
-
-function convertToFahrenheit(t) {
-  return (t * 9) / 5 + 32;
-}
-
-function TEMP({ sensorData, tempUnits = "metric" }) {
-  const { t } = useTranslation();
-  const unit = tempUnits === "imperial" ? "fahrenheit" : "celsius";
-  let mainTemp = 0;
-  let maxTemp = 80;
-  const cpuSensors = sensorData?.filter(
-    (s) => cpuSensorLabels.some((label) => s.label.startsWith(label)) && s.type === "temperature_core",
-  );
-
-  if (cpuSensors) {
-    try {
-      mainTemp = cpuSensors.reduce((acc, s) => acc + s.value, 0) / cpuSensors.length;
-      maxTemp = Math.max(
-        cpuSensors.reduce((acc, s) => acc + (s.warning > 0 ? s.warning : 0), 0) / cpuSensors.length,
-        maxTemp,
-      );
-      if (unit === "fahrenheit") {
-        mainTemp = convertToFahrenheit(mainTemp);
-        maxTemp = convertToFahrenheit(maxTemp);
-      }
-    } catch (e) {
-      // cpu sensor retrieval failed
-    }
-  }
-
-  return (
-    mainTemp > 0 && (
-      <div className="text-xs flex">
-        <div className="opacity-75 mr-1">
-          {t("common.number", {
-            value: mainTemp,
-            maximumFractionDigits: 1,
-            style: "unit",
-            unit,
-          })}
-        </div>
-        <div className="opacity-50">
-          {"("}{t("glances.warn")}{" @ "}
-          {t("common.number", {
-            value: maxTemp,
-            maximumFractionDigits: 1,
-            style: "unit",
-            unit,
-          })}{")"}
-        </div>
-      </div>
-    )
-  );
-}
 
 export default function Component({ service }) {
   const { t } = useTranslation();
@@ -76,10 +21,6 @@ export default function Component({ service }) {
   const [dataPoints, setDataPoints] = useState(new Array(pointsLimit).fill({ value: 0 }, 0, pointsLimit));
 
   const { data, error } = useWidgetAPI(service.widget, "cpu", {
-    refreshInterval: Math.max(defaultInterval, refreshInterval),
-  });
-
-  const { data: sensorData, error: sensorError } = useWidgetAPI(service.widget, "sensors", {
     refreshInterval: Math.max(defaultInterval, refreshInterval),
   });
 
@@ -132,16 +73,12 @@ export default function Component({ service }) {
 
       {!chart && quicklookData && !quicklookError && (
         <Block position="top-3 right-3">
-          <div className="text-[0.6rem] opacity-50">
-            {quicklookData.cpu_name && quicklookData.cpu_name}
-          </div>
+          <div className="text-[0.6rem] opacity-50">{quicklookData.cpu_name && quicklookData.cpu_name}</div>
         </Block>
       )}
 
       {quicklookData && !quicklookError && (
         <Block position="bottom-3 left-3">
-          <TEMP sensorData={sensorData} tempUnits={widget.tempUnits} />
-
           {quicklookData.cpu_name && chart && <div className="text-xs opacity-50">{quicklookData.cpu_name}</div>}
         </Block>
       )}

--- a/src/widgets/glances/metrics/info.jsx
+++ b/src/widgets/glances/metrics/info.jsx
@@ -122,7 +122,10 @@ export default function Component({ service }) {
         )}
 
         {!chart && quicklookData?.swap === 0 && (
-          <div className="text-[0.6rem] opacity-50">{quicklookData.cpu_name}</div>
+          <div className="text-[0.6rem] opacity-50">
+            {systemData.linux_distro && `${systemData.linux_distro} - `}
+            {systemData.os_version && systemData.os_version}
+          </div>
         )}
 
         <div className="w-[4rem]">{!chart && <Swap quicklookData={quicklookData} className="opacity-25" />}</div>

--- a/src/widgets/glances/metrics/info.jsx
+++ b/src/widgets/glances/metrics/info.jsx
@@ -123,8 +123,8 @@ export default function Component({ service }) {
 
         {!chart && quicklookData?.swap === 0 && (
           <div className="text-[0.6rem] opacity-50">
-            {systemData.linux_distro && `${systemData.linux_distro} - `}
-            {systemData.os_version && systemData.os_version}
+            {systemData && systemData.linux_distro && `${systemData.linux_distro} - `}
+            {systemData && systemData.os_version && systemData.os_version}
           </div>
         )}
 

--- a/src/widgets/glances/metrics/info.jsx
+++ b/src/widgets/glances/metrics/info.jsx
@@ -13,7 +13,7 @@ function Swap({ quicklookData, className = "" }) {
     quicklookData &&
     quicklookData.swap !== 0 && (
       <div className="text-xs flex place-content-between">
-        <div className={className}>{t("glances.swap")}</div>
+        <div className={className + ' mr-1'}>{t("glances.swap")}</div>
         <div className={className}>
           {t("common.number", {
             value: quicklookData.swap,
@@ -34,7 +34,7 @@ function CPU({ quicklookData, className = "" }) {
     quicklookData &&
     quicklookData.cpu && (
       <div className="text-xs flex place-content-between">
-        <div className={className}>{t("glances.cpu")}</div>
+        <div className={className + ' mr-1'}>{t("glances.cpu")}</div>
         <div className={className}>
           {t("common.number", {
             value: quicklookData.cpu,
@@ -55,7 +55,7 @@ function Mem({ quicklookData, className = "" }) {
     quicklookData &&
     quicklookData.mem && (
       <div className="text-xs flex place-content-between">
-        <div className={className}>{t("glances.mem")}</div>
+        <div className={className + ' mr-1'}>{t("glances.mem")}</div>
         <div className={className}>
           {t("common.number", {
             value: quicklookData.mem,
@@ -140,7 +140,7 @@ export default function Component({ service }) {
       )}
 
       {!chart && (
-        <Block position="bottom-3 left-3 w-[3rem]">
+        <Block position="bottom-3 left-3">
           <CPU quicklookData={quicklookData} className="opacity-75" />
         </Block>
       )}

--- a/src/widgets/glances/metrics/info.jsx
+++ b/src/widgets/glances/metrics/info.jsx
@@ -13,7 +13,7 @@ function Swap({ quicklookData, className = "" }) {
     quicklookData &&
     quicklookData.swap !== 0 && (
       <div className="text-xs flex place-content-between">
-        <div className={className + ' mr-1'}>{t("glances.swap")}</div>
+        <div className={className}>{t("glances.swap")}</div>
         <div className={className}>
           {t("common.number", {
             value: quicklookData.swap,
@@ -34,7 +34,7 @@ function CPU({ quicklookData, className = "" }) {
     quicklookData &&
     quicklookData.cpu && (
       <div className="text-xs flex place-content-between">
-        <div className={className + ' mr-1'}>{t("glances.cpu")}</div>
+        <div className={className}>{t("glances.cpu")}</div>
         <div className={className}>
           {t("common.number", {
             value: quicklookData.cpu,
@@ -55,7 +55,7 @@ function Mem({ quicklookData, className = "" }) {
     quicklookData &&
     quicklookData.mem && (
       <div className="text-xs flex place-content-between">
-        <div className={className + ' mr-1'}>{t("glances.mem")}</div>
+        <div className={className}>{t("glances.mem")}</div>
         <div className={className}>
           {t("common.number", {
             value: quicklookData.mem,
@@ -124,7 +124,7 @@ export default function Component({ service }) {
         {!chart && quicklookData?.swap === 0 && (
           <div className="text-[0.6rem] opacity-50">
             {systemData && systemData.linux_distro && `${systemData.linux_distro} - `}
-            {systemData && systemData.os_version && systemData.os_version}
+            {systemData && systemData.os_version}
           </div>
         )}
 
@@ -140,7 +140,7 @@ export default function Component({ service }) {
       )}
 
       {!chart && (
-        <Block position="bottom-3 left-3">
+        <Block position="bottom-3 left-3 w-[3rem]">
           <CPU quicklookData={quicklookData} className="opacity-75" />
         </Block>
       )}


### PR DESCRIPTION
## Proposed change

This fix is for Glances Widget Service where the `info` metric without chart would only display the CPU instead of the OS, but most importantly fix the `cpu` metric to show the CPU brand / model as well as the temperature, instead of the OS as before.

The `cpu` metric now shows the temperatures as well, current and warn, just like the informational widget, and you can change the units to fahrenheit with `tempUnits: imperial`

Also updated the documentation to reflect `refreshInterval` and `pointsLimit` introduced in #2363 

![image](https://github.com/gethomepage/homepage/assets/163424707/4a91555e-47f2-46d1-b807-ad0ce8b31594)

Closes #3160 

## Type of change

- [ ] New service widget
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [X] If applicable, I have added corresponding documentation changes.
- [X] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) 
- [X] I have checked that all code style checks pass using [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [X] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
