### PR TITLE
Feature/tautulli jellyfin emby additional configurations

### DIFF
--- a/docs/widgets/services/emby.md
+++ b/docs/widgets/services/emby.md
@@ -17,4 +17,6 @@ widget:
   enableBlocks: true # optional, defaults to false
   enableNowPlaying: true # optional, defaults to true
   enableUser: true # optional, defaults to false
+  showEpisodeNumber: true # optional, defaults to false
+  expandOneStreamToTwoRows: false # optional, defaults to true
 ```

--- a/docs/widgets/services/jellyfin.md
+++ b/docs/widgets/services/jellyfin.md
@@ -16,4 +16,7 @@ widget:
   key: apikeyapikeyapikeyapikeyapikey
   enableBlocks: true # optional, defaults to false
   enableNowPlaying: true # optional, defaults to true
+  enableUser: true # optional, defaults to false
+  showEpisodeNumber: true # optional, defaults to false
+  expandOneStreamToTwoRows: false # optional, defaults to true
 ```

--- a/docs/widgets/services/plex-tautulli.md
+++ b/docs/widgets/services/plex-tautulli.md
@@ -15,4 +15,6 @@ widget:
   url: http://tautulli.host.or.ip
   key: apikeyapikeyapikeyapikeyapikey
   enableUser: true # optional, defaults to false
