### PR TITLE
Documentation: Update authentik api key info

### DIFF
--- a/docs/widgets/services/authentik.md
+++ b/docs/widgets/services/authentik.md
@@ -16,6 +16,12 @@ You will need to generate an API token for an existing user. To do so follow the
 5. Click the Create button on the dialog
 6. Click the copy button on the far right of the newly created API Token
 
+The account you made the API-key for also need the following **Assigned global permissions** in Authentik:
+* authentik Core
+  * User
+* authentik Events
+  * Event 
+
 Allowed fields: `["users", "loginsLast24H", "failedLoginsLast24H"]`.
 
 ```yaml

--- a/docs/widgets/services/authentik.md
+++ b/docs/widgets/services/authentik.md
@@ -7,16 +7,10 @@ Learn more about [Authentik](https://github.com/goauthentik/authentik).
 
 This widget reads the number of active users in the system, as well as logins for the last 24 hours.
 
-You will need to generate an API token for an existing user. To do so follow these steps:
+You will need to generate an API token for an existing user under `Admin Portal` > `Directory` > `Tokens & App passwords`.
+Make sure to set Intent to "API Token".
 
-1. Navigate to the Authentik Admin Portal
-2. Expand Directory, the click Tokens & App passwords
-3. Click the Create button
-4. Fill out the dialog making sure to set Intent to API Token
-5. Click the Create button on the dialog
-6. Click the copy button on the far right of the newly created API Token
-
-The account you made the API-key for also need the following **Assigned global permissions** in Authentik:
+The account you made the API token for also needs the following **Assigned global permissions** in Authentik:
 
 - authentik Core
   - User

--- a/docs/widgets/services/authentik.md
+++ b/docs/widgets/services/authentik.md
@@ -17,10 +17,11 @@ You will need to generate an API token for an existing user. To do so follow the
 6. Click the copy button on the far right of the newly created API Token
 
 The account you made the API-key for also need the following **Assigned global permissions** in Authentik:
-* authentik Core
-  * User
-* authentik Events
-  * Event 
+
+- authentik Core
+  - User
+- authentik Events
+  - Event
 
 Allowed fields: `["users", "loginsLast24H", "failedLoginsLast24H"]`.
 


### PR DESCRIPTION
## Proposed change

Add more information about what permissions are needed for the widget to retreive the fields it is intended to retrieve from Authentik.

Background for this is i wasted quite a bit of time figuring this out, and don't want a service account that retrieves statistics having more permissions than necessary.
