### PR TITLE
Fix dropdown of coinmarketcap widget

### DIFF
--- a/src/widgets/coinmarketcap/component.jsx
+++ b/src/widgets/coinmarketcap/component.jsx
@@ -65,7 +65,7 @@ export default function Component({ service }) {
 
   return (
     <Container service={service}>
-      <div className={classNames(service.description ? "-top-10" : "-top-8", "absolute right-1")}>
+      <div className={classNames(service.description ? "-top-10" : "-top-8", "absolute right-1 z-20")}>
         <Dropdown options={dateRangeOptions} value={dateRange} setValue={setDateRange} />
       </div>
 


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

Fix drop-down of CoinMarketCap widget:

![Screen Shot 2024-06-05 at 15 29 53-1](https://github.com/gethomepage/homepage/assets/2316687/fc6296aa-f389-444f-8ea1-b7ccb3074e0f)

Currently, the drop-down is not clickable because its z-index is set to `auto`, while the title bar (`.service-name`) of the widget has a z-index of `10` (z-10). As a result, the drop-down is shadowed by the title bar. This pull request sets the z-index of the drop-down to `20` (z-20), the next higher z-index class name I found in TailwindCSS, making the drop-down clickable again.

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
```
[nix-shell:~/Develop/homepage]$ date; npm run lint
Wed Jun  5 15:40:21 CST 2024
                                                                                                                                                                                                                    
> startpage@0.1.0 lint
> next lint
                                                                                                                                                                                                                    
✔ No ESLint warnings or errors
```
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.

Tested on Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:126.0) Gecko/20100101 Firefox/126.0

| Desktop | Tablet | Phone |
|--------|--------|--------|
| ![Screen Shot 2024-06-05 at 15 42 41](https://github.com/gethomepage/homepage/assets/2316687/1ef135a3-53c1-475f-b590-efb8f63efd09) | ![Screen Shot 2024-06-05 at 15 44 16](https://github.com/gethomepage/homepage/assets/2316687/7a0bb91c-a76a-4a72-8624-8da964a77100) | ![Screen Shot 2024-06-05 at 15 46 08](https://github.com/gethomepage/homepage/assets/2316687/e52f1b66-7bfe-4524-88eb-c3621c8d05de) |