### PR TITLE
Fix: allow exclamation to open quicklaunch

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -227,7 +227,8 @@ function Home({ initialSettings }) {
           (e.key.length === 1 &&
             e.key.match(/(\w|\s|[à-ü]|[À-Ü]|[\w\u0430-\u044f])/gi) &&
             !(e.altKey || e.ctrlKey || e.metaKey || e.shiftKey)) ||
-          e.key.match(/([à-ü]|[À-Ü])/g) || // accented characters may require modifier keys
+          // accented/special characters may require modifier keys
+          e.key.match(/([à-ü]|[À-Ü]|[\u0021-\u0024]|[\u0026-002F]|[\u003A-\u0040])/g) ||
           (e.key === "v" && (e.ctrlKey || e.metaKey))
         ) {
           setSearching(true);

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -227,8 +227,8 @@ function Home({ initialSettings }) {
           (e.key.length === 1 &&
             e.key.match(/(\w|\s|[à-ü]|[À-Ü]|[\w\u0430-\u044f])/gi) &&
             !(e.altKey || e.ctrlKey || e.metaKey || e.shiftKey)) ||
-          // accented/special characters may require modifier keys
-          e.key.match(/([à-ü]|[À-Ü]|[\u0021-\u0024]|[\u0026-002F]|[\u003A-\u0040])/g) ||
+          // accented characters and the bang may require modifier keys
+          e.key.match(/([à-ü]|[À-Ü]|!)/g) ||
           (e.key === "v" && (e.ctrlKey || e.metaKey))
         ) {
           setSearching(true);


### PR DESCRIPTION
## Proposed change
Quicklaunch wouldn't start with characters that require modifier keys to be typed (i.e. !,@,#,$), making it annoying to use quicklaunch alongside duckduckgo bangs

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
