### PR TITLE
Fix: wg-easy widget show o.filter is not a function when wg-easy api return error

### DIFF
--- a/src/widgets/wgeasy/component.jsx
+++ b/src/widgets/wgeasy/component.jsx
@@ -15,7 +15,7 @@ export default function Component({ service }) {
     return <Container service={service} error={infoError} />;
   }
 
-  if (!infoData) {
+  if (!infoData || infoData.errorCode) {
     return (
       <Container service={service}>
         <Block label="wgeasy.connected" />


### PR DESCRIPTION
## Proposed change

![image](https://github.com/user-attachments/assets/29ea7cb4-742e-45e7-a32b-f3ce3673dbe5)

Closes #3658 

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
