### PR TITLE
Fix: remove comma in Caddy and EVCC widgets

### DIFF
--- a/src/widgets/caddy/component.jsx
+++ b/src/widgets/caddy/component.jsx
@@ -17,7 +17,6 @@ export default function Component({ service }) {
   if (!resultData) {
     return (
       <Container service={service}>
-        ,
         <Block label="caddy.upstreams" />
         <Block label="caddy.requests" />
         <Block label="caddy.requests_failed" />

--- a/src/widgets/evcc/component.jsx
+++ b/src/widgets/evcc/component.jsx
@@ -17,7 +17,6 @@ export default function Component({ service }) {
   if (!stateData) {
     return (
       <Container service={service}>
-        ,
         <Block label="evcc.pv_power" />
         <Block label="evcc.grid_power" />
         <Block label="evcc.home_power" />


### PR DESCRIPTION
## Proposed change

Commit 19c25713c42c25795e117d2f75d92f69c4211f38 introduced a very minor layout bug to my Caddy and the EVCC widget (a comma character in the layout block of the widget).
It just shows up when the API call for the widget is still loading so it's very hard to notice, but once you do notice it the first time, you will notice it every time 😉 

I did not create a bug report since the issue is very minor. If necessary I can create one however.

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
