### PR TITLE
Enhancement: additional tautulli jellyfin emby configuration options

### DIFF
--- a/docs/widgets/services/emby.md
+++ b/docs/widgets/services/emby.md
@@ -17,4 +17,6 @@ widget:
   enableBlocks: true # optional, defaults to false
   enableNowPlaying: true # optional, defaults to true
   enableUser: true # optional, defaults to false
+  showEpisodeNumber: true # optional, defaults to false
+  expandOneStreamToTwoRows: false # optional, defaults to true
 ```

--- a/docs/widgets/services/jellyfin.md
+++ b/docs/widgets/services/jellyfin.md
@@ -16,4 +16,7 @@ widget:
   key: apikeyapikeyapikeyapikeyapikey
   enableBlocks: true # optional, defaults to false
   enableNowPlaying: true # optional, defaults to true
+  enableUser: true # optional, defaults to false
+  showEpisodeNumber: true # optional, defaults to false
+  expandOneStreamToTwoRows: false # optional, defaults to true
 ```

--- a/docs/widgets/services/plex-tautulli.md
+++ b/docs/widgets/services/plex-tautulli.md
@@ -15,4 +15,6 @@ widget:
   url: http://tautulli.host.or.ip
   key: apikeyapikeyapikeyapikeyapikey
   enableUser: true # optional, defaults to false
