### PR TITLE
Documentation: correct Medusa link

### DIFF
--- a/docs/widgets/services/medusa.md
+++ b/docs/widgets/services/medusa.md
@@ -3,7 +3,7 @@ title: Medusa
 description: Medusa Widget Configuration
 ---
 
-Learn more about [Medusa](https://github.com/medusajs/medusa).
+Learn more about [Medusa](https://github.com/pymedusa/Medusa).
 
 Allowed fields: `["wanted", "queued", "series"]`.
 


### PR DESCRIPTION
## Proposed change

Fix repo link for Medusa, using the wrong Medusa Project


## Type of change


Fixes Wrong Link in Documentation


- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ x] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
