### PR TITLE
Feature: Add Tab Indexing

### DIFF
--- a/src/components/bookmarks/item.jsx
+++ b/src/components/bookmarks/item.jsx
@@ -14,6 +14,7 @@ export default function Item({ bookmark }) {
         href={bookmark.href}
         title={bookmark.name}
         target={bookmark.target ?? settings.target ?? "_blank"}
+        tabIndex={0}
         className={classNames(
           settings.cardBlur !== undefined && `backdrop-blur${settings.cardBlur.length ? "-" : ""}${settings.cardBlur}`,
           "block w-full text-left cursor-pointer transition-all h-15 mb-3 rounded-md font-medium text-theme-700 dark:text-theme-200 dark:hover:text-theme-300 shadow-md shadow-theme-900/10 dark:shadow-theme-900/20 bg-theme-100/20 hover:bg-theme-300/20 dark:bg-white/5 dark:hover:bg-white/10",

--- a/src/components/services/item.jsx
+++ b/src/components/services/item.jsx
@@ -46,6 +46,7 @@ export default function Item({ service, group, useEqualHeights }) {
               <a
                 href={service.href}
                 target={service.target ?? settings.target ?? "_blank"}
+                tabIndex={0}
                 rel="noreferrer"
                 className="flex-shrink-0 flex items-center justify-center w-12 service-icon z-10"
                 aria-label={service.icon}
@@ -62,6 +63,7 @@ export default function Item({ service, group, useEqualHeights }) {
             <a
               href={service.href}
               target={service.target ?? settings.target ?? "_blank"}
+              tabIndex={0}
               rel="noreferrer"
               className="flex-1 flex items-center justify-between rounded-r-md service-title-text"
             >


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

Added `tabIndex={0}` to the `<a href>` homepage elements to allow keyboard-only navigation to comply with [WAI](https://www.w3.org/WAI/fundamentals/).

Closes #3738

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
