### PR TITLE
Refactor: change RomM API endpoint

### DIFF
--- a/docs/widgets/services/romm.md
+++ b/docs/widgets/services/romm.md
@@ -3,7 +3,7 @@ title: Romm
 description: Romm Widget Configuration
 ---
 
-Allowed fields: `["platforms", "totalRoms", "totalSaves", "totalStates", "totalScreenshots", "totalFilesize"]`.
+Allowed fields: `["platforms", "roms", "saves", "states", "screenshots", "totalfilesize"]`.
 
 ```yaml
 widget:
@@ -11,5 +11,5 @@ widget:
   url: http://romm.host.or.ip
   username: username # optional
   password: password # optional
-  fields: ["platforms", "totalRoms", "totalSaves", "totalScreenshots"]
+  fields: ["platforms", "roms", "saves", "screenshots"]
 ```

--- a/docs/widgets/services/romm.md
+++ b/docs/widgets/services/romm.md
@@ -3,7 +3,7 @@ title: Romm
 description: Romm Widget Configuration
 ---
 
-Allowed fields: `["platforms", "roms", "saves", "states", "screenshots", "totalfilesize"]`.
+Allowed fields: `["platforms", "totalRoms", "saves", "states", "screenshots", "totalfilesize"]`.
 If more than (4) fields are provided, only the first (4) will be used.
 
 ```yaml
@@ -12,5 +12,5 @@ widget:
   url: http://romm.host.or.ip
   username: username # optional
   password: password # optional
-  fields: ["platforms", "roms", "saves", "states"] # optional - default fields shown
+  fields: ["platforms", "totalRoms", "saves", "states"] # optional - default fields shown
 ```

--- a/docs/widgets/services/romm.md
+++ b/docs/widgets/services/romm.md
@@ -4,6 +4,7 @@ description: Romm Widget Configuration
 ---
 
 Allowed fields: `["platforms", "roms", "saves", "states", "screenshots", "totalfilesize"]`.
+If more than (4) fields are provided, only the first (4) will be used.
 
 ```yaml
 widget:
@@ -11,5 +12,5 @@ widget:
   url: http://romm.host.or.ip
   username: username # optional
   password: password # optional
-  fields: ["platforms", "roms", "saves", "screenshots"]
+  fields: ["platforms", "roms", "saves", "states"] # optional - default fields shown
 ```

--- a/docs/widgets/services/romm.md
+++ b/docs/widgets/services/romm.md
@@ -3,7 +3,7 @@ title: Romm
 description: Romm Widget Configuration
 ---
 
-Allowed fields: `["platforms", "totalRoms"]`.
+Allowed fields: `["platforms", "totalRoms", "totalSaves", "totalStates", "totalScreenshots", "totalFilesize"]`.
 
 ```yaml
 widget:
@@ -11,4 +11,5 @@ widget:
   url: http://romm.host.or.ip
   username: username # optional
   password: password # optional
+  fields: ["platforms", "totalRoms", "totalSaves", "totalScreenshots"]
 ```

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -831,7 +831,11 @@
     },
     "romm": {
         "platforms": "Platforms",
-        "totalRoms": "Total ROMs"
+        "roms": "Games",
+        "saves": "Saves",
+        "states": "States",
+        "screenshots": "Screenshots",
+        "totalfilesize": "Total Size"
     },
     "netdata": {
       "warnings": "Warnings",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -831,7 +831,7 @@
     },
     "romm": {
         "platforms": "Platforms",
-        "roms": "Games",
+        "totalRoms": "Games",
         "saves": "Saves",
         "states": "States",
         "screenshots": "Screenshots",

--- a/src/widgets/romm/component.jsx
+++ b/src/widgets/romm/component.jsx
@@ -18,8 +18,17 @@ export default function Component({ service }) {
     );
   }
 
