### PR TITLE
Fix: pihole `ads_percentage_today` sometimes returned as string

### DIFF
--- a/src/widgets/pihole/component.jsx
+++ b/src/widgets/pihole/component.jsx
@@ -32,7 +32,7 @@ export default function Component({ service }) {
 
   let blockedValue = `${t("common.number", { value: parseInt(piholeData.ads_blocked_today, 10) })}`;
   if (!widget.fields.includes("blocked_percent")) {
-    blockedValue += ` (${t("common.percent", { value: parseFloat(piholeData.ads_percentage_today.toPrecision(3)) })})`;
+    blockedValue += ` (${t("common.percent", { value: parseFloat(piholeData.ads_percentage_today).toPrecision(3) })})`;
   }
 
   return (
@@ -41,7 +41,7 @@ export default function Component({ service }) {
       <Block label="pihole.blocked" value={blockedValue} />
       <Block
         label="pihole.blocked_percent"
-        value={t("common.percent", { value: parseFloat(piholeData.ads_percentage_today.toPrecision(3)) })}
+        value={t("common.percent", { value: parseFloat(piholeData.ads_percentage_today).toPrecision(3) })}
       />
       <Block
         label="pihole.gravity"


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

Closes #3312

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
