### PR TITLE
Fix: query crowdsec api without limit

### DIFF
--- a/src/widgets/crowdsec/widget.js
+++ b/src/widgets/crowdsec/widget.js
@@ -7,10 +7,10 @@ const widget = {
 
   mappings: {
     alerts: {
-      endpoint: "alerts",
+      endpoint: "alerts?limit=0",
     },
     bans: {
-      endpoint: "alerts?decision_type=ban&origin=crowdsec&has_active_decision=1",
+      endpoint: "alerts?decision_type=ban&origin=crowdsec&has_active_decision=1&limit=0",
     },
   },
 };


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

The crowdsec widget queries the Crowdsec LAPI to get the amount of alerts and bans. Apparently there is a default limit of 100.

![grafik](https://github.com/user-attachments/assets/ed14f46c-9785-4bef-b6aa-dd4a0b76c75e)

Setting the limit parameter to 0 removes that limit and shows the correct number of alerts/bans:

![grafik](https://github.com/user-attachments/assets/55751666-8bb7-4aec-9a4d-d286d95c1b00)

Link to the [Crowdsec LAPI documentation](https://crowdsecurity.github.io/api_doc/lapi/#/watchers/searchAlerts)

Closes # (no issue)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
