### PR TITLE
Enhancement: add bitrate precision config option for speedtest-tracker 

### DIFF
--- a/docs/widgets/services/speedtest-tracker.md
+++ b/docs/widgets/services/speedtest-tracker.md
@@ -16,4 +16,5 @@ Allowed fields: `["download", "upload", "ping"]`.
 widget:
   type: speedtest
   url: http://speedtest.host.or.ip
+  bitrateNumOfDecimalPlaces: 3 # default is 2
 ```

--- a/docs/widgets/services/speedtest-tracker.md
+++ b/docs/widgets/services/speedtest-tracker.md
@@ -16,5 +16,5 @@ Allowed fields: `["download", "upload", "ping"]`.
 widget:
   type: speedtest
   url: http://speedtest.host.or.ip
-  bitrateNumOfDecimalPlaces: 3 # default is 0
+  bitratePrecision: 3 # optional, default is 0
 ```

--- a/docs/widgets/services/speedtest-tracker.md
+++ b/docs/widgets/services/speedtest-tracker.md
@@ -16,5 +16,5 @@ Allowed fields: `["download", "upload", "ping"]`.
 widget:
   type: speedtest
   url: http://speedtest.host.or.ip
-  bitrateNumOfDecimalPlaces: 3 # default is 2
+  bitrateNumOfDecimalPlaces: 3 # default is 0
 ```

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -450,6 +450,9 @@ export function cleanServiceGroups(groups) {
           // proxmox
           node,
 
+          // speedtest
+          bitratePrecision,
+
           // sonarr, radarr
           enableQueue,
 
@@ -459,9 +462,6 @@ export function cleanServiceGroups(groups) {
 
           // unifi
           site,
-
-          // speedtest-tracker
-          bitrateNumOfDecimalPlaces,
         } = cleanedService.widget;
 
         let fieldsList = fields;
@@ -592,13 +592,8 @@ export function cleanServiceGroups(groups) {
           if (uuid !== undefined) cleanedService.widget.uuid = uuid;
         }
         if (type === "speedtest") {
-          if (bitrateNumOfDecimalPlaces !== undefined) {
-            // if the result can't be parsed, set to -1
-            cleanedService.widget.bitrateNumOfDecimalPlaces = Number.parseInt(bitrateNumOfDecimalPlaces, 10);
-            if (Number.isNaN(cleanedService.widget.bitrateNumOfDecimalPlaces)) {
-              // negative values fallback to the default
-              cleanedService.widget.bitrateNumOfDecimalPlaces = -1;
-            }
+          if (bitratePrecision !== undefined) {
+            cleanedService.widget.bitratePrecision = parseInt(bitratePrecision, 10);
           }
         }
       }

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -459,6 +459,9 @@ export function cleanServiceGroups(groups) {
 
           // unifi
           site,
+
+          // speedtest-tracker
+          bitrateNumOfDecimalPlaces,
         } = cleanedService.widget;
 
         let fieldsList = fields;
@@ -587,6 +590,16 @@ export function cleanServiceGroups(groups) {
         }
         if (type === "healthchecks") {
           if (uuid !== undefined) cleanedService.widget.uuid = uuid;
+        }
+        if (type === "speedtest") {
+          if (bitrateNumOfDecimalPlaces !== undefined) {
+            // if the result can't be parsed, set to -1
+            cleanedService.widget.bitrateNumOfDecimalPlaces = Number.parseInt(bitrateNumOfDecimalPlaces, 10);
+            if (Number.isNaN(cleanedService.widget.bitrateNumOfDecimalPlaces)) {
+              // negative values fallback to the default
+              cleanedService.widget.bitrateNumOfDecimalPlaces = -1;
+            }
+          }
         }
       }
 

--- a/src/widgets/speedtest/component.jsx
+++ b/src/widgets/speedtest/component.jsx
@@ -4,8 +4,6 @@ import Container from "components/services/widget/container";
 import Block from "components/services/widget/block";
 import useWidgetAPI from "utils/proxy/use-widget-api";
 
-const DEFAULT_BITRATE_NUM_OF_DECIMAL_PLACES = 2;
-
 export default function Component({ service }) {
   const { t } = useTranslation();
 
@@ -13,12 +11,10 @@ export default function Component({ service }) {
 
   const { data: speedtestData, error: speedtestError } = useWidgetAPI(widget, "speedtest/latest");
 
-  let bitrateNumOfDecimalPlaces = widget?.bitrateNumOfDecimalPlaces ?? DEFAULT_BITRATE_NUM_OF_DECIMAL_PLACES; // Default is 2
-
-  // if not a number or negative, set to default
-  if (bitrateNumOfDecimalPlaces < 0) {
-    bitrateNumOfDecimalPlaces = DEFAULT_BITRATE_NUM_OF_DECIMAL_PLACES;
-  }
+  const bitratePrecision =
+    !widget?.bitratePrecision || Number.isNaN(widget?.bitratePrecision) || widget?.bitratePrecision < 0
+      ? 0
+      : widget.bitratePrecision;
 
   if (speedtestError) {
     return <Container service={service} error={speedtestError} />;
@@ -40,14 +36,14 @@ export default function Component({ service }) {
         label="speedtest.download"
         value={t("common.bitrate", {
           value: speedtestData.data.download * 1000 * 1000,
-          decimals: bitrateNumOfDecimalPlaces,
+          decimals: bitratePrecision,
         })}
       />
       <Block
         label="speedtest.upload"
         value={t("common.bitrate", {
           value: speedtestData.data.upload * 1000 * 1000,
-          decimals: bitrateNumOfDecimalPlaces,
+          decimals: bitratePrecision,
         })}
       />
       <Block

--- a/src/widgets/speedtest/component.jsx
+++ b/src/widgets/speedtest/component.jsx
@@ -4,12 +4,21 @@ import Container from "components/services/widget/container";
 import Block from "components/services/widget/block";
 import useWidgetAPI from "utils/proxy/use-widget-api";
 
+const DEFAULT_BITRATE_NUM_OF_DECIMAL_PLACES = 2;
+
 export default function Component({ service }) {
   const { t } = useTranslation();
 
   const { widget } = service;
 
   const { data: speedtestData, error: speedtestError } = useWidgetAPI(widget, "speedtest/latest");
+
+  let bitrateNumOfDecimalPlaces = widget?.bitrateNumOfDecimalPlaces ?? DEFAULT_BITRATE_NUM_OF_DECIMAL_PLACES; // Default is 2
+
+  // if not a number or negative, set to default
+  if (bitrateNumOfDecimalPlaces < 0) {
+    bitrateNumOfDecimalPlaces = DEFAULT_BITRATE_NUM_OF_DECIMAL_PLACES;
+  }
 
   if (speedtestError) {
     return <Container service={service} error={speedtestError} />;
@@ -29,9 +38,18 @@ export default function Component({ service }) {
     <Container service={service}>
       <Block
         label="speedtest.download"
-        value={t("common.bitrate", { value: speedtestData.data.download * 1000 * 1000 })}
+        value={t("common.bitrate", {
+          value: speedtestData.data.download * 1000 * 1000,
+          decimals: bitrateNumOfDecimalPlaces,
+        })}
       />
-      <Block label="speedtest.upload" value={t("common.bitrate", { value: speedtestData.data.upload * 1000 * 1000 })} />
+      <Block
+        label="speedtest.upload"
+        value={t("common.bitrate", {
+          value: speedtestData.data.upload * 1000 * 1000,
+          decimals: bitrateNumOfDecimalPlaces,
+        })}
+      />
       <Block
         label="speedtest.ping"
         value={t("common.ms", {


### PR DESCRIPTION
## Proposed change
Add new widget configuration option for speedtest-tracker widget to configure the number of decimal places it will print the bitrate at. (`bitrateNumOfDecimalPlaces`)

It will now default to 2 decimal places but can be configured for any non-negative integer. If an invalid value is passed in, it will fallback to the default value.

with `bitrateNumOfDecimalPlaces: 3`:
![image](https://github.com/gethomepage/homepage/assets/24537535/8976096e-622d-42fb-aa2a-ed0df659f02b)

with `bitrateNumOfDecimalPlaces: 0`:
![image](https://github.com/gethomepage/homepage/assets/24537535/7b2674ec-737b-44d8-98fb-9f0945c09ae5)

with `bitrateNumOfDecimalPlaces: -3` (falls back to default):
![image](https://github.com/gethomepage/homepage/assets/24537535/1b0a7ec6-8416-45c6-81b0-8e238683e487)


Closes #1308 (issue)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
