### PR TITLE
Fix: correctly decode tab names with special chars

### DIFF
--- a/src/components/tab.jsx
+++ b/src/components/tab.jsx
@@ -14,7 +14,7 @@ export function slugifyAndEncode(tabName) {
 export default function Tab({ tab }) {
   const { activeTab, setActiveTab } = useContext(TabContext);
 
-  const matchesTab = decodeURI(activeTab) === slugify(tab);
+  const matchesTab = decodeURIComponent(activeTab) === slugify(tab);
 
   return (
     <li


### PR DESCRIPTION
## Proposed change

<img width="771" alt="Screenshot 2024-07-30 at 8 50 56 PM" src="https://github.com/user-attachments/assets/5ad89a70-7931-400f-a4e1-194b4fdfb628">


Closes #3796

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