+  showEpisodeNumber: true # optional, defaults to false
+  expandOneStreamToTwoRows: false # optional, defaults to true
 ```

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -395,6 +395,8 @@ export function cleanServiceGroups(groups) {
 
           // emby, jellyfin, tautulli
           enableUser,
+          expandOneStreamToTwoRows,
+          showEpisodeNumber,
 
           // glances, pihole
           version,
@@ -520,11 +522,10 @@ export function cleanServiceGroups(groups) {
         if (["emby", "jellyfin"].includes(type)) {
           if (enableBlocks !== undefined) cleanedService.widget.enableBlocks = JSON.parse(enableBlocks);
           if (enableNowPlaying !== undefined) cleanedService.widget.enableNowPlaying = JSON.parse(enableNowPlaying);
-          if (enableUser !== undefined) {
-            cleanedService.widget.enableUser = !!JSON.parse(enableUser);
-          }
         }
-        if (["tautulli"].includes(type)) {
+        if (["emby", "jellyfin", "tautulli"].includes(type)) {
+          if (expandOneStreamToTwoRows !== undefined) cleanedService.widget.expandOneStreamToTwoRows = !!JSON.parse(expandOneStreamToTwoRows);
+          if (showEpisodeNumber !== undefined) cleanedService.widget.showEpisodeNumber = !!JSON.parse(showEpisodeNumber);
           if (enableUser !== undefined) {
             cleanedService.widget.enableUser = !!JSON.parse(enableUser);
           }

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -526,9 +526,7 @@ export function cleanServiceGroups(groups) {
         if (["emby", "jellyfin", "tautulli"].includes(type)) {
           if (expandOneStreamToTwoRows !== undefined) cleanedService.widget.expandOneStreamToTwoRows = !!JSON.parse(expandOneStreamToTwoRows);
           if (showEpisodeNumber !== undefined) cleanedService.widget.showEpisodeNumber = !!JSON.parse(showEpisodeNumber);
-          if (enableUser !== undefined) {
-            cleanedService.widget.enableUser = !!JSON.parse(enableUser);
-          }
+          if (enableUser !== undefined) cleanedService.widget.enableUser = !!JSON.parse(enableUser);
         }
         if (["sonarr", "radarr"].includes(type)) {
           if (enableQueue !== undefined) cleanedService.widget.enableQueue = JSON.parse(enableQueue);

--- a/src/widgets/emby/component.jsx
+++ b/src/widgets/emby/component.jsx
@@ -33,7 +33,7 @@ function generateStreamTitle(session, showEpisodeNumber) {
   } = session;
 
   if (Type === "Episode" && showEpisodeNumber) {
-    return `${SeriesName} - S${ParentIndexNumber.toString().padStart(2, "0")}E${IndexNumber.toString().padStart(2, "0")} - ${Name}`;
+    return `${SeriesName} - S${ParentIndexNumber.toString().padStart(2, "0")} · E${IndexNumber.toString().padStart(2, "0")} - ${Name}`;
   }
 
   return `${Name}${SeriesName ? ` - ${SeriesName}` : ""}`;

--- a/src/widgets/emby/component.jsx
+++ b/src/widgets/emby/component.jsx
@@ -27,7 +27,7 @@ function ticksToString(ticks) {
   return parts.map((part) => part.toString().padStart(2, "0")).join(":");
 }
 
-function generateSeriesTitle(session, showEpisodeNumber) {
+function generateStreamTitle(session, showEpisodeNumber) {
   const {
     NowPlayingItem: { Name, SeriesName, Type, ParentIndexNumber, IndexNumber },
   } = session;
@@ -54,13 +54,13 @@ function SingleSessionEntry({ playCommand, session, enableUser, showEpisodeNumbe
 
   const percent = Math.min(1, PositionTicks / RunTimeTicks) * 100;
 
-  const seriesTitle = generateSeriesTitle(session, enableUser, showEpisodeNumber);
+  const streamTitle = generateStreamTitle(session, enableUser, showEpisodeNumber);
   return (
     <>
       <div className="text-theme-700 dark:text-theme-200 relative h-5 w-full rounded-md bg-theme-200/50 dark:bg-theme-900/20 mt-1 flex">
         <div className="grow text-xs z-10 self-center ml-2 relative w-full h-4 mr-2">
           <div className="absolute w-full whitespace-nowrap text-ellipsis overflow-hidden">
-            {seriesTitle}
+            {streamTitle}
             {enableUser && ` (${UserName})`}
           </div>
         </div>
@@ -123,7 +123,7 @@ function SessionEntry({ playCommand, session, enableUser, showEpisodeNumber }) {
     IsVideoDirect: true,
   }; // if no transcodinginfo its videodirect
 
-  const seriesTitle = generateSeriesTitle(session, enableUser, showEpisodeNumber);
+  const streamTitle = generateStreamTitle(session, enableUser, showEpisodeNumber);
 
   const percent = Math.min(1, PositionTicks / RunTimeTicks) * 100;
 
@@ -155,7 +155,7 @@ function SessionEntry({ playCommand, session, enableUser, showEpisodeNumber }) {
       </div>
       <div className="grow text-xs z-10 self-center relative w-full h-4">
         <div className="absolute w-full whitespace-nowrap text-ellipsis overflow-hidden">
-          {seriesTitle}
+          {streamTitle}
           {enableUser && ` (${UserName})`}
         </div>
       </div>


### PR DESCRIPTION
## Proposed change

Adds the following services widget options to Tautulli and Emby (includes Jellyfin)
- `expandOneStreamToTwoRows` 
  - *optional* default to true
  - functionality: currently expands one stream to two rows (top row is media details and bottom is media progress bar). This includes making 2 rows when there are 0 streams. When set to false, it will at most show 1 row saying "No Active Streams". 
- `showEpisodeNumber`
  - *optional* default to false
  - functionality: would check the media type and if it is an episode type, would grab the episode number and display it right before the episode title and right after the show title
  - e.g. `show_title`: `episode_number` - `episode_title`

### Examples for the following options:
- `showEpisodeNumber`: true
- `expandOneStreamToTwoRows`: false
- `enableUser`: true

#### No streams
![image](https://github.com/gethomepage/homepage/assets/24537535/b504c37e-6448-474a-9c00-e19117f6ff23)

#### One stream
![image](https://github.com/gethomepage/homepage/assets/24537535/255ca4ca-9c8a-4c39-b9eb-7f7732344c51)

Closes #3337 (issue)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
