### PR TITLE
Enhancement: Allow Disk Resources Widget For Combined Disk Mounts

### DIFF
--- a/src/components/widgets/resources/disk.jsx
+++ b/src/components/widgets/resources/disk.jsx
@@ -31,15 +31,19 @@ export default function Disk({ options, expanded, diskUnits, refresh = 1500 }) {
     );
   }
 
-  // data.drive.used not accurate?
-  const percent = Math.round(((data.drive.size - data.drive.available) / data.drive.size) * 100);
+  // Calculate the total size and available space from the data.drive array
+  const totalSize = data.drive.reduce((acc, drive) => acc + drive.size, 0);
+  const totalAvailable = data.drive.reduce((acc, drive) => acc + drive.available, 0);
+
+  // Calculate the percentage of used space
+  const percent = Math.round(((totalSize - totalAvailable) / totalSize) * 100);
 
   return (
     <Resource
       icon={FiHardDrive}
-      value={t(diskUnitsName, { value: data.drive.available })}
+      value={t(diskUnitsName, { value: totalAvailable })}
       label={t("resources.free")}
-      expandedValue={t(diskUnitsName, { value: data.drive.size })}
+      expandedValue={t(diskUnitsName, { value: totalSize })}
       expandedLabel={t("resources.total")}
       percentage={percent}
       expanded={expanded}

--- a/src/pages/api/widgets/resources.js
+++ b/src/pages/api/widgets/resources.js
@@ -23,9 +23,18 @@ export default async function handler(req, res) {
     }
 
     const fsSize = await si.fsSize();
+    let driveData;
+
+    if (target === "/") {
+      const rootTarget = fsSize.find((fs) => fs.mount === "/");
+      driveData = rootTarget ?? [rootTarget];
+    } else {
+      const foundTarget = fsSize.find((fs) => fs.mount === target);
+      driveData = foundTarget ? [foundTarget] : fsSize;
+    }
 
     return res.status(200).json({
-      drive: fsSize.find((fs) => fs.mount === target) ?? fsSize.find((fs) => fs.mount === "/"),
+      drive: driveData,
     });
   }
 

--- a/src/pages/api/widgets/resources.js
+++ b/src/pages/api/widgets/resources.js
@@ -23,14 +23,14 @@ export default async function handler(req, res) {
     }
 
     const fsSize = await si.fsSize();
+    const rootTarget = fsSize.find((fs) => fs.mount === "/") || [];
     let driveData;
 
     if (target === "/") {
-      const rootTarget = fsSize.find((fs) => fs.mount === "/");
-      driveData = rootTarget ?? [rootTarget];
+      driveData = [rootTarget];
     } else {
-      const foundTarget = fsSize.find((fs) => fs.mount === target);
-      driveData = foundTarget ? [foundTarget] : fsSize;
+      const filteredData = fsSize.filter((fs) => fs.mount.startsWith(target));
+      driveData = filteredData.length > 0 ? filteredData : [rootTarget];
     }
 
     return res.status(200).json({


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

## Changes
### Backend
The API now returns an array of drive data, previous logic for root  '/'  and local paths remains.

**Example Response**
```
{
    "drive": [
        {
            "fs": "/dev/sdc1",
            "type": "ext4",
            "size": 3936819662848,
            "used": 28672,
            "available": 3736763559936,
            "use": 0,
            "mount": "/storage_disks/hdd4",
            "rw": false
        },
        {
            "fs": "/dev/sdf1",
            "type": "ext4",
            "size": 1967846068224,
            "used": 1863119540224,
            "available": 4689858560,
            "use": 99.75,
            "mount": "/storage_disks/hdd1",
            "rw": false
        },
        {
            "fs": "/dev/sde1",
            "type": "ext4",
            "size": 1967846068224,
            "used": 1857638305792,
            "available": 10171092992,
            "use": 99.46,
            "mount": "/storage_disks/hdd2",
            "rw": false
        },
        {
            "fs": "/dev/sdd1",
            "type": "ext4",
            "size": 983350071296,
            "used": 891776819200,
            "available": 41546285056,
            "use": 95.55,
            "mount": "/storage_disks/hdd3",
            "rw": false
        }
    ]
}
```

### Frontend
-  The Disk component now sums up total size and available space from the array data.

## Example Use Case

**docker-compose.yml**
```
    volumes:
      - /hdd1:/storage_disks/hdd1:ro 
      - /hdd2:/storage_disks/hdd2:ro
      - /hdd3:/storage_disks/hdd3:ro
      - /hdd4:/storage_disks/hdd4:ro
```

**widgets.yaml**
```
- resources:
    disk: /storage_disks
    expanded: true
```

**Results**
![image](https://github.com/gethomepage/homepage/assets/12860603/f84bcda5-fafc-4d33-8795-aae969f2a8b9)



## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [x] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