+  showEpisodeNumber: true # optional, defaults to false
+  expandOneStreamToTwoRows: false # optional, defaults to true
 ```

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -395,6 +395,8 @@ export function cleanServiceGroups(groups) {
 
           // emby, jellyfin, tautulli
           enableUser,
+          expandOneStreamToTwoRows,
+          showEpisodeNumber,
 
           // glances, pihole
           version,
@@ -520,11 +522,10 @@ export function cleanServiceGroups(groups) {
         if (["emby", "jellyfin"].includes(type)) {
           if (enableBlocks !== undefined) cleanedService.widget.enableBlocks = JSON.parse(enableBlocks);
           if (enableNowPlaying !== undefined) cleanedService.widget.enableNowPlaying = JSON.parse(enableNowPlaying);
-          if (enableUser !== undefined) {
-            cleanedService.widget.enableUser = !!JSON.parse(enableUser);
-          }
         }
-        if (["tautulli"].includes(type)) {
+        if (["emby", "jellyfin", "tautulli"].includes(type)) {
+          if (expandOneStreamToTwoRows !== undefined) cleanedService.widget.expandOneStreamToTwoRows = !!JSON.parse(expandOneStreamToTwoRows);
+          if (showEpisodeNumber !== undefined) cleanedService.widget.showEpisodeNumber = !!JSON.parse(showEpisodeNumber);
           if (enableUser !== undefined) {
             cleanedService.widget.enableUser = !!JSON.parse(enableUser);
           }

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -526,9 +526,7 @@ export function cleanServiceGroups(groups) {
         if (["emby", "jellyfin", "tautulli"].includes(type)) {
           if (expandOneStreamToTwoRows !== undefined) cleanedService.widget.expandOneStreamToTwoRows = !!JSON.parse(expandOneStreamToTwoRows);
           if (showEpisodeNumber !== undefined) cleanedService.widget.showEpisodeNumber = !!JSON.parse(showEpisodeNumber);
-          if (enableUser !== undefined) {
-            cleanedService.widget.enableUser = !!JSON.parse(enableUser);
-          }
+          if (enableUser !== undefined) cleanedService.widget.enableUser = !!JSON.parse(enableUser);
         }
         if (["sonarr", "radarr"].includes(type)) {
           if (enableQueue !== undefined) cleanedService.widget.enableQueue = JSON.parse(enableQueue);

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -524,8 +524,10 @@ export function cleanServiceGroups(groups) {
           if (enableNowPlaying !== undefined) cleanedService.widget.enableNowPlaying = JSON.parse(enableNowPlaying);
         }
         if (["emby", "jellyfin", "tautulli"].includes(type)) {
-          if (expandOneStreamToTwoRows !== undefined) cleanedService.widget.expandOneStreamToTwoRows = !!JSON.parse(expandOneStreamToTwoRows);
-          if (showEpisodeNumber !== undefined) cleanedService.widget.showEpisodeNumber = !!JSON.parse(showEpisodeNumber);
+          if (expandOneStreamToTwoRows !== undefined)
+            cleanedService.widget.expandOneStreamToTwoRows = !!JSON.parse(expandOneStreamToTwoRows);
+          if (showEpisodeNumber !== undefined)
+            cleanedService.widget.showEpisodeNumber = !!JSON.parse(showEpisodeNumber);
           if (enableUser !== undefined) cleanedService.widget.enableUser = !!JSON.parse(enableUser);
         }
         if (["sonarr", "radarr"].includes(type)) {

--- a/src/widgets/emby/component.jsx
+++ b/src/widgets/emby/component.jsx
@@ -33,7 +33,7 @@ function generateStreamTitle(session, showEpisodeNumber) {
   } = session;
 
   if (Type === "Episode" && showEpisodeNumber) {
-    return `${SeriesName} - S${ParentIndexNumber.toString().padStart(2, "0")} · E${IndexNumber.toString().padStart(2, "0")} - ${Name}`;
+    return `${SeriesName}: S${ParentIndexNumber.toString().padStart(2, "0")} · E${IndexNumber.toString().padStart(2, "0")} - ${Name}`;
   }
 
   return `${Name}${SeriesName ? ` - ${SeriesName}` : ""}`;

--- a/src/widgets/emby/component.jsx
+++ b/src/widgets/emby/component.jsx
@@ -27,22 +27,25 @@ function ticksToString(ticks) {
   return parts.map((part) => part.toString().padStart(2, "0")).join(":");
 }
 
-function generateStreamTitle(session, showEpisodeNumber) {
+function generateStreamTitle(session, enableUser, showEpisodeNumber) {
   const {
     NowPlayingItem: { Name, SeriesName, Type, ParentIndexNumber, IndexNumber },
+    UserName,
   } = session;
+  let streamTitle = "";
 
   if (Type === "Episode" && showEpisodeNumber) {
-    return `${SeriesName}: S${ParentIndexNumber.toString().padStart(2, "0")} · E${IndexNumber.toString().padStart(2, "0")} - ${Name}`;
+    streamTitle = `${SeriesName}: S${ParentIndexNumber.toString().padStart(2, "0")} · E${IndexNumber.toString().padStart(2, "0")} - ${Name}`;
+  } else {
+    streamTitle = `${Name}${SeriesName ? ` - ${SeriesName}` : ""}`;
   }
 
-  return `${Name}${SeriesName ? ` - ${SeriesName}` : ""}`;
+  return enableUser ? `${streamTitle} (${UserName})` : streamTitle;
 }
 
 function SingleSessionEntry({ playCommand, session, enableUser, showEpisodeNumber }) {
   const {
     PlayState: { PositionTicks, IsPaused, IsMuted },
-    UserName,
   } = session;
 
   const RunTimeTicks =
@@ -59,9 +62,8 @@ function SingleSessionEntry({ playCommand, session, enableUser, showEpisodeNumbe
     <>
       <div className="text-theme-700 dark:text-theme-200 relative h-5 w-full rounded-md bg-theme-200/50 dark:bg-theme-900/20 mt-1 flex">
         <div className="grow text-xs z-10 self-center ml-2 relative w-full h-4 mr-2">
-          <div className="absolute w-full whitespace-nowrap text-ellipsis overflow-hidden">
+          <div className="absolute w-full whitespace-nowrap text-ellipsis overflow-hidden" title={streamTitle}>
             {streamTitle}
-            {enableUser && ` (${UserName})`}
           </div>
         </div>
         <div className="self-center text-xs flex justify-end mr-1.5 pl-1">
@@ -113,7 +115,6 @@ function SingleSessionEntry({ playCommand, session, enableUser, showEpisodeNumbe
 function SessionEntry({ playCommand, session, enableUser, showEpisodeNumber }) {
   const {
     PlayState: { PositionTicks, IsPaused, IsMuted },
-    UserName,
   } = session;
 
   const RunTimeTicks =
@@ -154,9 +155,8 @@ function SessionEntry({ playCommand, session, enableUser, showEpisodeNumber }) {
         )}
       </div>
       <div className="grow text-xs z-10 self-center relative w-full h-4">
-        <div className="absolute w-full whitespace-nowrap text-ellipsis overflow-hidden">
+        <div className="absolute w-full whitespace-nowrap text-ellipsis overflow-hidden" title={streamTitle}>
           {streamTitle}
-          {enableUser && ` (${UserName})`}
         </div>
       </div>
       <div className="self-center text-xs flex justify-end mr-1 z-10">{IsMuted && <BsVolumeMuteFill />}</div>

--- a/src/widgets/emby/component.jsx
+++ b/src/widgets/emby/component.jsx
@@ -230,7 +230,7 @@ export default function Component({ service }) {
 
   const enableBlocks = service.widget?.enableBlocks;
   const enableNowPlaying = service.widget?.enableNowPlaying ?? true;
-  const enableUser = !!service.widget?.enableUser; // default is true
+  const enableUser = !!service.widget?.enableUser; // default is false
   const expandOneStreamToTwoRows = service.widget?.expandOneStreamToTwoRows !== false; // default is true
   const showEpisodeNumber = !!service.widget?.showEpisodeNumber; // default is false
 

--- a/src/widgets/emby/component.jsx
+++ b/src/widgets/emby/component.jsx
@@ -33,7 +33,7 @@ function generateStreamTitle(session, showEpisodeNumber) {
   } = session;
 
   if (Type === "Episode" && showEpisodeNumber) {
-    return `${SeriesName} - S${ParentIndexNumber.toString().padStart(2, "0")}E${IndexNumber.toString().padStart(2, "0")} - ${Name}`;
+    return `${SeriesName} - S${ParentIndexNumber.toString().padStart(2, "0")} · E${IndexNumber.toString().padStart(2, "0")} - ${Name}`;
   }
 
   return `${Name}${SeriesName ? ` - ${SeriesName}` : ""}`;

--- a/src/widgets/emby/component.jsx
+++ b/src/widgets/emby/component.jsx
@@ -243,9 +243,11 @@ export default function Component({ service }) {
             <div className="text-theme-700 dark:text-theme-200 text-xs relative h-5 w-full rounded-md bg-theme-200/50 dark:bg-theme-900/20 mt-1">
               <span className="absolute left-2 text-xs mt-[2px]">-</span>
             </div>
-            <div className="text-theme-700 dark:text-theme-200 text-xs relative h-5 w-full rounded-md bg-theme-200/50 dark:bg-theme-900/20 mt-1">
-              <span className="absolute left-2 text-xs mt-[2px]">-</span>
-            </div>
+            {expandOneStreamToTwoRows && (
+              <div className="text-theme-700 dark:text-theme-200 text-xs relative h-5 w-full rounded-md bg-theme-200/50 dark:bg-theme-900/20 mt-1">
+                <span className="absolute left-2 text-xs mt-[2px]">-</span>
+              </div>
+            )}
           </div>
         )}
       </>

--- a/src/widgets/emby/component.jsx
+++ b/src/widgets/emby/component.jsx
@@ -35,7 +35,9 @@ function generateStreamTitle(session, enableUser, showEpisodeNumber) {
   let streamTitle = "";
 
   if (Type === "Episode" && showEpisodeNumber) {
-    streamTitle = `${SeriesName}: S${ParentIndexNumber.toString().padStart(2, "0")} · E${IndexNumber.toString().padStart(2, "0")} - ${Name}`;
+    const seasonStr = `S${ParentIndexNumber.toString().padStart(2, "0")}`;
+    const episodeStr = `E${IndexNumber.toString().padStart(2, "0")}`;
+    streamTitle = `${SeriesName}: ${seasonStr} · ${episodeStr} - ${Name}`;
   } else {
     streamTitle = `${Name}${SeriesName ? ` - ${SeriesName}` : ""}`;
   }
@@ -277,7 +279,7 @@ export default function Component({ service }) {
             </div>
             {expandOneStreamToTwoRows && (
               <div className="text-theme-700 dark:text-theme-200 text-xs relative h-5 w-full rounded-md bg-theme-200/50 dark:bg-theme-900/20 mt-1">
-              <span className="absolute left-2 text-xs mt-[2px]">-</span>
+                <span className="absolute left-2 text-xs mt-[2px]">-</span>
               </div>
             )}
           </div>

--- a/src/widgets/emby/component.jsx
+++ b/src/widgets/emby/component.jsx
@@ -27,7 +27,7 @@ function ticksToString(ticks) {
   return parts.map((part) => part.toString().padStart(2, "0")).join(":");
 }
 
-function generateSeriesTitle(session, showEpisodeNumber) {
+function generateStreamTitle(session, showEpisodeNumber) {
   const {
     NowPlayingItem: { Name, SeriesName, Type, ParentIndexNumber, IndexNumber },
   } = session;
@@ -54,13 +54,13 @@ function SingleSessionEntry({ playCommand, session, enableUser, showEpisodeNumbe
 
   const percent = Math.min(1, PositionTicks / RunTimeTicks) * 100;
 
-  const seriesTitle = generateSeriesTitle(session, enableUser, showEpisodeNumber);
+  const streamTitle = generateStreamTitle(session, enableUser, showEpisodeNumber);
   return (
     <>
       <div className="text-theme-700 dark:text-theme-200 relative h-5 w-full rounded-md bg-theme-200/50 dark:bg-theme-900/20 mt-1 flex">
         <div className="grow text-xs z-10 self-center ml-2 relative w-full h-4 mr-2">
           <div className="absolute w-full whitespace-nowrap text-ellipsis overflow-hidden">
-            {seriesTitle}
+            {streamTitle}
             {enableUser && ` (${UserName})`}
           </div>
         </div>
@@ -123,7 +123,7 @@ function SessionEntry({ playCommand, session, enableUser, showEpisodeNumber }) {
     IsVideoDirect: true,
   }; // if no transcodinginfo its videodirect
 
-  const seriesTitle = generateSeriesTitle(session, enableUser, showEpisodeNumber);
+  const streamTitle = generateStreamTitle(session, enableUser, showEpisodeNumber);
 
   const percent = Math.min(1, PositionTicks / RunTimeTicks) * 100;
 
@@ -155,7 +155,7 @@ function SessionEntry({ playCommand, session, enableUser, showEpisodeNumber }) {
       </div>
       <div className="grow text-xs z-10 self-center relative w-full h-4">
         <div className="absolute w-full whitespace-nowrap text-ellipsis overflow-hidden">
-          {seriesTitle}
+          {streamTitle}
           {enableUser && ` (${UserName})`}
         </div>
       </div>

--- a/src/widgets/tautulli/component.jsx
+++ b/src/widgets/tautulli/component.jsx
@@ -27,14 +27,14 @@ function millisecondsToString(milliseconds) {
 
 function generateStreamTitle(session, enableUser, showEpisodeNumber) {
   let stream_title = "";
-  const { media_type, parent_media_index, media_index, title, grandparent_title, full_title, username } = session;
+  const { media_type, parent_media_index, media_index, title, grandparent_title, full_title, friendly_name } = session;
   if (media_type === "episode" && showEpisodeNumber) {
     stream_title = `${grandparent_title}: S${parent_media_index.toString().padStart(2, "0")} · E${media_index.toString().padStart(2, "0")} - ${title}`;
   } else {
     stream_title = full_title;
   }
 
-  return enableUser ? `${stream_title} (${username})` : stream_title;
+  return enableUser ? `${stream_title} (${friendly_name})` : stream_title;
 }
 
 function SingleSessionEntry({ session, enableUser, showEpisodeNumber }) {

--- a/src/widgets/tautulli/component.jsx
+++ b/src/widgets/tautulli/component.jsx
@@ -29,7 +29,9 @@ function generateStreamTitle(session, enableUser, showEpisodeNumber) {
   let stream_title = "";
   const { media_type, parent_media_index, media_index, title, grandparent_title, full_title, friendly_name } = session;
   if (media_type === "episode" && showEpisodeNumber) {
-    stream_title = `${grandparent_title}: S${parent_media_index.toString().padStart(2, "0")} · E${media_index.toString().padStart(2, "0")} - ${title}`;
+    const season_str = `S${parent_media_index.toString().padStart(2, "0")}`;
+    const episode_str = `E${media_index.toString().padStart(2, "0")}`;
+    stream_title = `${grandparent_title}: ${season_str} · ${episode_str} - ${title}`;
   } else {
     stream_title = full_title;
   }
@@ -38,14 +40,7 @@ function generateStreamTitle(session, enableUser, showEpisodeNumber) {
 }
 
 function SingleSessionEntry({ session, enableUser, showEpisodeNumber }) {
-  const {
-    duration,
-    view_offset,
-    progress_percent,
-    state,
-    video_decision,
-    audio_decision,
-  } = session;
+  const { duration, view_offset, progress_percent, state, video_decision, audio_decision } = session;
 
   const stream_title = generateStreamTitle(session, enableUser, showEpisodeNumber);
 
@@ -98,15 +93,9 @@ function SingleSessionEntry({ session, enableUser, showEpisodeNumber }) {
 }
 
 function SessionEntry({ session, enableUser, showEpisodeNumber }) {
-  const {
-    view_offset,
-    progress_percent,
-    state,
-    video_decision,
-    audio_decision,
-  } = session;
+  const { view_offset, progress_percent, state, video_decision, audio_decision } = session;
 
-  const stream_title = generateStreamTitle(session, enableUser, showEpisodeNumber)
+  const stream_title = generateStreamTitle(session, enableUser, showEpisodeNumber);
 
   return (
     <div className="text-theme-700 dark:text-theme-200 relative h-5 w-full rounded-md bg-theme-200/50 dark:bg-theme-900/20 mt-1 flex">
@@ -215,7 +204,12 @@ export default function Component({ service }) {
   return (
     <div className="flex flex-col pb-1 mx-1">
       {playing.map((session) => (
-        <SessionEntry key={session.Id} session={session} enableUser={enableUser} showEpisodeNumber={showEpisodeNumber} />
+        <SessionEntry
+          key={session.Id}
+          session={session}
+          enableUser={enableUser}
+          showEpisodeNumber={showEpisodeNumber}
+        />
       ))}
     </div>
   );

--- a/src/widgets/tautulli/component.jsx
+++ b/src/widgets/tautulli/component.jsx
@@ -183,7 +183,9 @@ export default function Component({ service }) {
     return 0;
   });
 
+  const enableUser = !!service.widget?.enableUser; // default is false
   const expandOneStreamToTwoRows = service.widget?.expandOneStreamToTwoRows !== false; // default is true
+  const showEpisodeNumber = !!service.widget?.showEpisodeNumber; // default is false
 
   if (playing.length === 0) {
     return (
@@ -199,9 +201,6 @@ export default function Component({ service }) {
       </div>
     );
   }
-
-  const enableUser = !!service.widget?.enableUser; // default is false
-  const showEpisodeNumber = !!service.widget?.showEpisodeNumber; // default is false
 
   if (expandOneStreamToTwoRows && playing.length === 1) {
     const session = playing[0];

--- a/src/widgets/tautulli/component.jsx
+++ b/src/widgets/tautulli/component.jsx
@@ -155,6 +155,10 @@ export default function Component({ service }) {
     refreshInterval: 5000,
   });
 
+  const enableUser = !!service.widget?.enableUser; // default is false
+  const expandOneStreamToTwoRows = service.widget?.expandOneStreamToTwoRows !== false; // default is true
+  const showEpisodeNumber = !!service.widget?.showEpisodeNumber; // default is false
+
   if (activityError || (activityData && Object.keys(activityData.response.data).length === 0)) {
     return <Container service={service} error={activityError ?? { message: t("tautulli.plex_connection_error") }} />;
   }
@@ -165,9 +169,11 @@ export default function Component({ service }) {
         <div className="text-theme-700 dark:text-theme-200 text-xs relative h-5 w-full rounded-md bg-theme-200/50 dark:bg-theme-900/20 mt-1">
           <span className="absolute left-2 text-xs mt-[2px]">-</span>
         </div>
-        <div className="text-theme-700 dark:text-theme-200 text-xs relative h-5 w-full rounded-md bg-theme-200/50 dark:bg-theme-900/20 mt-1">
-          <span className="absolute left-2 text-xs mt-[2px]">-</span>
-        </div>
+        {expandOneStreamToTwoRows && (
+          <div className="text-theme-700 dark:text-theme-200 text-xs relative h-5 w-full rounded-md bg-theme-200/50 dark:bg-theme-900/20 mt-1">
+            <span className="absolute left-2 text-xs mt-[2px]">-</span>
+          </div>
+        )}
       </div>
     );
   }
@@ -181,10 +187,6 @@ export default function Component({ service }) {
     }
     return 0;
   });
-
-  const enableUser = !!service.widget?.enableUser; // default is false
-  const expandOneStreamToTwoRows = service.widget?.expandOneStreamToTwoRows !== false; // default is true
-  const showEpisodeNumber = !!service.widget?.showEpisodeNumber; // default is false
 
   if (playing.length === 0) {
     return (

--- a/src/widgets/tautulli/component.jsx
+++ b/src/widgets/tautulli/component.jsx
@@ -25,13 +25,16 @@ function millisecondsToString(milliseconds) {
   return parts.map((part) => part.toString().padStart(2, "0")).join(":");
 }
 
-function generateStreamTitle(session, showEpisodeNumber) {
-  const { media_type, parent_media_index, media_index, title, grandparent_title, full_title } = session;
+function generateStreamTitle(session, enableUser, showEpisodeNumber) {
+  let stream_title = "";
+  const { media_type, parent_media_index, media_index, title, grandparent_title, full_title, username } = session;
   if (media_type === "episode" && showEpisodeNumber) {
-    return `${grandparent_title}: S${parent_media_index.toString().padStart(2, "0")} · E${media_index.toString().padStart(2, "0")} - ${title}`;
+    stream_title = `${grandparent_title}: S${parent_media_index.toString().padStart(2, "0")} · E${media_index.toString().padStart(2, "0")} - ${title}`;
+  } else {
+    stream_title = full_title;
   }
 
-  return full_title;
+  return enableUser ? `${stream_title} (${username})` : stream_title;
 }
 
 function SingleSessionEntry({ session, enableUser, showEpisodeNumber }) {
@@ -42,18 +45,16 @@ function SingleSessionEntry({ session, enableUser, showEpisodeNumber }) {
     state,
     video_decision,
     audio_decision,
-    username
   } = session;
 
-  const stream_title = generateStreamTitle(session, showEpisodeNumber)
+  const stream_title = generateStreamTitle(session, enableUser, showEpisodeNumber);
 
   return (
     <>
       <div className="text-theme-700 dark:text-theme-200 relative h-5 w-full rounded-md bg-theme-200/50 dark:bg-theme-900/20 mt-1 flex">
         <div className="text-xs z-10 self-center ml-2 relative w-full h-4 grow mr-2">
-          <div className="absolute w-full whitespace-nowrap text-ellipsis overflow-hidden">
+          <div className="absolute w-full whitespace-nowrap text-ellipsis overflow-hidden" title={stream_title}>
             {stream_title}
-            {enableUser && ` (${username})`}
           </div>
         </div>
         <div className="self-center text-xs flex justify-end mr-1.5 pl-1">
@@ -103,10 +104,9 @@ function SessionEntry({ session, enableUser, showEpisodeNumber }) {
     state,
     video_decision,
     audio_decision,
-    username
   } = session;
 
-  const stream_title = generateStreamTitle(session, showEpisodeNumber)
+  const stream_title = generateStreamTitle(session, enableUser, showEpisodeNumber)
 
   return (
     <div className="text-theme-700 dark:text-theme-200 relative h-5 w-full rounded-md bg-theme-200/50 dark:bg-theme-900/20 mt-1 flex">
@@ -125,9 +125,8 @@ function SessionEntry({ session, enableUser, showEpisodeNumber }) {
         )}
       </div>
       <div className="text-xs z-10 self-center ml-2 relative w-full h-4 grow mr-2">
-        <div className="absolute w-full whitespace-nowrap text-ellipsis overflow-hidden">
+        <div className="absolute w-full whitespace-nowrap text-ellipsis overflow-hidden" title={stream_title}>
           {stream_title}
-          {enableUser && ` (${username})`}
         </div>
       </div>
       <div className="self-center text-xs flex justify-end mr-1.5 pl-1 z-10">


### PR DESCRIPTION
## Proposed change

Adds the following service widget options to Tautulli and Emby (includes Jellyfin)
- `expandOneStreamToTwoRows` 
  - *optional* default to true
  - functionality: currently expands one stream to two rows (top row is media details and bottom is media progress bar). This includes making 2 rows when there are 0 streams. When set to false, it will at most show 1 row saying, "No Active Streams". 
- `showEpisodeNumber`
  - *optional* default to false
  - functionality: would check the media type and if it is an episode type, would grab the episode number and display it right before the episode title and right after the show title
  - e.g. `show_title`: `episode_number` - `episode_title`

Also changes username to friendly_name. Noticed that @brikim wanted to make that change on the last PR so thought it would make sense to fit it in on this PR. https://github.com/gethomepage/homepage/pull/3343#discussion_r1573876182

### Examples for the following options:
- `showEpisodeNumber`: true
- `expandOneStreamToTwoRows`: false
- `enableUser`: true

#### No streams
![image](https://github.com/gethomepage/homepage/assets/24537535/b504c37e-6448-474a-9c00-e19117f6ff23)

#### One stream
![image](https://github.com/ameerabdallah/homepage/assets/24537535/0e0c3084-da95-4a81-8b2a-fc8a7c988832)

Closes #3337

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
