### PR TITLE
Documentation: authentik fine-grained permissions

### DIFF
--- a/docs/widgets/services/authentik.md
+++ b/docs/widgets/services/authentik.md
@@ -12,10 +12,8 @@ Make sure to set Intent to "API Token".
 
 The account you made the API token for also needs the following **Assigned global permissions** in Authentik:
 
-- authentik Core
-  - User
-- authentik Events
-  - Event
+- authentik Core -> Can view User (Model: User)
+- authentik Events -> Can view Event (Model: Event)
 
 Allowed fields: `["users", "loginsLast24H", "failedLoginsLast24H"]`.
 


### PR DESCRIPTION
## Proposed change

Edits the documentation around Authentik to use fine-grained permissions since the widget only needs read access to Users and Events. The current documentation around these permissions are vague and could lead to people giving the widget unnecessary access.

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
