### PR TITLE
Fix: Glances cpu chartless whitespace issue

### DIFF
--- a/src/widgets/glances/metrics/info.jsx
+++ b/src/widgets/glances/metrics/info.jsx
@@ -140,7 +140,7 @@ export default function Component({ service }) {
       )}
 
       {!chart && (
-        <Block position="bottom-3 left-3 w-[3rem]">
+        <Block position="bottom-3 left-3 w-[4rem]">
           <CPU quicklookData={quicklookData} className="opacity-75" />
         </Block>
       )}


### PR DESCRIPTION
## Proposed change

There is an issue with the spacing for the glances service cpu chartless widget, previously addressed by adding a margin right to ensure the label never touches the value [here](https://github.com/gethomepage/homepage/pull/3164/commits/459bc293c0c52c12b7852dcd094b59d4cc68e57f#diff-eac3c6efb61eb5fc47ec41f9997cc48e32ace2f8ae60d3193d3d6d9b961d2b62), now fixed by simply increasing the width of the flex container, matching the one from memory and swap.

### Before
![image](https://github.com/gethomepage/homepage/assets/163424707/9fc8543e-d52d-45fe-9efe-49548b027b8f)

### After
![image](https://github.com/gethomepage/homepage/assets/163424707/c0f80b31-270f-426f-b0f2-d40bda73a9d4)

## Type of change

- [ ] New service widget
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
