### PR TITLE
Feature: Fireshare widget

### DIFF
--- a/docs/widgets/services/fireshare.md
+++ b/docs/widgets/services/fireshare.md
@@ -1,0 +1,16 @@
+---
+title: Fireshare
+description: Fireshare Widget Configuration
+---
+
+Learn more about [Fireshare](https://github.com/ShaneIsrael/fireshare).
+
+Allowed fields: `["total", "categories", "views"]`.
+
+```yaml
+widget:
+  type: fireshare
+  url: http://fireshare.host.or.ip
+  username: username
+  password: password
+```

--- a/docs/widgets/services/fireshare.md
+++ b/docs/widgets/services/fireshare.md
@@ -5,7 +5,7 @@ description: Fireshare Widget Configuration
 
 Learn more about [Fireshare](https://github.com/ShaneIsrael/fireshare).
 
-Allowed fields: `["total", "categories", "views"]`.
+Allowed fields: `["total", "categories", "views", "private", "public"]`.
 
 ```yaml
 widget:

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -882,5 +882,10 @@
         "enabled": "Enabled",
         "disabled": "Disabled",
         "total": "Total"
+    },
+    "fireshare": {
+      "total": "Total",
+      "categories": "Categories",
+      "views": "Views"
     }
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -886,6 +886,8 @@
     "fireshare": {
       "total": "Total",
       "categories": "Categories",
-      "views": "Views"
+      "views": "Views",
+      "private": "Private",
+      "public": "Public"
     }
 }

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -27,6 +27,7 @@ const components = {
   esphome: dynamic(() => import("./esphome/component")),
   evcc: dynamic(() => import("./evcc/component")),
   fileflows: dynamic(() => import("./fileflows/component")),
+  fireshare: dynamic(() => import("./fireshare/component")),
   flood: dynamic(() => import("./flood/component")),
   freshrss: dynamic(() => import("./freshrss/component")),
   fritzbox: dynamic(() => import("./fritzbox/component")),

--- a/src/widgets/fireshare/component.jsx
+++ b/src/widgets/fireshare/component.jsx
@@ -21,6 +21,8 @@ export default function Component({ service }) {
         <Block label="fireshare.total" />
         <Block label="fireshare.categories" />
         <Block label="fireshare.views" />
+        <Block label="fireshare.private" />
+        <Block label="fireshare.public" />
       </Container>
     );
   }
@@ -33,12 +35,16 @@ export default function Component({ service }) {
   });
   const categoriesCount = categoriesSet.size;
   const totalViews = infoData.videos.reduce((acc, video) => acc + video.view_count, 0);
+  const privateCount = infoData.videos.filter(video => video.info.private).length;
+  const publicCount = total - privateCount;
 
   return (
     <Container service={service}>
       <Block label="fireshare.total" value={total} />
       <Block label="fireshare.categories" value={categoriesCount} />
       <Block label="fireshare.views" value={totalViews} />
+      <Block label="fireshare.private" value={privateCount} />
+      <Block label="fireshare.public" value={publicCount} />
     </Container>
   );
 }

--- a/src/widgets/fireshare/component.jsx
+++ b/src/widgets/fireshare/component.jsx
@@ -1,0 +1,44 @@
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { widget } = service;
+
+  const { data: infoData, error: infoError } = useWidgetAPI(widget);
+
+  if (!widget.fields) {
+    widget.fields = ["total", "categories", "views"];
+  }
+
+  if (infoError) {
+    return <Container service={service} error={infoError} />;
+  }
+
+  if (!infoData) {
+    return (
+      <Container service={service}>
+        <Block label="fireshare.total" />
+        <Block label="fireshare.categories" />
+        <Block label="fireshare.views" />
+      </Container>
+    );
+  }
+
+  const total = infoData.videos.length;
+  const categoriesSet = new Set();
+  infoData.videos.forEach(video => {
+    const category = video.path.split('/')[0];
+    categoriesSet.add(category);
+  });
+  const categoriesCount = categoriesSet.size;
+  const totalViews = infoData.videos.reduce((acc, video) => acc + video.view_count, 0);
+
+  return (
+    <Container service={service}>
+      <Block label="fireshare.total" value={total} />
+      <Block label="fireshare.categories" value={categoriesCount} />
+      <Block label="fireshare.views" value={totalViews} />
+    </Container>
+  );
+}

--- a/src/widgets/fireshare/proxy.js
+++ b/src/widgets/fireshare/proxy.js
@@ -1,0 +1,74 @@
+import cache from "memory-cache";
+
+import getServiceWidget from "utils/config/service-helpers";
+import { formatApiCall } from "utils/proxy/api-helpers";
+import { httpProxy } from "utils/proxy/http";
+import widgets from "widgets/widgets";
+import createLogger from "utils/logger";
+
+const proxyName = "fireshareProxyHandler";
+const logger = createLogger(proxyName);
+const sessionTokenCacheKey = `${proxyName}__sessionToken`;
+
+async function login(widget, service) {
+  const url = formatApiCall(widgets[widget.type].api, { ...widget, endpoint: "login" });
+  logger.info(`url: ${url}`);
+  logger.info(`username: ${widget.username}, password: ${widget.password}`);
+  const [, , , responseHeaders] = await httpProxy(url, {
+    method: "POST",
+    body: JSON.stringify({ username: widget.username, password: widget.password }),
+    headers: {
+      "Content-Type": "application/json"
+    }
+  });
+
+  try {
+    logger.info(responseHeaders);
+    const rememberTokenCookie = responseHeaders["set-cookie"]
+      .find((cookie) => cookie.startsWith("remember_token="))
+      .split(";")[0]
+      .replace("remember_token=", "");
+    logger.info(`remember_token: ${rememberTokenCookie}`);
+    cache.put(`${sessionTokenCacheKey}.${service}`, rememberTokenCookie);
+    return rememberTokenCookie;
+  } catch (e) {
+    logger.error(`Error retrieving 'remember_token' cookie for service: ${service}`);
+    cache.del(`${sessionTokenCacheKey}.${service}`);
+    return null;
+  }
+}
+
+export default async function fireshareProxyHandler(req, res) {
+  const { group, service } = req.query;
+
+  if (group && service) {
+    const widget = await getServiceWidget(group, service);
+
+    if (!widgets?.[widget.type]?.api) {
+      return res.status(403).json({ error: "Service does not support API calls" });
+    }
+
+    if (widget) {
+      let token = cache.get(`${sessionTokenCacheKey}.${service}`);
+      if (!token) {
+        token = await login(widget, service);
+        if (!token) {
+          return res.status(500).json({ error: "Failed to authenticate with Fireshare" });
+        }
+      }
+      const [, , data] = await httpProxy(
+        formatApiCall(widgets[widget.type].api, { ...widget, endpoint: "videos?sort=updated_at+desc" }),
+        {
+          headers: {
+            "Content-Type": "application/json",
+            Cookie: `remember_token=${token}`
+          }
+        }
+      );
+
+      return res.json(JSON.parse(data));
+    }
+  }
+
+  return res.status(400).json({ error: "Invalid proxy service type" });
+}

--- a/src/widgets/fireshare/widget.js
+++ b/src/widgets/fireshare/widget.js
@@ -1,0 +1,8 @@
+import fireshareProxyHandler from "./proxy";
+
+const widget = {
+  api: "{url}/api/{endpoint}",
+  proxyHandler: fireshareProxyHandler,
+};
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -21,6 +21,7 @@ import emby from "./emby/widget";
 import esphome from "./esphome/widget";
 import evcc from "./evcc/widget";
 import fileflows from "./fileflows/widget";
+import fireshare from "./fireshare/widget";
 import flood from "./flood/widget";
 import freshrss from "./freshrss/widget";
 import fritzbox from "./fritzbox/widget";
@@ -136,6 +137,7 @@ const widgets = {
   esphome,
   evcc,
   fileflows,
+  fireshare,
   flood,
   freshrss,
   fritzbox,


### PR DESCRIPTION
## Proposed change

This is a widget for [Fireshare](https://github.com/ShaneIsrael/fireshare). It can display total videos, number of categories, private and public video counts and total views. The default fields are `["total", "categories", "views"]`

![image](https://github.com/gethomepage/homepage/assets/26893126/8e634d6d-1a0e-4909-8ae2-13931c9dbc41)

```yaml
- Fireshare:
    href: http://fireshare.host.or.ip
    description: Fireshare
    icon: fireshare
    widget:
      type: fireshare
      url: http://fireshare.host.or.ip
      username: username
      password: password
```

Although not requested, I developed this feature for personal use and believe it could benefit others in our community.

## Type of change

- [x] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.