### PR TITLE
Fix: don't show "partial" for k8s status if there are completed job pods

### DIFF
--- a/src/pages/api/kubernetes/status/[...service].js
+++ b/src/pages/api/kubernetes/status/[...service].js
@@ -48,8 +48,8 @@ export default async function handler(req, res) {
       logger.error(`no pods found with namespace=${namespace} and labelSelector=${labelSelector}`);
       return;
     }
-    const someReady = pods.find((pod) => pod.status.phase === "Running");
-    const allReady = pods.every((pod) => pod.status.phase === "Running");
+    const someReady = pods.find((pod) => pod.status.phase in ["Completed", "Running"]);
+    const allReady = pods.every((pod) => pod.status.phase in ["Completed", "Running"]);
     let status = "down";
     if (allReady) {
       status = "running";


### PR DESCRIPTION
i'm using a kubernetes service that includes a web UI and cronjobs. because the job finish and go to status `Completed`, the homepage link to the web UI shows `partial` instead of `running`

this patch updates the `someReady` & `allReady` pod filter to include pods that are both `Running` and `Completed`

## Proposed change

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

Closes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
