### PR TITLE
Enhancement: support Jackett widget with admin password (#3097)

### DIFF
--- a/docs/widgets/services/jackett.md
+++ b/docs/widgets/services/jackett.md
@@ -13,5 +13,5 @@ Allowed fields: `["configured", "errored"]`.
 widget:
   type: jackett
   url: http://jackett.host.or.ip
-  password: JackettAdminPassword
+  password: jackettadminpassword # optional
 ```

--- a/docs/widgets/services/jackett.md
+++ b/docs/widgets/services/jackett.md
@@ -5,7 +5,7 @@ description: Jackett Widget Configuration
 
 Learn more about [Jackett](https://github.com/Jackett/Jackett).
 
-Jackett must not have any authentication for the widget to work.
+If Jackett has an admin password set, you must set the `password` field for the widget to work.
 
 Allowed fields: `["configured", "errored"]`.
 
@@ -13,5 +13,5 @@ Allowed fields: `["configured", "errored"]`.
 widget:
   type: jackett
   url: http://jackett.host.or.ip
-  key: jackettapikey
+  password: JackettAdminPassword
 ```

--- a/src/utils/proxy/http.js
+++ b/src/utils/proxy/http.js
@@ -103,7 +103,7 @@ export async function httpProxy(url, params = {}) {
 
   try {
     const [status, contentType, data, responseHeaders] = await request;
-    return [status, contentType, data, responseHeaders];
+    return [status, contentType, data, responseHeaders, params];
   } catch (err) {
     logger.error(
       "Error calling %s//%s%s%s...",

--- a/src/widgets/jackett/proxy.js
+++ b/src/widgets/jackett/proxy.js
@@ -6,24 +6,22 @@ import widgets from "widgets/widgets";
 
 const logger = createLogger("jackettProxyHandler");
 
-// Fetches the Jackett cookie; assumes implementation is similar to the previous discussion
 async function fetchJackettCookie(widget, loginURL) {
   const url = new URL(formatApiCall(loginURL, widget));
   const loginData = `password=${encodeURIComponent(widget.password)}`;
   const [status, , , , params] = await httpProxy(url, {
-    method: 'POST',
+    method: "POST",
     headers: {
-      'Content-Type': 'application/x-www-form-urlencoded'
+      "Content-Type": "application/x-www-form-urlencoded",
     },
     body: loginData,
   });
 
-  if (!(status === 200) || !params || !params.headers || !params.headers.Cookie) {
+  if (!(status === 200) || !params?.headers?.Cookie) {
     logger.error("Failed to fetch Jackett cookie, status: %d", status);
     return null;
   }
-  const cookieValue = params.headers.Cookie;
-  return cookieValue;
+  return params.headers.Cookie;
 }
 
 export default async function jackettProxyHandler(req, res) {
@@ -49,11 +47,10 @@ export default async function jackettProxyHandler(req, res) {
     widget.headers = { ...widget.headers, Cookie: jackettCookie };
   }
 
-  // Construct the API call to Jackett
   const url = new URL(formatApiCall(widgets[widget.type].api, { endpoint, ...widget }));
 
   try {
-    const [status, contentType, data] = await httpProxy(url.toString(), {
+    const [status, , data] = await httpProxy(url, {
       method: "GET",
       headers: widget.headers,
     });
@@ -63,9 +60,6 @@ export default async function jackettProxyHandler(req, res) {
       return res.status(status).json({ error: "Failed to call Jackett API", data });
     }
 
-    if (contentType) {
-      res.setHeader("Content-Type", contentType);
-    }
     return res.status(status).send(data);
   } catch (error) {
     logger.error("Exception calling Jackett API: %s", error.message);

--- a/src/widgets/jackett/proxy.js
+++ b/src/widgets/jackett/proxy.js
@@ -1,0 +1,74 @@
+import { httpProxy } from "utils/proxy/http";
+import { formatApiCall } from "utils/proxy/api-helpers";
+import getServiceWidget from "utils/config/service-helpers";
+import createLogger from "utils/logger";
+import widgets from "widgets/widgets";
+
+const logger = createLogger("jackettProxyHandler");
+
+// Fetches the Jackett cookie; assumes implementation is similar to the previous discussion
+async function fetchJackettCookie(widget, loginURL) {
+  const url = new URL(formatApiCall(loginURL, widget));
+  const loginData = `password=${encodeURIComponent(widget.password)}`;
+  const [status, , , , params] = await httpProxy(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded'
+    },
+    body: loginData,
+  });
+
+  if (!(status === 200) || !params || !params.headers || !params.headers.Cookie) {
+    logger.error("Failed to fetch Jackett cookie, status: %d", status);
+    return null;
+  }
+  const cookieValue = params.headers.Cookie;
+  return cookieValue;
+}
+
+export default async function jackettProxyHandler(req, res) {
+  const { group, service, endpoint } = req.query;
+
+  if (!group || !service) {
+    logger.error("Invalid or missing service '%s' or group '%s'", service, group);
+    return res.status(400).json({ error: "Invalid proxy service type" });
+  }
+
+  const widget = await getServiceWidget(group, service);
+  if (!widget || !widgets[widget.type].api) {
+    logger.error("Invalid or missing widget for service '%s' in group '%s'", service, group);
+    return res.status(400).json({ error: "Invalid widget configuration" });
+  }
+
+  if (widget.password) {
+    const jackettCookie = await fetchJackettCookie(widget, widgets[widget.type].loginURL);
+    if (!jackettCookie) {
+      return res.status(500).json({ error: "Failed to authenticate with Jackett" });
+    }
+    // Add the cookie to the widget for use in subsequent requests
+    widget.headers = { ...widget.headers, Cookie: jackettCookie };
+  }
+
+  // Construct the API call to Jackett
+  const url = new URL(formatApiCall(widgets[widget.type].api, { endpoint, ...widget }));
+
+  try {
+    const [status, contentType, data] = await httpProxy(url.toString(), {
+      method: "GET",
+      headers: widget.headers,
+    });
+
+    if (status !== 200) {
+      logger.error("Error calling Jackett API: %d. Data: %s", status, data);
+      return res.status(status).json({ error: "Failed to call Jackett API", data });
+    }
+
+    if (contentType) {
+      res.setHeader("Content-Type", contentType);
+    }
+    return res.status(status).send(data);
+  } catch (error) {
+    logger.error("Exception calling Jackett API: %s", error.message);
+    return res.status(500).json({ error: "Server error", message: error.message });
+  }
+}

--- a/src/widgets/jackett/widget.js
+++ b/src/widgets/jackett/widget.js
@@ -1,8 +1,9 @@
-import genericProxyHandler from "utils/proxy/handlers/generic";
+import jackettProxyHandler from "./proxy";
 
 const widget = {
   api: "{url}/api/v2.0/{endpoint}?apikey={key}&configured=true",
-  proxyHandler: genericProxyHandler,
+  proxyHandler: jackettProxyHandler,
+  loginURL: "{url}/UI/Dashboard",
 
   mappings: {
     indexers: {


### PR DESCRIPTION
Opening again because #3115 has 10 upvotes.

See #3125 for original PR
## Proposed change

Fixes the error that occurs as seen in (#437, #1799 and #2794) which occurs due to the way password authentication works in Jackett. We now make a login request to Jackett to get the cookie and then use that cookie to make the actual request to the Jackett API.

Closes #3115 

## Type of change

- [ ] New service widget
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ x ] If applicable, I have added corresponding documentation changes.
- [ x ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [ x ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ x ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