-  if (responseError) {
-    return <Container service={service} error={responseError} />;
+  if (!response) {
+    return (
+      <Container service={service}>
+        <Block label="romm.platforms" />
+        <Block label="romm.roms" />
+        <Block label="romm.saves" />
+        <Block label="romm.states" />
+        <Block label="romm.screenshots" />
+        <Block label="romm.totalfilesize" />
+      </Container>
+    );
   }
 
   if (response) {
@@ -28,11 +37,11 @@ export default function Component({ service }) {
     return (
       <Container service={service}>
         <Block label="romm.platforms" value={t("common.number", { value: response.PLATFORMS })} />
-        <Block label="romm.totalRoms" value={t("common.number", { value: response.ROMS })} />
-        <Block label="romm.totalSaves" value={t("common.number", { value: response.SAVES })} />
-        <Block label="romm.totalStates" value={t("common.number", { value: response.STATES })} />
-        <Block label="romm.totalScreenshots" value={t("common.number", { value: response.SCREENSHOTS })} />
-        <Block label="romm.totalFilesize" value={t("common.filesize", { value: totalFilesizeGB })} />
+        <Block label="romm.roms" value={t("common.number", { value: response.ROMS })} />
+        <Block label="romm.saves" value={t("common.number", { value: response.SAVES })} />
+        <Block label="romm.states" value={t("common.number", { value: response.STATES })} />
+        <Block label="romm.screenshots" value={t("common.number", { value: response.SCREENSHOTS })} />
+        <Block label="romm.totalfilesize" value={t("common.filesize", { value: totalFilesizeGB })} />
       </Container>
     );
   }

--- a/src/widgets/romm/component.jsx
+++ b/src/widgets/romm/component.jsx
@@ -23,22 +23,17 @@ export default function Component({ service }) {
   }
 
   if (response) {
-  const platforms = response.PLATFORMS;
-  const totalRoms = response.ROMS;
-  const totalSaves = response.SAVES;
-  const totalStates = response.STATES;
-  const totalScreenshots = response.SCREENSHOTS;
-  const totalFilesizeGB = (response.FILESIZE / (1024 ** 3)).toFixed(2);
+    const totalFilesizeGB = (response.FILESIZE / (1024 ** 3)).toFixed(2);
 
-  return (
-    <Container service={service}>
-      <Block label="romm.platforms" value={t("common.number", { value: platforms })} />
-      <Block label="romm.totalRoms" value={t("common.number", { value: totalRoms })} />
-      <Block label="romm.totalSaves" value={t("common.number", { value: totalSaves })} />
-      <Block label="romm.totalStates" value={t("common.number", { value: totalStates })} />
-      <Block label="romm.totalScreenshots" value={t("common.number", { value: totalScreenshots })} />
-      <Block label="romm.totalFilesize" value={t("common.filesize", { value: totalFilesizeGB })} />
-    </Container>
-  );
- }
+    return (
+      <Container service={service}>
+        <Block label="romm.platforms" value={t("common.number", { value: response.PLATFORMS })} />
+        <Block label="romm.totalRoms" value={t("common.number", { value: response.ROMS })} />
+        <Block label="romm.totalSaves" value={t("common.number", { value: response.SAVES })} />
+        <Block label="romm.totalStates" value={t("common.number", { value: response.STATES })} />
+        <Block label="romm.totalScreenshots" value={t("common.number", { value: response.SCREENSHOTS })} />
+        <Block label="romm.totalFilesize" value={t("common.filesize", { value: totalFilesizeGB })} />
+      </Container>
+    );
+  }
 }

--- a/src/widgets/romm/component.jsx
+++ b/src/widgets/romm/component.jsx
@@ -4,7 +4,8 @@ import Container from "components/services/widget/container";
 import Block from "components/services/widget/block";
 import useWidgetAPI from "utils/proxy/use-widget-api";
 
-export const rommDefaultFields = ["platforms", "totalRoms", "saves", "states"];
+const ROMM_DEFAULT_FIELDS = ["platforms", "totalRoms", "saves", "states"];
+const MAX_ALLOWED_FIELDS = 4;
 
 export default function Component({ service }) {
   const { widget } = service;
@@ -15,12 +16,9 @@ export default function Component({ service }) {
     return <Container service={service} error={responseError} />;
   }
 
-  // Default fields
   if (!widget.fields?.length > 0) {
-    widget.fields = rommDefaultFields;
-  }
-  const MAX_ALLOWED_FIELDS = 4;
-  if (widget.fields?.length > MAX_ALLOWED_FIELDS) {
+    widget.fields = ROMM_DEFAULT_FIELDS;
+  } else if (widget.fields.length > MAX_ALLOWED_FIELDS) {
     widget.fields = widget.fields.slice(0, MAX_ALLOWED_FIELDS);
   }
 

--- a/src/widgets/romm/component.jsx
+++ b/src/widgets/romm/component.jsx
@@ -23,13 +23,22 @@ export default function Component({ service }) {
   }
 
   if (response) {
-    const platforms = response.filter((x) => x.rom_count !== 0).length;
-    const totalRoms = response.reduce((total, stat) => total + stat.rom_count, 0);
-    return (
-      <Container service={service}>
-        <Block label="romm.platforms" value={t("common.number", { value: platforms })} />
-        <Block label="romm.totalRoms" value={t("common.number", { value: totalRoms })} />
-      </Container>
-    );
-  }
+  const platforms = response.PLATFORMS;
+  const totalRoms = response.ROMS;
+  const totalSaves = response.SAVES;
+  const totalStates = response.STATES;
+  const totalScreenshots = response.SCREENSHOTS;
+  const totalFilesizeGB = (response.FILESIZE / (1024 ** 3)).toFixed(2);
+
+  return (
+    <Container service={service}>
+      <Block label="romm.platforms" value={t("common.number", { value: platforms })} />
+      <Block label="romm.totalRoms" value={t("common.number", { value: totalRoms })} />
+      <Block label="romm.totalSaves" value={t("common.number", { value: totalSaves })} />
+      <Block label="romm.totalStates" value={t("common.number", { value: totalStates })} />
+      <Block label="romm.totalScreenshots" value={t("common.number", { value: totalScreenshots })} />
+      <Block label="romm.totalFilesize" value={t("common.filesize", { value: totalFilesizeGB })} />
+    </Container>
+  );
+ }
 }

