### PR TITLE
Enhancement: configurable CPU temp scale

### DIFF
--- a/docs/widgets/info/resources.md
+++ b/docs/widgets/info/resources.md
@@ -19,6 +19,8 @@ _Note: unfortunately, the package used for getting CPU temp ([systeminformation]
     memory: true
     disk: /disk/mount/path
     cputemp: true
+    tempmin: 0 # optional, minimum cpu temp
+    tempmax: 100 # optional, maximum cpu temp
     uptime: true
     units: imperial # only used by cpu temp
     refresh: 3000 # optional, in ms

--- a/src/components/widgets/resources/cputemp.jsx
+++ b/src/components/widgets/resources/cputemp.jsx
@@ -9,7 +9,7 @@ function convertToFahrenheit(t) {
   return (t * 9) / 5 + 32;
 }
 
-export default function CpuTemp({ expanded, units, refresh = 1500 }) {
+export default function CpuTemp({ expanded, units, refresh = 1500, tempmin = 0, tempmax = -1 }) {
   const { t } = useTranslation();
 
   const { data, error } = useSWR(`/api/widgets/resources?type=cputemp`, {
@@ -39,7 +39,12 @@ export default function CpuTemp({ expanded, units, refresh = 1500 }) {
   }
   const unit = units === "imperial" ? "fahrenheit" : "celsius";
   mainTemp = unit === "celsius" ? mainTemp : convertToFahrenheit(mainTemp);
-  const maxTemp = unit === "celsius" ? data.cputemp.max : convertToFahrenheit(data.cputemp.max);
+
+  const minTemp = tempmin < mainTemp ? tempmin : mainTemp;
+  let maxTemp = tempmax;
+  if(maxTemp < minTemp) {
+    maxTemp = unit === "celsius" ? data.cputemp.max : convertToFahrenheit(data.cputemp.max);
+  }
 
   return (
     <Resource
@@ -58,7 +63,7 @@ export default function CpuTemp({ expanded, units, refresh = 1500 }) {
         unit,
       })}
       expandedLabel={t("resources.max")}
-      percentage={Math.round((mainTemp / maxTemp) * 100)}
+      percentage={Math.round(((mainTemp - minTemp) / (maxTemp - minTemp)) * 100)}
       expanded={expanded}
     />
   );

--- a/src/components/widgets/resources/cputemp.jsx
+++ b/src/components/widgets/resources/cputemp.jsx
@@ -42,7 +42,7 @@ export default function CpuTemp({ expanded, units, refresh = 1500, tempmin = 0, 
 
   const minTemp = tempmin < mainTemp ? tempmin : mainTemp;
   let maxTemp = tempmax;
-  if(maxTemp < minTemp) {
+  if (maxTemp < minTemp) {
     maxTemp = unit === "celsius" ? data.cputemp.max : convertToFahrenheit(data.cputemp.max);
   }
 

--- a/src/components/widgets/resources/resources.jsx
+++ b/src/components/widgets/resources/resources.jsx
@@ -23,7 +23,9 @@ export default function Resources({ options }) {
                 <Disk key={disk} options={{ disk }} expanded={expanded} diskUnits={diskUnits} refresh={refresh} />
               ))
             : options.disk && <Disk options={options} expanded={expanded} diskUnits={diskUnits} refresh={refresh} />}
-          {options.cputemp && <CpuTemp expanded={expanded} units={units} refresh={refresh} tempmin={tempmin} tempmax={tempmax} />}
+          {options.cputemp && (
+            <CpuTemp expanded={expanded} units={units} refresh={refresh} tempmin={tempmin} tempmax={tempmax} />
+          )}
           {options.uptime && <Uptime refresh={refresh} />}
         </div>
         {options.label && (

--- a/src/components/widgets/resources/resources.jsx
+++ b/src/components/widgets/resources/resources.jsx
@@ -8,7 +8,7 @@ import CpuTemp from "./cputemp";
 import Uptime from "./uptime";
 
 export default function Resources({ options }) {
-  const { expanded, units, diskUnits } = options;
+  const { expanded, units, diskUnits, tempmin, tempmax } = options;
   let { refresh } = options;
   if (!refresh) refresh = 1500;
   refresh = Math.max(refresh, 1000);
@@ -23,7 +23,7 @@ export default function Resources({ options }) {
                 <Disk key={disk} options={{ disk }} expanded={expanded} diskUnits={diskUnits} refresh={refresh} />
               ))
             : options.disk && <Disk options={options} expanded={expanded} diskUnits={diskUnits} refresh={refresh} />}
-          {options.cputemp && <CpuTemp expanded={expanded} units={units} refresh={refresh} />}
+          {options.cputemp && <CpuTemp expanded={expanded} units={units} refresh={refresh} tempmin={tempmin} tempmax={tempmax} />}
           {options.uptime && <Uptime refresh={refresh} />}
         </div>
         {options.label && (


### PR DESCRIPTION
## Proposed change

Introduces `tempmin` and `tempmax` in **resources/cputemp.jsx** as optional parameters to configure the CPU temperature scale. By default, if no values are provided, the existing heuristic is used (scale from 0 to highest core temp). If `tempmin` and/or `tempmax` are set, the scale will be adjusted accordingly. This allows for a more meaningful scale, that isn't always at 99% for most use cases.

Closes #2478

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
