### PR TITLE
Change icon in the longhorn widget to use the same as resources

### DIFF
--- a/src/components/widgets/longhorn/node.jsx
+++ b/src/components/widgets/longhorn/node.jsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "next-i18next";
-import { FaThermometerHalf } from "react-icons/fa";
+import { FiHardDrive } from "react-icons/fi";
 
 import Resource from "../widget/resource";
 import WidgetLabel from "../widget/widget_label";
@@ -10,7 +10,7 @@ export default function Node({ data, expanded, labels }) {
   return (
     <Resource
       additionalClassNames="information-widget-longhorn-node"
-      icon={FaThermometerHalf}
+      icon={FiHardDrive}
       value={t("common.bytes", { value: data.node.available })}
       label={t("resources.free")}
       expandedValue={t("common.bytes", { value: data.node.maximum })}


### PR DESCRIPTION
## Proposed change

This change corrects what looks like an incorrect icon copy/paste from another widget within the longhorn widget. Now longhorn displays a disk icon rather than a temperature icon

Before: 
https://imgur.com/2QWQY8m
After: 
https://imgur.com/VkOrMFz


Closes # N/A

## Type of change

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
