### PR TITLE
Enhancement: support Minecraft Bedrock for Minecraft widget

### DIFF
--- a/docs/widgets/services/minecraft.md
+++ b/docs/widgets/services/minecraft.md
@@ -9,4 +9,5 @@ Allowed fields: `["players", "version", "status"]`.
 widget:
   type: minecraft
   url: udp://minecraftserveripordomain:port
+  edition: # Optional, should be 'java' or 'bedrock'. Defaults to 'java'
 ```

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "luxon": "^3.4.4",
     "memory-cache": "^0.2.0",
     "minecraft-ping-js": "^1.0.2",
+    "minecraft-server-util-dist": "^5.4.5",
     "next": "^12.3.4",
     "next-i18next": "^12.1.0",
     "ping": "^0.4.4",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "json-rpc-2.0": "^1.7.0",
     "luxon": "^3.4.4",
     "memory-cache": "^0.2.0",
-    "minecraft-ping-js": "^1.0.2",
     "minecraft-server-util-dist": "^5.4.5",
     "next": "^12.3.4",
     "next-i18next": "^12.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,9 +44,6 @@ dependencies:
   memory-cache:
     specifier: ^0.2.0
     version: 0.2.0
-  minecraft-ping-js:
-    specifier: ^1.0.2
-    version: 1.0.2
   minecraft-server-util-dist:
     specifier: ^5.4.5
     version: 5.4.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ dependencies:
   minecraft-ping-js:
     specifier: ^1.0.2
     version: 1.0.2
+  minecraft-server-util-dist:
+    specifier: ^5.4.5
+    version: 5.4.5
   next:
     specifier: ^12.3.4
     version: 12.3.4(react-dom@18.2.0)(react@18.2.0)
@@ -2755,6 +2758,11 @@ packages:
     engines: {node: '>=6.0'}
     dev: false
 
+  /jsonrepair@3.6.0:
+    resolution: {integrity: sha512-ZvOmoq35LhlDaf1W3uT7e17Bh2dYbln1+pdJ1KUIMkRAoUC4mvXX+dbr9Ih6dDmYvB0mdijAucyPk4xX1cEjww==}
+    hasBin: true
+    dev: false
+
   /jsprim@1.4.2:
     resolution: {integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==}
     engines: {node: '>=0.6.0'}
@@ -2923,12 +2931,25 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dev: false
 
+  /minecraft-motd-util@1.1.12:
+    resolution: {integrity: sha512-5TuTRjrRupSTruea0nRC37r0FdhkS1O4wIJKAYfwJRCQd/X4Zyl/dVIs96h9UVW6N8jhIuz9pNkrDsqyN7VBdA==}
+    deprecated: no longer maintained
+    dev: false
+
   /minecraft-ping-js@1.0.2:
     resolution: {integrity: sha512-h9QYG2n+fBKgp520tXBwR354XRzR/w5wXe8CJCmxKm6jbLpAoLODM8Nj5+ssuIVQF8rtxkAnjwv7PH+7ehFzQQ==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     dependencies:
       node-int64: 0.4.0
       varint: 6.0.0
+    dev: false
+
+  /minecraft-server-util-dist@5.4.5:
+    resolution: {integrity: sha512-s1X//SM/IrFcaZYQrnVd6feWC39pmerhbdDhO/7naKQ0tUjsyFsHcfqZiVpU7jlKtHwDcYbBrs3ad8kRnExapA==}
+    engines: {node: '>=10.0.0'}
+    dependencies:
+      jsonrepair: 3.6.0
+      minecraft-motd-util: 1.1.12
     dev: false
 
   /mini-svg-data-uri@1.4.4:

--- a/src/widgets/minecraft/proxy.js
+++ b/src/widgets/minecraft/proxy.js
@@ -1,4 +1,4 @@
-import { pingWithPromise } from "minecraft-ping-js";
+import {status, statusBedrock} from "minecraft-server-util-dist";
 
 import createLogger from "utils/logger";
 import getServiceWidget from "utils/config/service-helpers";
@@ -10,12 +10,19 @@ export default async function minecraftProxyHandler(req, res) {
   const { group, service } = req.query;
   const serviceWidget = await getServiceWidget(group, service);
   const url = new URL(serviceWidget.url);
+  const edition = serviceWidget.edition || "java";
+
   try {
-    const pingResponse = await pingWithPromise(url.hostname, url.port || 25565);
+    let svrResponse;
+    if (edition.toLowerCase() === "java") {
+      svrResponse = await status(url.hostname, Number(url.port));
+    } else if (edition.toLowerCase() === "bedrock") {
+      svrResponse = await statusBedrock(url.hostname, Number(url.port));
+    }
     res.status(200).send({
-      version: pingResponse.version.name,
+      version: svrResponse.version.name,
       online: true,
-      players: pingResponse.players,
+      players: svrResponse.players,
     });
   } catch (e) {
     if (e) logger.error(e);


### PR DESCRIPTION
## Proposed change
Updates the current Minecraft widget to be able to load status information from bedrock edition servers also.

Changes:
- switched to [minecraft-server-util-dist](https://www.npmjs.com/package/minecraft-server-util-dist) instead of minecraft-ping-js since minecraft-server-util-dist supports both java and bedrock edition whereas minecraft-ping-js only supports java edition.
- also added the use of a field called 'edition' (see examples below) for users to specify which minecraft edition they are querying. If this field is not specified then the edition will default to java. 
```
- Minecraft Java:
        widget:
            type: minecraft
            url: udp://192.168.1.50:25565
            edition: java

- Minecraft Bedrock:
        widget:
            type: minecraft
            url: udp://192.168.1.51:19132
            edition: bedrock
```
- Updated documentation of the minecraft widget.

Tested my changes against vanilla Minecraft servers, both bedrock and java, that I have selfhosted locally in my network. Also tested against public java and bedrock servers I found [here](https://findmcserver.com/). See image below.

![MC-Test](https://github.com/gethomepage/homepage/assets/30556267/dd1b9644-2893-43d2-b7de-6d235402e2f0)

Config used from screenshot above:
```
---
- Minecraft Servers - Selfhosted:
    - Java - Selfhosted - Ubuntu Server - Without Edition:
        widget:
            type: minecraft
            url: udp://192.168.1.50:25565
    - Java - Selfhosted - Ubuntu Server - With Edition:
        widget:
            type: minecraft
            url: udp://192.168.1.50:25565
            edition: JAVA
    - Bedrock - Selfhosted - Ubuntu Server:
        widget:
            type: minecraft
            url: udp://192.168.1.51:19132
            edition: bedrock

- Minecraft Java Servers - Public:
    - MINR.ORG:
        widget:
            type: minecraft
            url: udp://zero.minr.org:25565
    - TogehterCrafg:
        widget:
            type: minecraft
            url: udp://play.togethercraft.online:25565
            edition: java
    - Simple Survival:
        widget:
            type: minecraft
            url: udp://mc.simplesurvival.gg:25565
            edition: java

- Minecraft Bedrock Servers - Public:
    - Lifeboatt:
        widget:
            type: minecraft
            url: udp://play.lbsg.net:19132
            edition: BEDROCK
    - GamesMC:
        widget:
            type: minecraft
            url: udp://gamesmc.de:19132
            edition: bedrock
    - Minehaus:
        widget:
            type: minecraft
            url: udp://play.mineha.us:19132
            edition: bedrock
```
## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
