### PR TITLE
Chore: handle mealie API change

### DIFF
--- a/docs/widgets/services/mealie.md
+++ b/docs/widgets/services/mealie.md
@@ -14,5 +14,5 @@ widget:
   type: mealie
   url: http://mealie-frontend.host.or.ip
   key: mealieapitoken
-  version: 1 # optional, defaults to 1
+  version: 2 # only required if version > 1, defaults to 1
 ```

--- a/docs/widgets/services/mealie.md
+++ b/docs/widgets/services/mealie.md
@@ -14,4 +14,5 @@ widget:
   type: mealie
   url: http://mealie-frontend.host.or.ip
   key: mealieapitoken
+  version: 1 # optional, defaults to 1
 ```

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -402,7 +402,7 @@ export function cleanServiceGroups(groups) {
           // frigate
           enableRecentEvents,
 
-          // glances, pihole, pfsense
+          // glances, mealie, pihole, pfsense
           version,
 
           // glances
@@ -512,9 +512,6 @@ export function cleanServiceGroups(groups) {
         if (type === "unifi") {
           if (site) cleanedService.widget.site = site;
         }
-        if (type === "pfsense") {
-          if (version) cleanedService.widget.version = version;
-        }
         if (type === "proxmox") {
           if (node) cleanedService.widget.node = node;
         }
@@ -561,7 +558,7 @@ export function cleanServiceGroups(groups) {
           if (snapshotHost) cleanedService.widget.snapshotHost = snapshotHost;
           if (snapshotPath) cleanedService.widget.snapshotPath = snapshotPath;
         }
-        if (["glances", "pihole"].includes(type)) {
+        if (["glances", "mealie", "pfsense", "pihole"].includes(type)) {
           if (version) cleanedService.widget.version = version;
         }
         if (type === "glances") {

--- a/src/widgets/mealie/component.jsx
+++ b/src/widgets/mealie/component.jsx
@@ -6,7 +6,7 @@ export default function Component({ service }) {
   const { widget } = service;
 
   const { data: versionData, error: versionError } = useWidgetAPI(widget, "version");
-  const endpoint = parseInt(versionData?.version) >= 2 || versionData?.version === "nightly" ? "households" : "groups";
+  const endpoint = parseInt(versionData?.version, 10) >= 2 || versionData?.version === "nightly" ? "households" : "groups";
 
   const { data: mealieData, error: mealieError } = useWidgetAPI(widget, endpoint);
 

--- a/src/widgets/mealie/component.jsx
+++ b/src/widgets/mealie/component.jsx
@@ -6,7 +6,7 @@ export default function Component({ service }) {
   const { widget } = service;
 
   const { data: versionData, error: versionError } = useWidgetAPI(widget, "version");
-  const endpoint = versionData?.version.major >= 2 || versionData?.version === "nightly" ? "households" : "groups";
+  const endpoint = parseInt(versionData?.version) >= 2 || versionData?.version === "nightly" ? "households" : "groups";
 
   const { data: mealieData, error: mealieError } = useWidgetAPI(widget, endpoint);
 

--- a/src/widgets/mealie/component.jsx
+++ b/src/widgets/mealie/component.jsx
@@ -1,21 +1,20 @@
+import { useTranslation } from "next-i18next";
+
 import Container from "components/services/widget/container";
 import Block from "components/services/widget/block";
 import useWidgetAPI from "utils/proxy/use-widget-api";
 
 export default function Component({ service }) {
+  const { t } = useTranslation();
   const { widget } = service;
+  const version = widget.version ?? 1;
+  const { data, error } = useWidgetAPI(widget, version === 1 ? "statisticsv1" : "statisticsv2");
 
-  const { data: versionData, error: versionError } = useWidgetAPI(widget, "version");
-  const endpoint =
-    versionData?.version?.startsWith("v2") || versionData?.version === "nightly" ? "households" : "groups";
-
-  const { data: mealieData, error: mealieError } = useWidgetAPI(widget, endpoint);
-
-  if (versionError || mealieError || mealieData?.statusCode === 401) {
-    return <Container service={service} error={versionError ?? mealieError ?? mealieData} />;
+  if (error) {
+    return <Container service={service} error={error} />;
   }
 
-  if (!mealieData) {
+  if (!data) {
     return (
       <Container service={service}>
         <Block label="mealie.recipes" />
@@ -25,13 +24,12 @@ export default function Component({ service }) {
       </Container>
     );
   }
-
   return (
     <Container service={service}>
-      <Block label="mealie.recipes" value={mealieData.totalRecipes} />
-      <Block label="mealie.users" value={mealieData.totalUsers} />
-      <Block label="mealie.categories" value={mealieData.totalCategories} />
-      <Block label="mealie.tags" value={mealieData.totalTags} />
+      <Block label="mealie.recipes" value={t("common.number", { value: data.totalRecipes })} />
+      <Block label="mealie.users" value={t("common.number", { value: data.totalUsers })} />
+      <Block label="mealie.categories" value={t("common.number", { value: data.totalCategories })} />
+      <Block label="mealie.tags" value={t("common.number", { value: data.totalTags })} />
     </Container>
   );
 }

--- a/src/widgets/mealie/component.jsx
+++ b/src/widgets/mealie/component.jsx
@@ -6,7 +6,7 @@ export default function Component({ service }) {
   const { widget } = service;
 
   const { data: versionData, error: versionError } = useWidgetAPI(widget, "version");
-  const endpoint = parseInt(versionData?.version, 10) >= 2 || versionData?.version === "nightly" ? "households" : "groups";
+  const endpoint = versionData?.version?.startsWith("v2") || versionData?.version === "nightly" ? "households" : "groups";
 
   const { data: mealieData, error: mealieError } = useWidgetAPI(widget, endpoint);
 

--- a/src/widgets/mealie/component.jsx
+++ b/src/widgets/mealie/component.jsx
@@ -6,7 +6,8 @@ export default function Component({ service }) {
   const { widget } = service;
 
   const { data: versionData, error: versionError } = useWidgetAPI(widget, "version");
-  const endpoint = versionData?.version?.startsWith("v2") || versionData?.version === "nightly" ? "households" : "groups";
+  const endpoint =
+    versionData?.version?.startsWith("v2") || versionData?.version === "nightly" ? "households" : "groups";
 
   const { data: mealieData, error: mealieError } = useWidgetAPI(widget, endpoint);
 

--- a/src/widgets/mealie/component.jsx
+++ b/src/widgets/mealie/component.jsx
@@ -5,10 +5,13 @@ import useWidgetAPI from "utils/proxy/use-widget-api";
 export default function Component({ service }) {
   const { widget } = service;
 
-  const { data: mealieData, error: mealieError } = useWidgetAPI(widget);
+  const { data: versionData, error: versionError } = useWidgetAPI(widget, "version");
+  const endpoint = versionData?.version.major >= 2 || versionData?.version === "nightly" ? "households" : "groups";
 
-  if (mealieError || mealieData?.statusCode === 401) {
-    return <Container service={service} error={mealieError ?? mealieData} />;
+  const { data: mealieData, error: mealieError } = useWidgetAPI(widget, endpoint);
+
+  if (versionError || mealieError || mealieData?.statusCode === 401) {
+    return <Container service={service} error={versionError ?? mealieError ?? mealieData} />;
   }
 
   if (!mealieData) {

--- a/src/widgets/mealie/widget.js
+++ b/src/widgets/mealie/widget.js
@@ -5,13 +5,10 @@ const widget = {
   proxyHandler: credentialedProxyHandler,
 
   mappings: {
-    version: {
-      endpoint: "app/about",
-    },
-    groups: {
+    statisticsv1: {
       endpoint: "groups/statistics",
     },
-    households: {
+    statisticsv2: {
       endpoint: "households/statistics",
     },
   },

--- a/src/widgets/mealie/widget.js
+++ b/src/widgets/mealie/widget.js
@@ -1,8 +1,20 @@
 import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
 
 const widget = {
-  api: "{url}/api/groups/statistics",
+  api: "{url}/api/{endpoint}",
   proxyHandler: credentialedProxyHandler,
+
+  mappings: {
+    version: {
+      endpoint: "app/about",
+    },
+    groups: {
+      endpoint: "groups/statistics",
+    },
+    households: {
+      endpoint: "households/statistics",
+    },
+  }
 };
 
 export default widget;

--- a/src/widgets/mealie/widget.js
+++ b/src/widgets/mealie/widget.js
@@ -14,7 +14,7 @@ const widget = {
     households: {
       endpoint: "households/statistics",
     },
-  }
+  },
 };
 
 export default widget;


### PR DESCRIPTION
## Proposed change

Mealie is introducing breaking API changes that are already merged in the "nightly" builds. See https://github.com/mealie-recipes/mealie/pull/3970. The `groups/statistics` endpoint is being deprecated and replaced with a `households/statistics` API.

I modelled the API handling on the Immich implementation https://github.com/gethomepage/homepage/pull/2284. If the version starts with "v2", or equals "nightly" it will use the new endpoint. Otherwise, it will keep using the existing endpoint to ensure this is non-breaking for people who pin to a v1 build.

Closes #

## Type of change


- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
