### PR TITLE
Site monitor url defaults to services href

### DIFF
--- a/docs/configs/services.md
+++ b/docs/configs/services.md
@@ -125,6 +125,8 @@ You can also apply different styles to the ping indicator by using the `statusSt
 
 Services may have an optional `siteMonitor` property (formerly `ping`) that allows you to monitor the availability of a URL you chose and have the response time displayed. You do not need to set your monitor URL equal to your href or ping URL.
 
+If you set the `siteMonitor` property to `true`, the monitored URL be the same as `href`.
+
 !!! note
 
     The site monitor feature works by making an http `HEAD` request to the URL, and falls back to `GET` in case that fails. It will not, for example, login if the URL requires auth or is behind e.g. Authelia. In the case of a reverse proxy and/or auth this usually requires the use of an 'internal' URL to make the site monitor feature correctly display status.
@@ -141,6 +143,12 @@ Services may have an optional `siteMonitor` property (formerly `ping`) that allo
         icon: radarr.png
         href: http://radarr.host/
         siteMonitor: http://some.other.host/
+
+- Group C:
+    - Lidarr:
+        icon: lidarr.png
+        href: http://lidarr.host/
+        siteMonitor: true
 ```
 
 You can also apply different styles to the site monitor indicator by using the `statusStyle` property, see [settings](settings.md#status-style).

--- a/src/pages/api/siteMonitor.js
+++ b/src/pages/api/siteMonitor.js
@@ -16,13 +16,25 @@ export default async function handler(req, res) {
     });
   }
 
-  const { siteMonitor: monitorURL } = serviceItem;
+  const { href, siteMonitor } = serviceItem;
 
-  if (!monitorURL) {
+  if (!siteMonitor) {
     logger.debug("No http monitor URL specified");
     return res.status(400).send({
       error: "No http monitor URL given",
     });
+  }
+  let monitorURL = siteMonitor;
+  
+  if (siteMonitor === true) {
+    // if monitor is set to "true", use the href as the monitor target
+    if (!href) {
+      logger.error(`Monitoring requestd for service '${service}' but no url specified.\n\tEither set monitor to a url or set href`);
+      return res.status(400).send({
+        error: "No url specified for monitor, see logs.",
+      });
+    }
+    monitorURL = href;
   }
 
   try {

--- a/src/pages/api/siteMonitor.js
+++ b/src/pages/api/siteMonitor.js
@@ -30,7 +30,7 @@ export default async function handler(req, res) {
     // if monitor is set to "true", use the href as the monitor target
     if (!href) {
       logger.error(
-        `Monitoring requestd for service '${service}' but no url specified.\n\tEither set monitor to a url or set href`,
+        `Monitoring requested for service '${service}' but no url specified.\n\tEither set monitor to a url or set href`,
       );
       return res.status(400).send({
         error: "No url specified for monitor, see logs.",

--- a/src/pages/api/siteMonitor.js
+++ b/src/pages/api/siteMonitor.js
@@ -25,11 +25,13 @@ export default async function handler(req, res) {
     });
   }
   let monitorURL = siteMonitor;
-  
+
   if (siteMonitor === true) {
     // if monitor is set to "true", use the href as the monitor target
     if (!href) {
-      logger.error(`Monitoring requestd for service '${service}' but no url specified.\n\tEither set monitor to a url or set href`);
+      logger.error(
+        `Monitoring requestd for service '${service}' but no url specified.\n\tEither set monitor to a url or set href`,
+      );
       return res.status(400).send({
         error: "No url specified for monitor, see logs.",
       });


### PR DESCRIPTION
The approach where we don't allow for a fallback `siteMonitor` URL increases config duplication as it's common for administrators to set `siteMonitor` to the same value as the `href`. In the scenario where an administrator has many services with different `href` values and they want the `siteMonitor` to match `href`, they would need to configure both  `siteMonitor` and `href` values on each service item.

## Proposed change
The proposed changes address this issue by adding a new condition to handle the case where `siteMonitor` is `true`. In this case, it checks if the `href` property exists. If the `href` property does exist, it sets `monitorURL` to `href`. Otherwise, it _fails with message_. 

This change allows the use of the `href` property as the monitor target when `siteMonitor` is set to `true`.

> ```yaml
>   - dummyService:
>       href: https://github.com/
>       siteMonitor: true
> ```
> ![image](https://github.com/gethomepage/homepage/assets/15911689/c9cde6b6-f821-4f1c-95db-da50249633d1)
> ---
> 
> ```yaml
>   - dummyService:
>       siteMonitor: true
> ```
> ![image](https://github.com/gethomepage/homepage/assets/15911689/7b1a6a03-07a9-4994-b76e-89b6f1121047)
> ```
> docker compose logs homepage
> homepage  | Listening on port 3000
> homepage  | [2024-05-20T13:12:22.578Z] error: <siteMonitor> Monitoring requested for service 'dummyService' but no url specified.
> homepage  | 	Either set monitor to a url or set href
> ```

## Type of change

- [ ] ~New service widget~
- [ ] ~Bug fix (non-breaking change which fixes an issue)~
- [x] New feature (non-breaking change which adds functionality)
- [ ] ~Documentation only~
- [ ] ~Other (please explain)~

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.