### PR TITLE
Documentation: clarify api key usage for pfsense v1 vs v2

### DIFF
--- a/docs/widgets/services/pfsense.md
+++ b/docs/widgets/services/pfsense.md
@@ -9,7 +9,7 @@ This widget requires the installation of the [pfsense-api](https://github.com/ja
 
 Once pfSense API is installed, you can set the API to be read-only in System > API > Settings.
 
-There are two currently supported authentication modes: 'Local Database' and 'API Token'. For 'Local Database', use `username` and `password` with the credentials of an admin user. For 'API Token', utilize the `headers` parameter with the `X-API-Key` header name and `token` value obtained from pfSense as shown below. Do not use both headers and username / password.
+There are two currently supported authentication modes: 'Local Database' and 'API Key'. For 'Local Database', use `username` and `password` with the credentials of an admin user. For 'API Key', utilize the `headers` parameter with the `X-API-Key` header name and `key` value obtained from pfSense as shown below. Do not use both headers and username / password.
 
 The interface to monitor is defined by updating the `wan` parameter. It should be referenced as it is shown under Interfaces > Assignments in pfSense.
 
@@ -21,10 +21,10 @@ Allowed fields: `["load", "memory", "temp", "wanStatus", "wanIP", "disk"]` (maxi
 widget:
   type: pfsense
   url: http://pfsense.host.or.ip:port
-  username: user # optional, or API token
-  password: pass # optional, or API token
+  username: user # optional, or API key
+  password: pass # optional, or API key
   headers: # optional, or username/password
-    X-API-Key: token
+    X-API-Key: key
   wan: igb0
   version: 2 # optional, defaults to 1 for api v1
   fields: ["load", "memory", "temp", "wanStatus"] # optional

--- a/docs/widgets/services/pfsense.md
+++ b/docs/widgets/services/pfsense.md
@@ -9,7 +9,7 @@ This widget requires the installation of the [pfsense-api](https://github.com/ja
 
 Once pfSense API is installed, you can set the API to be read-only in System > API > Settings.
 
-There are two currently supported authentication modes: 'Local Database' and 'API Token'. For 'Local Database', use `username` and `password` with the credentials of an admin user. For 'API Token', utilize the `headers` parameter with `client_token` and `client_id` obtained from pfSense as shown below. Do not use both headers and username / password.
+There are two currently supported authentication modes: 'Local Database' and 'API Token'. For 'Local Database', use `username` and `password` with the credentials of an admin user. For 'API Token', utilize the `headers` parameter with the `X-API-Key` header name and `token` value obtained from pfSense as shown below. Do not use both headers and username / password.
 
 The interface to monitor is defined by updating the `wan` parameter. It should be referenced as it is shown under Interfaces > Assignments in pfSense.
 
@@ -24,7 +24,7 @@ widget:
   username: user # optional, or API token
   password: pass # optional, or API token
   headers: # optional, or username/password
-    Authorization: client_id client_token
+    X-API-Key: token
   wan: igb0
   version: 2 # optional, defaults to 1 for api v1
   fields: ["load", "memory", "temp", "wanStatus"] # optional

--- a/docs/widgets/services/pfsense.md
+++ b/docs/widgets/services/pfsense.md
@@ -9,13 +9,15 @@ This widget requires the installation of the [pfsense-api](https://github.com/ja
 
 Once pfSense API is installed, you can set the API to be read-only in System > API > Settings.
 
-There are two currently supported authentication modes: 'Local Database' and 'API Key'. For 'Local Database', use `username` and `password` with the credentials of an admin user. For 'API Key', utilize the `headers` parameter with the `X-API-Key` header name and `key` value obtained from pfSense as shown below. Do not use both headers and username / password.
+There are two currently supported authentication modes: 'Local Database' and 'API Key' (v2) / 'API Token' (v1). For 'Local Database', use `username` and `password` with the credentials of an admin user. The specifics of using the API key / token depend on the version of the pfSense API, see the config examples below. Do not use both headers and username / password.
 
 The interface to monitor is defined by updating the `wan` parameter. It should be referenced as it is shown under Interfaces > Assignments in pfSense.
 
 Load is returned instead of cpu utilization. This is a limitation in the pfSense API due to the complexity of this calculation. This may become available in future versions.
 
 Allowed fields: `["load", "memory", "temp", "wanStatus", "wanIP", "disk"]` (maximum of 4)
+
+For version 2:
 
 ```yaml
 widget:
@@ -28,4 +30,12 @@ widget:
   wan: igb0
   version: 2 # optional, defaults to 1 for api v1
   fields: ["load", "memory", "temp", "wanStatus"] # optional
+```
+
+For version 1:
+
+```yaml
+headers: # optional, or username/password
+  Authorization: client_id client_token # obtained from pfSense API
+version: 1
 ```


### PR DESCRIPTION
Fixing pfSense widget documentation for usage with an API key. Current documentation has incorrect header of `Authorization` and a value of `client_id client_token`. The correct header name is `X-API-Key` and the value is the API `key` produced by the pfSense v2 API package. I have tested this format and it works as expected. 

Example working config for reference:

```
    - pfSense:
        icon: pfsense.png
        href: https://pfsense.example.com
        description: router
        widget:
            type: pfsense
            url: https://pfsense.example.com
            headers:
              X-API-Key: 12345678
            wan: ix0
            version: 2
            fields: ["load", "memory", "wanStatus", "wanIP"]
```
pfSense API authorization documentation is here: https://pfrest.org/AUTHENTICATION_AND_AUTHORIZATION/

## Proposed change

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

Closes [Discussion #3716](https://github.com/gethomepage/homepage/discussions/3757)

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Documentation only
- [ ] Other (please explain)

## Checklist:

- [X] If applicable, I have added corresponding documentation changes.
- [X] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [X] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [X] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
