### PR TITLE
Documentation: remove version line from readme docker compose yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Please note that when using features such as widgets, Homepage can access person
 Using docker compose:
 
 ```yaml
-version: "3.3"
+---
 services:
   homepage:
     image: ghcr.io/gethomepage/homepage:latest

--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ Please note that when using features such as widgets, Homepage can access person
 Using docker compose:
 
 ```yaml
----
 services:
   homepage:
     image: ghcr.io/gethomepage/homepage:latest


### PR DESCRIPTION
Removed version: 3.3 line from docker compose yaml. Specifying version is obsolete and will throw a warning message in Docker.