### PR TITLE
Documentation: fix indentation for proxmox docs.

### DIFF
--- a/docs/widgets/services/proxmox.md
+++ b/docs/widgets/services/proxmox.md
@@ -15,15 +15,15 @@ You will need to generate an API Token for new or an existing user. Here is an e
 4. Name the group something informative, like api-ro-users
 5. Click on the Permissions "folder"
 6. Click Add -> Group Permission
-   - Path: /
-   - Group: group from bullet 4 above
-   - Role: PVEAuditor
-   - Propagate: Checked
+    - Path: /
+    - Group: group from bullet 4 above
+    - Role: PVEAuditor
+    - Propagate: Checked
 7. Expand Permissions, click on Users
 8. Click the Add button
-   - User name: something informative like `api`
-   - Realm: Linux PAM standard authentication
-   - Group: group from bullet 4 above
+    - User name: something informative like `api`
+    - Realm: Linux PAM standard authentication
+    - Group: group from bullet 4 above
 9. Expand Permissions, click on API Tokens
 10. Click the Add button
     - User: user from bullet 8 above

--- a/docs/widgets/services/proxmox.md
+++ b/docs/widgets/services/proxmox.md
@@ -9,22 +9,22 @@ This widget shows the running and total counts of both QEMU VMs and LX Container
 
 You will need to generate an API Token for new or an existing user. Here is an example of how to do this for a new user.
 
-1. Navigate to the Proxmox portal, click on Datacenter
-2. Expand Permissions, click on Groups
-3. Click the Create button
-4. Name the group something informative, like api-ro-users
-5. Click on the Permissions "folder"
-6. Click Add -> Group Permission
+1.  Navigate to the Proxmox portal, click on Datacenter
+2.  Expand Permissions, click on Groups
+3.  Click the Create button
+4.  Name the group something informative, like api-ro-users
+5.  Click on the Permissions "folder"
+6.  Click Add -> Group Permission
     - Path: /
     - Group: group from bullet 4 above
     - Role: PVEAuditor
     - Propagate: Checked
-7. Expand Permissions, click on Users
-8. Click the Add button
+7.  Expand Permissions, click on Users
+8.  Click the Add button
     - User name: something informative like `api`
     - Realm: Linux PAM standard authentication
     - Group: group from bullet 4 above
-9. Expand Permissions, click on API Tokens
+9.  Expand Permissions, click on API Tokens
 10. Click the Add button
     - User: user from bullet 8 above
     - Token ID: something informative like the application or purpose like `homepage`


### PR DESCRIPTION
## Proposed change
I added one space for the indentation of the proxmox.md. It's how it's supposed to be but since they only have three spaces they aren't indented properly.

![image](https://github.com/user-attachments/assets/c059c0b5-b6a8-4341-86b0-e9ade2812578)

The screenshot shows that the first two things would look like the third set of things.
<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Documentation only
- [ ] Other (please explain)

## Checklist:

- [X] If applicable, I have added corresponding documentation changes.
- [X] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [X] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [X] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
