### PR TITLE
docs: Set key to default value for peanut

### DIFF
--- a/docs/widgets/services/peanut.md
+++ b/docs/widgets/services/peanut.md
@@ -19,5 +19,5 @@ Allowed fields: `["battery_charge", "ups_load", "ups_status"]`.
 widget:
   type: peanut
   url: http://peanut.host.or.ip:port
-  key: nameofyourups
+  key: ups
 ```


### PR DESCRIPTION


## Proposed change

This PR
- Updates peanut docs to improve UX

As noted in the document, the default name is `ups` and unlikely to change in the future. Consider hardcoding this value in the integration.

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
