### PR TITLE
Enhancement: Change default k8s label selector to be from resource

### DIFF
--- a/src/pages/api/kubernetes/stats/[...service].js
+++ b/src/pages/api/kubernetes/stats/[...service].js
@@ -28,7 +28,7 @@ export default async function handler(req, res) {
       return;
     }
     const coreApi = kc.makeApiClient(CoreV1Api);
-    const labelSelector = podSelector !== undefined ? podSelector : await parseIngressSelector(appName, namespace, kc);
+    const labelSelector = podSelector !== undefined ? podSelector : await parseIngressSelector(appName, namespace, kc, logger);
     const metricsApi = new Metrics(kc);
     const podsResponse = await coreApi
       .listNamespacedPod(namespace, null, null, null, null, labelSelector)

--- a/src/pages/api/kubernetes/status/[...service].js
+++ b/src/pages/api/kubernetes/status/[...service].js
@@ -25,7 +25,7 @@ export default async function handler(req, res) {
       });
       return;
     }
-    const labelSelector = podSelector !== undefined ? podSelector : await parseIngressSelector(appName, namespace, kc);
+    const labelSelector = podSelector !== undefined ? podSelector : await parseIngressSelector(appName, namespace, kc, logger);
     const coreApi = kc.makeApiClient(CoreV1Api);
     const podsResponse = await coreApi
       .listNamespacedPod(namespace, null, null, null, null, labelSelector)

--- a/src/utils/kubernetes/kubernetes-utils.js
+++ b/src/utils/kubernetes/kubernetes-utils.js
@@ -1,3 +1,16 @@
+import { CoreV1Api, NetworkingV1Api } from "@kubernetes/client-node";
+
+export async function parseIngressSelector(ingressName, namespace, kc) {
+  const coreApi = kc.makeApiClient(CoreV1Api);
+  const networkApi = kc.makeApiClient(NetworkingV1Api);
+
+  const ingress = await networkApi.readNamespacedIngress(ingressName, namespace);
+  const serviceName = ingress.body.spec.rules[0].http.paths[0].backend.service.name;
+
+  const svc = await coreApi.readNamespacedService(serviceName, namespace);
+  return svc.body.spec.selector;
+}
+
 export function parseCpu(cpuStr) {
   const unitLength = 1;
   const base = Number.parseInt(cpuStr, 10);


### PR DESCRIPTION
## Proposed change

Enhance default k8s pod selector by using the api to automatically discover the service used by the ingress resource. Reduces need to manually set pod selectors and does not break existing functionality. I opened a discussion on this but I was unclear if I needed to upvotes for this since it's not really a new feature but please let me know if I do.

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.  
-->

Closes #3348

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [x] Other (please explain)

Enhancement of current functionality to integrate more natively in kubernetes.

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] (Did not test multiple front end platforms due to it being a backend change)
