### PR TITLE
Fix: wg-easy threshold not properly computed

### DIFF
--- a/src/widgets/wgeasy/component.jsx
+++ b/src/widgets/wgeasy/component.jsx
@@ -28,7 +28,7 @@ export default function Component({ service }) {
 
   const enabled = infoData.filter((item) => item.enabled).length;
   const disabled = infoData.length - enabled;
-  const connectionThreshold = widget.threshold ?? 2 * 60 * 1000;
+  const connectionThreshold = (widget.threshold ?? 2) * 60 * 1000;
   const currentTime = new Date();
   const connected = infoData.filter(
     (item) => currentTime - new Date(item.latestHandshakeAt) < connectionThreshold,

--- a/src/widgets/wgeasy/proxy.js
+++ b/src/widgets/wgeasy/proxy.js
@@ -21,11 +21,14 @@ async function login(widget, service) {
   });
 
   try {
-    const sid = cache.get(`${sessionSIDCacheKey}.${service}`);
-    if (sid) {
-      return sid;
+    const connectSidCookie = responseHeaders["set-cookie"];
+    if (!connectSidCookie) {
+      const sid = cache.get(`${sessionSIDCacheKey}.${service}`);
+      if (sid) {
+        return sid;
+      }
     }
-    const connectSidCookie = responseHeaders["set-cookie"]
+    connectSidCookie = connectSidCookie
       .find((cookie) => cookie.startsWith("connect.sid="))
       .split(";")[0]
       .replace("connect.sid=", "");

--- a/src/widgets/wgeasy/proxy.js
+++ b/src/widgets/wgeasy/proxy.js
@@ -21,6 +21,10 @@ async function login(widget, service) {
   });
 
   try {
+    const sid = cache.get(`${sessionSIDCacheKey}.${service}`);
+    if (sid) {
+      return sid;
+    }
     const connectSidCookie = responseHeaders["set-cookie"]
       .find((cookie) => cookie.startsWith("connect.sid="))
       .split(";")[0]
@@ -28,7 +32,7 @@ async function login(widget, service) {
     cache.put(`${sessionSIDCacheKey}.${service}`, connectSidCookie);
     return connectSidCookie;
   } catch (e) {
-    logger.error(`Error logging into wg-easy`);
+    logger.error(`Error logging into wg-easy, error: ${e}`);
     cache.del(`${sessionSIDCacheKey}.${service}`);
     return null;
   }


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

Closes #3568

- Changes the threshold calculation accounting for a custom threshold.
- Prints out the actual error when login fails
- Adds a check for the cached sid within login

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