--- a/src/widgets/romm/component.jsx
+++ b/src/widgets/romm/component.jsx
@@ -4,7 +4,7 @@ import Container from "components/services/widget/container";
 import Block from "components/services/widget/block";
 import useWidgetAPI from "utils/proxy/use-widget-api";
 
-export const rommDefaultFields = ["platforms", "roms", "saves", "states"];
+export const rommDefaultFields = ["platforms", "totalRoms", "saves", "states"];
 
 export default function Component({ service }) {
   const { widget } = service;
@@ -28,7 +28,7 @@ export default function Component({ service }) {
     return (
       <Container service={service}>
         <Block label="romm.platforms" />
-        <Block label="romm.roms" />
+        <Block label="romm.totalRoms" />
         <Block label="romm.saves" />
         <Block label="romm.states" />
         <Block label="romm.screenshots" />
@@ -41,7 +41,7 @@ export default function Component({ service }) {
     return (
       <Container service={service}>
         <Block label="romm.platforms" value={t("common.number", { value: response.PLATFORMS })} />
-        <Block label="romm.roms" value={t("common.number", { value: response.ROMS })} />
+        <Block label="romm.totalRoms" value={t("common.number", { value: response.ROMS })} />
         <Block label="romm.saves" value={t("common.number", { value: response.SAVES })} />
         <Block label="romm.states" value={t("common.number", { value: response.STATES })} />
         <Block label="romm.screenshots" value={t("common.number", { value: response.SCREENSHOTS })} />

--- a/src/widgets/romm/component.jsx
+++ b/src/widgets/romm/component.jsx
@@ -23,7 +23,7 @@ export default function Component({ service }) {
   }
 
   if (response) {
-    const totalFilesizeGB = (response.FILESIZE / (1024 ** 3)).toFixed(2);
+    const totalFilesizeGB = (response.FILESIZE / 1024 ** 3).toFixed(2);
 
     return (
       <Container service={service}>

--- a/src/widgets/romm/component.jsx
+++ b/src/widgets/romm/component.jsx
@@ -4,18 +4,24 @@ import Container from "components/services/widget/container";
 import Block from "components/services/widget/block";
 import useWidgetAPI from "utils/proxy/use-widget-api";
 
+export const rommDefaultFields = ["platforms", "roms", "saves", "states"];
+
 export default function Component({ service }) {
   const { widget } = service;
   const { t } = useTranslation();
-
   const { data: response, error: responseError } = useWidgetAPI(widget, "statistics");
 
   if (responseError) {
-    return (
-      <Container service={service}>
-        <Block label="Error" value={responseError.message} />
-      </Container>
-    );
+    return <Container service={service} error={responseError} />;
+  }
+
+  // Default fields
+  if (!widget.fields?.length > 0) {
+    widget.fields = rommDefaultFields;
+  }
+  const MAX_ALLOWED_FIELDS = 4;
+  if (widget.fields?.length > MAX_ALLOWED_FIELDS) {
+    widget.fields = widget.fields.slice(0, MAX_ALLOWED_FIELDS);
   }
 
   if (!response) {
@@ -32,8 +38,6 @@ export default function Component({ service }) {
   }
 
   if (response) {
-    const totalFilesizeGB = (response.FILESIZE / 1024 ** 3).toFixed(2);
-
     return (
       <Container service={service}>
         <Block label="romm.platforms" value={t("common.number", { value: response.PLATFORMS })} />
@@ -41,7 +45,7 @@ export default function Component({ service }) {
         <Block label="romm.saves" value={t("common.number", { value: response.SAVES })} />
         <Block label="romm.states" value={t("common.number", { value: response.STATES })} />
         <Block label="romm.screenshots" value={t("common.number", { value: response.SCREENSHOTS })} />
-        <Block label="romm.totalfilesize" value={t("common.filesize", { value: totalFilesizeGB })} />
+        <Block label="romm.totalfilesize" value={t("common.bytes", { value: response.FILESIZE })} />
       </Container>
     );
   }

--- a/src/widgets/romm/widget.js
+++ b/src/widgets/romm/widget.js
@@ -6,7 +6,7 @@ const widget = {
 
   mappings: {
     statistics: {
-      endpoint: "platforms",
+      endpoint: "stats",
     },
   },
 };


### PR DESCRIPTION
## Proposed change

An update to the currently existing RomM widget. This update changes the endpoint from the currently set 'platforms' endpoint to the more concise and cleaner 'stats' endpoint. The stats endpoint gives three additional fields of information that the existing two give, also without needing the calculations of the existing endpoint. Documentation has been updated to reflect the changes as well.
