### PR TITLE
Enhancement: use tubearchivist stats endpoints

### DIFF
--- a/docs/widgets/services/tubearchivist.md
+++ b/docs/widgets/services/tubearchivist.md
@@ -5,7 +5,7 @@ description: Tube Archivist Widget Configuration
 
 Learn more about [Tube Archivist](https://github.com/tubearchivist/tubearchivist).
 
-Requires API key.
+You must be running at least version 0.4.4
 
 Allowed fields: `["downloads", "videos", "channels", "playlists"]`.
 
@@ -13,5 +13,5 @@ Allowed fields: `["downloads", "videos", "channels", "playlists"]`.
 widget:
   type: tubearchivist
   url: http://tubearchivist.host.or.ip
-  key: apikeyapikeyapikeyapikeyapikey
+  key: tubearchivistapikey
 ```

--- a/src/widgets/tubearchivist/component.jsx
+++ b/src/widgets/tubearchivist/component.jsx
@@ -32,16 +32,10 @@ export default function Component({ service }) {
 
   return (
     <Container service={service}>
-      <Block
-        label="tubearchivist.downloads"
-        value={t("common.number", { value: downloadsData?.paginate?.total_hits })}
-      />
-      <Block label="tubearchivist.videos" value={t("common.number", { value: videosData?.paginate?.total_hits })} />
-      <Block label="tubearchivist.channels" value={t("common.number", { value: channelsData?.paginate?.total_hits })} />
-      <Block
-        label="tubearchivist.playlists"
-        value={t("common.number", { value: playlistsData?.paginate?.total_hits })}
-      />
+      <Block label="tubearchivist.downloads" value={t("common.number", { value: downloadsData.doc_count ?? 0 })} />
+      <Block label="tubearchivist.videos" value={t("common.number", { value: videosData.doc_count ?? 0 })} />
+      <Block label="tubearchivist.channels" value={t("common.number", { value: channelsData.doc_count ?? 0 })} />
+      <Block label="tubearchivist.playlists" value={t("common.number", { value: playlistsData.doc_count ?? 0 })} />
     </Container>
   );
 }

--- a/src/widgets/tubearchivist/widget.js
+++ b/src/widgets/tubearchivist/widget.js
@@ -6,20 +6,23 @@ const widget = {
 
   mappings: {
     downloads: {
-      endpoint: "download",
-      validate: ["paginate"],
+      endpoint: "stats/download",
+      validate: ["doc_count"],
     },
     videos: {
-      endpoint: "video",
-      validate: ["paginate"],
+      endpoint: "stats/video",
+      validate: ["doc_count"],
     },
     channels: {
-      endpoint: "channel",
-      validate: ["paginate"],
+      endpoint: "stats/channel",
+      validate: ["doc_count"],
     },
     playlists: {
-      endpoint: "playlist",
-      validate: ["paginate"],
+      endpoint: "stats/playlist",
+      validate: ["doc_count"],
+    },
+    stats: {
+      endpoint: "stats",
     },
   },
 };


### PR DESCRIPTION
## Proposed change

Seems like this was introduced a year or so ago, https://github.com/tubearchivist/tubearchivist/releases/tag/v0.4.4 so essentially will be required to use the widget now.

Closes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
