### PR TITLE
Fix/handle null id in json rpc responses and cpu load representation for openwrt widget

### DIFF
--- a/src/utils/proxy/handlers/jsonrpc.js
+++ b/src/utils/proxy/handlers/jsonrpc.js
@@ -31,6 +31,10 @@ export async function sendJsonRpcRequest(url, method, params, username, password
     if (status === 200) {
       const json = JSON.parse(data.toString());
 
+      if (json.id === null) {
+        json.id = 1;
+      }
+
       // in order to get access to the underlying error object in the JSON response
       // you must set `result` equal to undefined
       if (json.error && json.result === null) {

--- a/src/widgets/openwrt/proxy.js
+++ b/src/widgets/openwrt/proxy.js
@@ -77,7 +77,7 @@ async function fetchSystem(url) {
   const systemResponse = JSON.parse(data.toString())[1];
   const response = {
     uptime: systemResponse.uptime,
-    cpuLoad: systemResponse.load[1],
+    cpuLoad: (systemResponse.load[1] / 65536.0).toFixed(2),
   };
   return [200, contentType, response];
 }


### PR DESCRIPTION
## Proposed change

### Issue:
I've configured the OpenWRT widget in my `homepage` container, but saw the following:

![initial-state](https://github.com/gethomepage/homepage/assets/1328759/27c914f0-368e-48da-863d-ef3966d94561)

Tested on:
- Homepage `v0.8.13` and `master`
- OpenWrt `23.05.0`

The service configuration I've used:
```yaml
    - OpenWRT:
        icon: openwrt.png
        widget:
          type: openwrt
          url: https://10.0.0.138
          username: homepage
          password: ********
```

### Explanation:
The widget starts by issuing an unauthorized request to OpenWRT, which for some reason results with a response `id` that is `null` (according to the [JSON-RPC 2.0 specification](https://www.jsonrpc.org/specification#request_object) this is discouraged) and it seems to not play nice with the [json-rpc-2.0](https://www.npmjs.com/package/json-rpc-2.0) package)
```json
{
	"jsonrpc": "2.0",
	"id": null,
	"error": {
		"code": -32002,
		"message": "Access denied"
	}
}
```

My first commit solves this issue by checking if the response `id` is `null` and setting it as `1` instead.
This solves the issue and the widget starts working:

![null-id-fix](https://github.com/gethomepage/homepage/assets/1328759/8d1b2571-b81e-4d78-948c-2d48150f10a8)

### Additional Fix:
After the widget started working I've noticed that the CPU Load number was "off" and didn't look like the standard UNIX load format expected by something like `uptime`.
To solve this I've added the following calculation according to [this](https://openwrt.org/docs/guide-developer/ubus/system):

> The values in load are the load averages over 1, 5, and 15 minutes. to get to the familiar values reported by uptime divide these numbers by 65536.0 and round to 2 decimals. 

After fixing CPU load representation:
![cpu-load-fix](https://github.com/gethomepage/homepage/assets/1328759/cc973582-b648-4b1e-8ebc-c98a2f58b08f)






## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
