### PR TITLE
Fix: format Romm statistics

### DIFF
--- a/src/widgets/romm/component.jsx
+++ b/src/widgets/romm/component.jsx
@@ -4,6 +4,7 @@ import useWidgetAPI from "utils/proxy/use-widget-api";
 
 export default function Component({ service }) {
   const { widget } = service;
+  const { t } = useTranslation();
 
   const { data: response, error: responseError } = useWidgetAPI(widget, "statistics");
 
@@ -24,8 +25,8 @@ export default function Component({ service }) {
     const totalRoms = response.reduce((total, stat) => total + stat.rom_count, 0);
     return (
       <Container service={service}>
-        <Block label="romm.platforms" value={platforms} />
-        <Block label="romm.totalRoms" value={totalRoms} />
+        <Block label="romm.platforms" value={t("common.number", { value: platforms })} />
+        <Block label="romm.totalRoms" value={t("common.number", { value: totalRoms })} />
       </Container>
     );
   }

--- a/src/widgets/romm/component.jsx
+++ b/src/widgets/romm/component.jsx
@@ -1,3 +1,5 @@
+import { useTranslation } from "next-i18next";
+
 import Container from "components/services/widget/container";
 import Block from "components/services/widget/block";
 import useWidgetAPI from "utils/proxy/use-widget-api";


### PR DESCRIPTION
## Proposed change

Use the `"common.number"` translation for displaying statistics for the Romm widget.

## Type of change

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
