### PR TITLE
Chore: update Gamedig

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "compare-versions": "^6.1.0",
         "dockerode": "^4.0.2",
         "follow-redirects": "^1.15.6",
-        "gamedig": "^4.3.1",
+        "gamedig": "^5.1.1",
         "i18next": "^21.10.0",
         "js-yaml": "^4.1.0",
         "json-rpc-2.0": "^1.7.0",
@@ -3419,25 +3419,25 @@
       }
     },
     "node_modules/gamedig": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/gamedig/-/gamedig-4.3.1.tgz",
-      "integrity": "sha512-et9Aq4wlD0cExXEO3r3LWiEEjOzsnG5l/0YSqza7FZLoJqunNT6DedkAXAdeOqAqStkRQahQiPFjx2WCg4SOtg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/gamedig/-/gamedig-5.1.1.tgz",
+      "integrity": "sha512-r0+GofQFtsuMEVKmF502ULl0bpo/QhPfkY7srLW/EicgMiNE682NqpjKt9fhM0U8DFymlUJ28lmaTHa5Q9TJIQ==",
       "dependencies": {
-        "cheerio": "^1.0.0-rc.10",
-        "gbxremote": "^0.2.1",
-        "got": "^12.1.0",
-        "iconv-lite": "^0.6.3",
-        "long": "^5.2.0",
-        "minimist": "^1.2.6",
-        "punycode": "^2.1.1",
-        "seek-bzip": "^2.0.0",
-        "varint": "^6.0.0"
+        "cheerio": "1.0.0-rc.12",
+        "gbxremote": "0.2.1",
+        "got": "13.0.0",
+        "iconv-lite": "0.6.3",
+        "long": "5.2.3",
+        "minimist": "1.2.8",
+        "punycode": "2.3.1",
+        "seek-bzip": "2.0.0",
+        "varint": "6.0.0"
       },
       "bin": {
         "gamedig": "bin/gamedig.js"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.20.0"
       }
     },
     "node_modules/gbxremote": {
@@ -3616,9 +3616,9 @@
       }
     },
     "node_modules/got": {
-      "version": "12.6.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-12.6.1.tgz",
-      "integrity": "sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-13.0.0.tgz",
+      "integrity": "sha512-XfBk1CxOOScDcMr9O1yKkNaQyy865NbYs+F7dr4H0LZMVgCj2Le59k6PqbNHoL5ToeaEQUYh6c6yMfVcc6SJxA==",
       "dependencies": {
         "@sindresorhus/is": "^5.2.0",
         "@szmarczak/http-timer": "^5.0.1",
@@ -3633,7 +3633,7 @@
         "responselike": "^3.0.0"
       },
       "engines": {
-        "node": ">=14.16"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/got?sponsor=1"
@@ -5036,9 +5036,9 @@
       }
     },
     "node_modules/normalize-url": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.0.tgz",
-      "integrity": "sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.1.tgz",
+      "integrity": "sha512-IO9QvjUMWxPQQhs60oOu10CRkWCiZzSUkzbXGGV9pviYl1fXYcvkzQ5jV9z8Y6un8ARoVRl4EtC6v6jNqbaJ/w==",
       "engines": {
         "node": ">=14.16"
       },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "compare-versions": "^6.1.0",
     "dockerode": "^4.0.2",
     "follow-redirects": "^1.15.6",
-    "gamedig": "^4.3.1",
+    "gamedig": "^5.1.1",
     "i18next": "^21.10.0",
     "js-yaml": "^4.1.0",
     "json-rpc-2.0": "^1.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^1.15.6
         version: 1.15.6
       gamedig:
-        specifier: ^4.3.1
-        version: 4.3.1
+        specifier: ^5.1.1
+        version: 5.1.1
       i18next:
         specifier: ^21.10.0
         version: 21.10.0
@@ -1274,9 +1274,9 @@ packages:
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
-  gamedig@4.3.1:
-    resolution: {integrity: sha512-et9Aq4wlD0cExXEO3r3LWiEEjOzsnG5l/0YSqza7FZLoJqunNT6DedkAXAdeOqAqStkRQahQiPFjx2WCg4SOtg==}
-    engines: {node: '>=14.0.0'}
+  gamedig@5.1.1:
+    resolution: {integrity: sha512-r0+GofQFtsuMEVKmF502ULl0bpo/QhPfkY7srLW/EicgMiNE682NqpjKt9fhM0U8DFymlUJ28lmaTHa5Q9TJIQ==}
+    engines: {node: '>=16.20.0'}
     hasBin: true
 
   gbxremote@0.2.1:
@@ -1336,9 +1336,9 @@ packages:
   gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
 
-  got@12.6.1:
-    resolution: {integrity: sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==}
-    engines: {node: '>=14.16'}
+  got@13.0.0:
+    resolution: {integrity: sha512-XfBk1CxOOScDcMr9O1yKkNaQyy865NbYs+F7dr4H0LZMVgCj2Le59k6PqbNHoL5ToeaEQUYh6c6yMfVcc6SJxA==}
+    engines: {node: '>=16'}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -1872,8 +1872,8 @@ packages:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
 
