### PR TITLE
Documentation: correct weatherapi example

### DIFF
--- a/docs/configs/settings.md
+++ b/docs/configs/settings.md
@@ -363,7 +363,7 @@ providers:
 You can then pass `provider` instead of `apiKey` in your widget configuration.
 
 ```yaml
-- weather:
+- weatherapi:
     latitude: 50.449684
     longitude: 30.525026
     provider: weatherapi


### PR DESCRIPTION
Added "api" so that weather is working if a user copy&paste the entry from the documentation. See also #338

## Proposed change

## Type of change

- [x] Documentation only

