### PR TITLE
Fix: Service tags appearing over search dropdown

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -62,3 +62,7 @@ dialog ::-webkit-scrollbar {
 ::-webkit-details-marker {
   display: none;
 }
+
+li.service {
+  z-index: 10;
+}


### PR DESCRIPTION
## Proposed change

Fixed a visual bug by modifying the z-index of the service widget. The search suggestions dropdown and the service widget have probably the same z-index (20) so the tags (docker status, ping, etc) (z-index of 21) appear over the dropdown. 

Discussion # (https://github.com/gethomepage/homepage/discussions/3678) 

## Type of change

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
