### PR TITLE
Trim whitespace and quotes in variable substitution

### DIFF
--- a/src/utils/config/config.js
+++ b/src/utils/config/config.js
@@ -59,7 +59,10 @@ export function substituteEnvironmentVars(str) {
     const cachedVars = getCachedEnvironmentVars();
     cachedVars.forEach(([key, value]) => {
       if (key.startsWith(homepageVarPrefix)) {
-        result = result.replaceAll(`{{${key}}}`, value);
+        // Remove whitespace and quotes on edges of the string
+        // Leave quotes in the middle of the string in
+        const sanitizedValue = value.replace(/^[\s"']+|[\s"']+$/g, '');
+        result = result.replaceAll(`{{${key}}}`, sanitizedValue);
       } else if (key.startsWith(homepageFilePrefix)) {
         const filename = value;
         const fileContents = readFileSync(filename, "utf8");


### PR DESCRIPTION
## Proposed change

The new code trims quotes ( ' and " ) and surrounding whitespace off any environment variables that are to be replaced.

This prevents a failure case of the JSON.parse() for Traefik substitution that would fail if you have accidentally added whitespace around your environment variable in Docker/Kubernetes (same for accidental quotes).

Closes discussion https://github.com/gethomepage/homepage/discussions/3535

_Note that this might be a regression for those that rely on quotes or whitespace being the first or last character of an API key._

## Type of change

- [ ] New service widget
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
