### PR TITLE
Fix: increase width allowance for dates in ical agenda widget

### DIFF
--- a/src/widgets/calendar/event.jsx
+++ b/src/widgets/calendar/event.jsx
@@ -16,7 +16,7 @@ export default function Event({ event, colorVariants, showDate = false, showTime
       key={`event-${event.title}-${event.date}-${event.additional}`}
     >
       {showDateColumn && (
-        <span className="ml-2 w-10">
+        <span className="ml-2 w-12">
           <span>
             {(showDate || showTime) &&
               event.date


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

<img width="351" alt="Screenshot 2024-07-06 at 2 44 00 PM" src="https://github.com/gethomepage/homepage/assets/4887959/d54b6606-b452-47a3-88af-7992ddcd59fc">


Closes #3710

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