-  normalize-url@8.0.0:
-    resolution: {integrity: sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw==}
+  normalize-url@8.0.1:
+    resolution: {integrity: sha512-IO9QvjUMWxPQQhs60oOu10CRkWCiZzSUkzbXGGV9pviYl1fXYcvkzQ5jV9z8Y6un8ARoVRl4EtC6v6jNqbaJ/w==}
     engines: {node: '>=14.16'}
 
   npm-run-path@4.0.1:
@@ -3256,7 +3256,7 @@ snapshots:
       http-cache-semantics: 4.1.1
       keyv: 4.5.4
       mimic-response: 4.0.0
-      normalize-url: 8.0.0
+      normalize-url: 8.0.1
       responselike: 3.0.0
 
   cal-parser@1.0.2:
@@ -4086,11 +4086,11 @@ snapshots:
 
   functions-have-names@1.2.3: {}
 
-  gamedig@4.3.1:
+  gamedig@5.1.1:
     dependencies:
       cheerio: 1.0.0-rc.12
       gbxremote: 0.2.1
-      got: 12.6.1
+      got: 13.0.0
       iconv-lite: 0.6.3
       long: 5.2.3
       minimist: 1.2.8
@@ -4183,7 +4183,7 @@ snapshots:
     dependencies:
       get-intrinsic: 1.2.4
 
-  got@12.6.1:
+  got@13.0.0:
     dependencies:
       '@sindresorhus/is': 5.6.0
       '@szmarczak/http-timer': 5.0.1
@@ -4684,7 +4684,7 @@ snapshots:
 
   normalize-range@0.1.2: {}
 
-  normalize-url@8.0.0: {}
+  normalize-url@8.0.1: {}
 
   npm-run-path@4.0.1:
     dependencies:

--- a/src/widgets/gamedig/proxy.js
+++ b/src/widgets/gamedig/proxy.js
@@ -1,15 +1,14 @@
 import createLogger from "utils/logger";
 import getServiceWidget from "utils/config/service-helpers";
+import {GameDig as gamedig} from "gamedig";
 
 const proxyName = "gamedigProxyHandler";
 const logger = createLogger(proxyName);
-const gamedig = require("gamedig");
 
 export default async function gamedigProxyHandler(req, res) {
   const { group, service } = req.query;
   const serviceWidget = await getServiceWidget(group, service);
   const url = new URL(serviceWidget.url);
-  const gamedigArgs = serviceWidget.gamedigArgs;
 
   try {
     const serverData = await gamedig.query({
@@ -17,7 +16,6 @@ export default async function gamedigProxyHandler(req, res) {
       host: url.hostname,
       port: url.port,
       givenPortOnly: true,
-      ...gamedigArgs
     });
 
     res.status(200).send({

--- a/src/widgets/gamedig/proxy.js
+++ b/src/widgets/gamedig/proxy.js
@@ -9,6 +9,7 @@ export default async function gamedigProxyHandler(req, res) {
   const { group, service } = req.query;
   const serviceWidget = await getServiceWidget(group, service);
   const url = new URL(serviceWidget.url);
+  const gamedigArgs = serviceWidget.gamedigArgs;
 
   try {
     const serverData = await gamedig.query({
@@ -16,6 +17,7 @@ export default async function gamedigProxyHandler(req, res) {
       host: url.hostname,
       port: url.port,
       givenPortOnly: true,
+      ...gamedigArgs
     });
 
     res.status(200).send({

--- a/src/widgets/gamedig/proxy.js
+++ b/src/widgets/gamedig/proxy.js
@@ -1,6 +1,7 @@
+import { GameDig } from "gamedig";
+
 import createLogger from "utils/logger";
 import getServiceWidget from "utils/config/service-helpers";
-import {GameDig as gamedig} from "gamedig";
 
 const proxyName = "gamedigProxyHandler";
 const logger = createLogger(proxyName);
@@ -11,7 +12,7 @@ export default async function gamedigProxyHandler(req, res) {
   const url = new URL(serviceWidget.url);
 
   try {
-    const serverData = await gamedig.query({
+    const serverData = await GameDig.query({
       type: serviceWidget.serverType,
       host: url.hostname,
       port: url.port,

--- a/src/widgets/gamedig/proxy.js
+++ b/src/widgets/gamedig/proxy.js
@@ -16,6 +16,7 @@ export default async function gamedigProxyHandler(req, res) {
       host: url.hostname,
       port: url.port,
       givenPortOnly: true,
+      checkOldIDs: true,
     });
 
     res.status(200).send({


### PR DESCRIPTION
## Proposed change

I upgraded the gamedig library to version 5.1.1 and enabled the checkOldIDs option to ensure that requests using old game IDs are still processed correctly. I verified that it functions correctly with both old and new IDs.

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
