### PR TITLE
Fix: caddy widget broken in v0.9.1

### DIFF
--- a/src/widgets/caddy/component.jsx
+++ b/src/widgets/caddy/component.jsx
@@ -8,7 +8,7 @@ export default function Component({ service }) {
   const { t } = useTranslation();
 
   const { widget } = service;
-  const { data: resultData, error: resultError } = useWidgetAPI(widget, "result");
+  const { data: resultData, error: resultError } = useWidgetAPI(widget, "upstreams");
 
   if (resultError) {
     return <Container service={service} error={resultError} />;

--- a/src/widgets/caddy/widget.js
+++ b/src/widgets/caddy/widget.js
@@ -1,8 +1,14 @@
 import genericProxyHandler from "utils/proxy/handlers/generic";
 
 const widget = {
-  api: "{url}/reverse_proxy/upstreams",
+  api: "{url}/{endpoint}",
   proxyHandler: genericProxyHandler,
+
+  mappings: {
+    upstreams: {
+      endpoint: "reverse_proxy/upstreams",
+    },
+  },
 };
 
 export default widget;


### PR DESCRIPTION
## Proposed change

<img width="596" alt="Screenshot 2024-06-04 at 12 04 23 AM" src="https://github.com/gethomepage/homepage/assets/4887959/5191030a-4a36-4d60-b583-0642aa9acff4">


Closes #3578

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
