### PR TITLE
Enhancement: option to show user for Tautulli and Emby/Jellyfin widgets

### DIFF
--- a/docs/widgets/services/emby.md
+++ b/docs/widgets/services/emby.md
@@ -16,4 +16,5 @@ widget:
   key: apikeyapikeyapikeyapikeyapikey
   enableBlocks: true # optional, defaults to false
   enableNowPlaying: true # optional, defaults to true
+  enableUser: true # optional, defaults to false
 ```

--- a/docs/widgets/services/plex-tautulli.md
+++ b/docs/widgets/services/plex-tautulli.md
@@ -14,4 +14,5 @@ widget:
   type: tautulli
   url: http://tautulli.host.or.ip
   key: apikeyapikeyapikeyapikeyapikey
+  enableUser: true # optional, defaults to false
 ```

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -526,10 +526,7 @@ export function cleanServiceGroups(groups) {
         }
         if (["tautulli"].includes(type)) {
           if (enableUser !== undefined) { 
-            cleanedService.widget.enableUser = JSON.parse(enableUser);
-          } 
-          else { 
-            cleanedService.widget.enableUser = false;
+            cleanedService.widget.enableUser = !!JSON.parse(enableUser);
           }
         }
         if (["sonarr", "radarr"].includes(type)) {

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -520,12 +520,12 @@ export function cleanServiceGroups(groups) {
         if (["emby", "jellyfin"].includes(type)) {
           if (enableBlocks !== undefined) cleanedService.widget.enableBlocks = JSON.parse(enableBlocks);
           if (enableNowPlaying !== undefined) cleanedService.widget.enableNowPlaying = JSON.parse(enableNowPlaying);
-          if (enableUser !== undefined) { 
+          if (enableUser !== undefined) {
             cleanedService.widget.enableUser = !!JSON.parse(enableUser);
           }
         }
         if (["tautulli"].includes(type)) {
-          if (enableUser !== undefined) { 
+          if (enableUser !== undefined) {
             cleanedService.widget.enableUser = !!JSON.parse(enableUser);
           }
         }

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -393,6 +393,9 @@ export function cleanServiceGroups(groups) {
           enableBlocks,
           enableNowPlaying,
 
+          // emby, jellyfin, tautulli
+          enableUser,
+
           // glances, pihole
           version,
 
@@ -517,6 +520,20 @@ export function cleanServiceGroups(groups) {
         if (["emby", "jellyfin"].includes(type)) {
           if (enableBlocks !== undefined) cleanedService.widget.enableBlocks = JSON.parse(enableBlocks);
           if (enableNowPlaying !== undefined) cleanedService.widget.enableNowPlaying = JSON.parse(enableNowPlaying);
+          if (enableUser !== undefined) { 
+            cleanedService.widget.enableUser = JSON.parse(enableUser);
+          } 
+          else { 
+            cleanedService.widget.enableUser = false;
+          }
+        }
+        if (["tautulli"].includes(type)) {
+          if (enableUser !== undefined) { 
+            cleanedService.widget.enableUser = JSON.parse(enableUser);
+          } 
+          else { 
+            cleanedService.widget.enableUser = false;
+          }
         }
         if (["sonarr", "radarr"].includes(type)) {
           if (enableQueue !== undefined) cleanedService.widget.enableQueue = JSON.parse(enableQueue);

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -521,10 +521,7 @@ export function cleanServiceGroups(groups) {
           if (enableBlocks !== undefined) cleanedService.widget.enableBlocks = JSON.parse(enableBlocks);
           if (enableNowPlaying !== undefined) cleanedService.widget.enableNowPlaying = JSON.parse(enableNowPlaying);
           if (enableUser !== undefined) { 
-            cleanedService.widget.enableUser = JSON.parse(enableUser);
-          } 
-          else { 
-            cleanedService.widget.enableUser = false;
+            cleanedService.widget.enableUser = !!JSON.parse(enableUser);
           }
         }
         if (["tautulli"].includes(type)) {

--- a/src/widgets/emby/component.jsx
+++ b/src/widgets/emby/component.jsx
@@ -27,10 +27,11 @@ function ticksToString(ticks) {
   return parts.map((part) => part.toString().padStart(2, "0")).join(":");
 }
 
-function SingleSessionEntry({ playCommand, session }) {
+function SingleSessionEntry({ playCommand, session, enableUser }) {
   const {
     NowPlayingItem: { Name, SeriesName },
     PlayState: { PositionTicks, IsPaused, IsMuted },
+    UserName,
   } = session;
 
   const RunTimeTicks =
@@ -49,6 +50,7 @@ function SingleSessionEntry({ playCommand, session }) {
           <div className="absolute w-full whitespace-nowrap text-ellipsis overflow-hidden">
             {Name}
             {SeriesName && ` - ${SeriesName}`}
+            {enableUser && ` (${UserName})`}
           </div>
         </div>
         <div className="self-center text-xs flex justify-end mr-1.5 pl-1">
@@ -97,10 +99,11 @@ function SingleSessionEntry({ playCommand, session }) {
   );
 }
 
-function SessionEntry({ playCommand, session }) {
+function SessionEntry({ playCommand, session, enableUser }) {
   const {
     NowPlayingItem: { Name, SeriesName },
     PlayState: { PositionTicks, IsPaused, IsMuted },
+    UserName,
   } = session;
 
   const RunTimeTicks =
@@ -142,6 +145,7 @@ function SessionEntry({ playCommand, session }) {
         <div className="absolute w-full whitespace-nowrap text-ellipsis overflow-hidden">
           {Name}
           {SeriesName && ` - ${SeriesName}`}
+          {enableUser && ` (${UserName})`}
         </div>
       </div>
       <div className="self-center text-xs flex justify-end mr-1 z-10">{IsMuted && <BsVolumeMuteFill />}</div>
@@ -215,6 +219,7 @@ export default function Component({ service }) {
 
   const enableBlocks = service.widget?.enableBlocks;
   const enableNowPlaying = service.widget?.enableNowPlaying ?? true;
+  const enableUser = service.widget?.enableUser ?? true;
 
   if (!sessionsData || !countData) {
     return (
@@ -272,6 +277,7 @@ export default function Component({ service }) {
             <SingleSessionEntry
               playCommand={(currentSession, command) => handlePlayCommand(currentSession, command)}
               session={session}
+              enableUser={enableUser}
             />
           </div>
         </>
@@ -288,6 +294,7 @@ export default function Component({ service }) {
                 key={session.Id}
                 playCommand={(currentSession, command) => handlePlayCommand(currentSession, command)}
                 session={session}
+                enableUser={enableUser}
               />
             ))}
           </div>

--- a/src/widgets/emby/component.jsx
+++ b/src/widgets/emby/component.jsx
@@ -219,7 +219,7 @@ export default function Component({ service }) {
 
   const enableBlocks = service.widget?.enableBlocks;
   const enableNowPlaying = service.widget?.enableNowPlaying ?? true;
-  const enableUser = service.widget?.enableUser ?? true;
+  const enableUser = !!service.widget?.enableUser;
 
   if (!sessionsData || !countData) {
     return (

--- a/src/widgets/tautulli/component.jsx
+++ b/src/widgets/tautulli/component.jsx
@@ -25,14 +25,17 @@ function millisecondsToString(milliseconds) {
   return parts.map((part) => part.toString().padStart(2, "0")).join(":");
 }
 
-function SingleSessionEntry({ session }) {
-  const { full_title, duration, view_offset, progress_percent, state, video_decision, audio_decision } = session;
+function SingleSessionEntry({ session, enableUser }) {
+  const { full_title, duration, view_offset, progress_percent, state, video_decision, audio_decision, username } = session;
 
   return (
     <>
       <div className="text-theme-700 dark:text-theme-200 relative h-5 w-full rounded-md bg-theme-200/50 dark:bg-theme-900/20 mt-1 flex">
         <div className="text-xs z-10 self-center ml-2 relative w-full h-4 grow mr-2">
-          <div className="absolute w-full whitespace-nowrap text-ellipsis overflow-hidden">{full_title}</div>
+          <div className="absolute w-full whitespace-nowrap text-ellipsis overflow-hidden">
+            {full_title}
+            {enableUser && ` (${username})`}
+          </div>
         </div>
         <div className="self-center text-xs flex justify-end mr-1.5 pl-1">
           {video_decision === "direct play" && audio_decision === "direct play" && (
@@ -74,8 +77,8 @@ function SingleSessionEntry({ session }) {
   );
 }
 
-function SessionEntry({ session }) {
-  const { full_title, view_offset, progress_percent, state, video_decision, audio_decision } = session;
+function SessionEntry({ session, enableUser }) {
+  const { full_title, view_offset, progress_percent, state, video_decision, audio_decision, username } = session;
 
   return (
     <div className="text-theme-700 dark:text-theme-200 relative h-5 w-full rounded-md bg-theme-200/50 dark:bg-theme-900/20 mt-1 flex">
@@ -94,7 +97,10 @@ function SessionEntry({ session }) {
         )}
       </div>
       <div className="text-xs z-10 self-center ml-2 relative w-full h-4 grow mr-2">
-        <div className="absolute w-full whitespace-nowrap text-ellipsis overflow-hidden">{full_title}</div>
+        <div className="absolute w-full whitespace-nowrap text-ellipsis overflow-hidden">
+          {full_title}
+          {enableUser && ` (${username})`}
+        </div>
       </div>
       <div className="self-center text-xs flex justify-end mr-1.5 pl-1 z-10">
         {video_decision === "direct play" && audio_decision === "direct play" && (
@@ -162,11 +168,13 @@ export default function Component({ service }) {
     );
   }
 
+  const enableUser = service.widget?.enableUser ?? true;
+
   if (playing.length === 1) {
     const session = playing[0];
     return (
       <div className="flex flex-col pb-1 mx-1">
-        <SingleSessionEntry session={session} />
+        <SingleSessionEntry session={session} enableUser={enableUser}/>
       </div>
     );
   }
@@ -174,7 +182,7 @@ export default function Component({ service }) {
   return (
     <div className="flex flex-col pb-1 mx-1">
       {playing.map((session) => (
-        <SessionEntry key={session.Id} session={session} />
+        <SessionEntry key={session.Id} session={session} enableUser={enableUser}/>
       ))}
     </div>
   );

--- a/src/widgets/tautulli/component.jsx
+++ b/src/widgets/tautulli/component.jsx
@@ -26,7 +26,8 @@ function millisecondsToString(milliseconds) {
 }
 
 function SingleSessionEntry({ session, enableUser }) {
-  const { full_title, duration, view_offset, progress_percent, state, video_decision, audio_decision, username } = session;
+  const { full_title, duration, view_offset, progress_percent, state, video_decision, audio_decision, username } =
+    session;
 
   return (
     <>
@@ -174,7 +175,7 @@ export default function Component({ service }) {
     const session = playing[0];
     return (
       <div className="flex flex-col pb-1 mx-1">
-        <SingleSessionEntry session={session} enableUser={enableUser}/>
+        <SingleSessionEntry session={session} enableUser={enableUser} />
       </div>
     );
   }
@@ -182,7 +183,7 @@ export default function Component({ service }) {
   return (
     <div className="flex flex-col pb-1 mx-1">
       {playing.map((session) => (
-        <SessionEntry key={session.Id} session={session} enableUser={enableUser}/>
+        <SessionEntry key={session.Id} session={session} enableUser={enableUser} />
       ))}
     </div>
   );

--- a/src/widgets/tautulli/component.jsx
+++ b/src/widgets/tautulli/component.jsx
@@ -168,7 +168,7 @@ export default function Component({ service }) {
     );
   }
 
-  const enableUser = service.widget?.enableUser ?? true;
+  const enableUser = !!service.widget?.enableUser;
 
   if (playing.length === 1) {
     const session = playing[0];


### PR DESCRIPTION
## Proposed change

Added a new optional flag that can be added to the widget enableUser. If true the username will be added in parenthesis behind the title. Updated the documentation stating that this is an optional field and defaults to false.

![TautulliEmbyJellyfinUsername](https://github.com/gethomepage/homepage/assets/3686683/0d3585ff-408c-45a7-8964-98b574d77042)
![TautulliJellyfinEnableUserConfig](https://github.com/gethomepage/homepage/assets/3686683/07b03235-2591-44bb-b9c3-1bfcfe90e1e2)

Closes #1233  #151 

## Type of change

<!--
Added an optional enableUser flag that displays the User name in parenthesis behind the title.
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
