### PR TITLE
Feature: Technitium DNS Widget

### DIFF
--- a/docs/widgets/services/index.md
+++ b/docs/widgets/services/index.md
@@ -113,6 +113,7 @@ You can also find a list of all available service widgets in the sidebar navigat
 - [Syncthing Relay Server](syncthing-relay-server.md)
 - [Tailscale](tailscale.md)
 - [Tandoor](tandoor.md)
+- [Technitium DNS](technitium.md)
 - [TDarr](tdarr.md)
 - [Traefik](traefik.md)
 - [Transmission](transmission.md)

--- a/docs/widgets/services/technitium.md
+++ b/docs/widgets/services/technitium.md
@@ -24,5 +24,3 @@ This can be generated via the Technitium DNS Dashboard, and should be generated 
 #### Range
 
 `range` value determines how far back of statistics to pull data for. The value comes directly from Technitium API documentation found [here](https://github.com/TechnitiumSoftware/DnsServer/blob/master/APIDOCS.md#dashboard-api-calls), defined as `"type"`. The value can be one of: `LastHour`, `LastDay`, `LastWeek`, `LastMonth`, `LastYear`.
-
-**NOTE:** The value of `Custom` as specified in the API documentation is _NOT_ supported.

--- a/docs/widgets/services/technitium.md
+++ b/docs/widgets/services/technitium.md
@@ -1,0 +1,28 @@
+---
+title: Technitium DNS Server
+description: Technitium DNS Server Widget Configuration
+---
+
+Learn more about [Technitium DNS Server](https://technitium.com/dns/).
+
+Allowed fields (up to 4): `["totalQueries","totalNoError","totalServerFailure","totalNxDomain","totalRefused","totalAuthoritative","totalRecursive","totalCached","totalBlocked","totalDropped","totalClients"]`.
+
+Defaults to: `["totalQueries", "totalAuthoritative", "totalCached", "totalServerFailure"]`
+
+```yaml
+widget:
+  type: technitium
+  url: <url to dns server>
+  key: biglongapitoken
+  range: LastDay # optional, defaults to LastHour
+```
+
+#### API Key
+
+This can be generated via the Technitium DNS Dashboard, and should be generated from a special API specific user.
+
+#### Range
+
+`range` value determines how far back of statistics to pull data for. The value comes directly from Technitium API documentation found [here](https://github.com/TechnitiumSoftware/DnsServer/blob/master/APIDOCS.md#dashboard-api-calls), defined as `"type"`. The value can be one of: `LastHour`, `LastDay`, `LastWeek`, `LastMonth`, `LastYear`.
+
+**NOTE:** The value of `Custom` as specified in the API documentation is _NOT_ supported.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -137,6 +137,7 @@ nav:
           - widgets/services/syncthing-relay-server.md
           - widgets/services/tailscale.md
           - widgets/services/tandoor.md
+          - widgets/services/technitium.md
           - widgets/services/tdarr.md
           - widgets/services/traefik.md
           - widgets/services/transmission.md

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -323,6 +323,19 @@
         "seconds": "{{number}}s",
         "ago": "{{value}} Ago"
     },
+    "technitium": {
+        "totalQueries": "Queries",
+        "totalNoError": "Success",
+        "totalServerFailure": "Failures",
+        "totalNxDomain": "NX Domains",
+        "totalRefused": "Refused",
+        "totalAuthoritative": "Authoritative",
+        "totalRecursive": "Recursive",
+        "totalCached": "Cached",
+        "totalBlocked": "Blocked",
+        "totalDropped": "Dropped",
+        "totalClients": "Clients"
+    },
     "tdarr": {
         "queue": "Queue",
         "processed": "Processed",

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -473,6 +473,9 @@ export function cleanServiceGroups(groups) {
 
           // wgeasy
           threshold,
+
+          // technitium
+          range,
         } = cleanedService.widget;
 
         let fieldsList = fields;
@@ -616,6 +619,9 @@ export function cleanServiceGroups(groups) {
         }
         if (type === "frigate") {
           if (enableRecentEvents !== undefined) cleanedService.widget.enableRecentEvents = enableRecentEvents;
+        }
+        if (type === "technitium") {
+          if (range !== undefined) cleanedService.widget.range = range;
         }
       }
 

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -112,6 +112,7 @@ const components = {
   tailscale: dynamic(() => import("./tailscale/component")),
   tandoor: dynamic(() => import("./tandoor/component")),
   tautulli: dynamic(() => import("./tautulli/component")),
+  technitium: dynamic(() => import("./technitium/component")),
   tdarr: dynamic(() => import("./tdarr/component")),
   traefik: dynamic(() => import("./traefik/component")),
   transmission: dynamic(() => import("./transmission/component")),

--- a/src/widgets/technitium/component.jsx
+++ b/src/widgets/technitium/component.jsx
@@ -1,0 +1,128 @@
+import { useTranslation } from "next-i18next";
+
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+const MAX_ALLOWED_FIELDS = 4;
+
+export const technitiumDefaultFields = ["totalQueries", "totalAuthoritative", "totalCached", "totalServerFailure"];
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+
+  const { widget } = service;
+
+  const params = {
+    type: widget.range ?? "LastHour",
+  };
+
+  const { data: statsData, error: statsError } = useWidgetAPI(widget, "stats", params);
+
+  // Default fields
+  if (!widget.fields?.length > 0) {
+    widget.fields = technitiumDefaultFields;
+  }
+
+  // Limits max number of displayed fields
+  if (widget.fields?.length > MAX_ALLOWED_FIELDS) {
+    widget.fields = widget.fields.slice(0, MAX_ALLOWED_FIELDS);
+  }
+
+  if (statsError) {
+    return <Container service={service} error={statsError} />;
+  }
+
+  if (!statsData) {
+    return (
+      <Container service={service}>
+        <Block label="technitium.totalQueries" />
+        <Block label="technitium.totalNoError" />
+        <Block label="technitium.totalServerFailure" />
+        <Block label="technitium.totalNxDomain" />
+        <Block label="technitium.totalRefused" />
+        <Block label="technitium.totalAuthoritative" />
+        <Block label="technitium.totalRecursive" />
+        <Block label="technitium.totalCached" />
+        <Block label="technitium.totalBlocked" />
+        <Block label="technitium.totalDropped" />
+        <Block label="technitium.totalClients" />
+      </Container>
+    );
+  }
+
+  const getPercentage = (count, total) => {
+    return ((count / total) * 100).toPrecision(3);
+  };
+
+  const noErrorPercent = getPercentage(statsData.totalNoError, statsData.totalQueries);
+  const failurePercent = getPercentage(statsData.totalServerFailure, statsData.totalQueries);
+  const nxDomainPercent = getPercentage(statsData.totalNxDomain, statsData.totalQueries);
+  const refusedPercent = getPercentage(statsData.totalRefused, statsData.totalQueries);
+  const authoritativePercent = getPercentage(statsData.totalAuthoritative, statsData.totalQueries);
+  const recursivePercent = getPercentage(statsData.totalRecursive, statsData.totalQueries);
+  const cachedPercent = getPercentage(statsData.totalCached, statsData.totalQueries);
+  const blockedPercent = getPercentage(statsData.totalBlocked, statsData.totalQueries);
+  const droppedPercent = getPercentage(statsData.totalDropped, statsData.totalQueries);
+
+  return (
+    <Container service={service}>
+      <Block label="technitium.totalQueries" value={`${t("common.number", { value: statsData.totalQueries })}`} />
+      <Block
+        label="technitium.totalNoError"
+        value={`${t("common.number", { value: statsData.totalNoError })} (${t("common.percent", {
+          value: noErrorPercent,
+        })})`}
+      />
+      <Block
+        label="technitium.totalServerFailure"
+        value={`${t("common.number", { value: statsData.totalServerFailure })} (${t("common.percent", {
+          value: failurePercent,
+        })})`}
+      />
+      <Block
+        label="technitium.totalNxDomain"
+        value={`${t("common.number", { value: statsData.totalNxDomain })} (${t("common.percent", {
+          value: nxDomainPercent,
+        })})`}
+      />
+      <Block
+        label="technitium.totalRefused"
+        value={`${t("common.number", { value: statsData.totalRefused })} (${t("common.percent", {
+          value: refusedPercent,
+        })})`}
+      />
+      <Block
+        label="technitium.totalAuthoritative"
+        value={`${t("common.number", { value: statsData.totalAuthoritative })} (${t("common.percent", {
+          value: authoritativePercent,
+        })})`}
+      />
+      <Block
+        label="technitium.totalRecursive"
+        value={`${t("common.number", { value: statsData.totalRecursive })} (${t("common.percent", {
+          value: recursivePercent,
+        })})`}
+      />
+      <Block
+        label="technitium.totalCached"
+        value={`${t("common.number", { value: statsData.totalCached })} (${t("common.percent", {
+          value: cachedPercent,
+        })})`}
+      />
+      <Block
+        label="technitium.totalBlocked"
+        value={`${t("common.number", { value: statsData.totalBlocked })} (${t("common.percent", {
+          value: blockedPercent,
+        })})`}
+      />
+      <Block
+        label="technitium.totalDropped"
+        value={`${t("common.number", { value: statsData.totalDropped })} (${t("common.percent", {
+          value: droppedPercent,
+        })})`}
+      />
+      <Block label="technitium.totalClients" value={`${t("common.number", { value: statsData.totalClients })}`} />
+    </Container>
+  );
+}

--- a/src/widgets/technitium/component.jsx
+++ b/src/widgets/technitium/component.jsx
@@ -51,76 +51,69 @@ export default function Component({ service }) {
     );
   }
 
-  const getPercentage = (count, total) => {
-    return ((count / total) * 100).toPrecision(3);
-  };
-
-  const noErrorPercent = getPercentage(statsData.totalNoError, statsData.totalQueries);
-  const failurePercent = getPercentage(statsData.totalServerFailure, statsData.totalQueries);
-  const nxDomainPercent = getPercentage(statsData.totalNxDomain, statsData.totalQueries);
-  const refusedPercent = getPercentage(statsData.totalRefused, statsData.totalQueries);
-  const authoritativePercent = getPercentage(statsData.totalAuthoritative, statsData.totalQueries);
-  const recursivePercent = getPercentage(statsData.totalRecursive, statsData.totalQueries);
-  const cachedPercent = getPercentage(statsData.totalCached, statsData.totalQueries);
-  const blockedPercent = getPercentage(statsData.totalBlocked, statsData.totalQueries);
-  const droppedPercent = getPercentage(statsData.totalDropped, statsData.totalQueries);
+  function toPercent(value, total) {
+    return t("common.percent", {
+      value: !Number.isNaN(value / total) ? value / total : 0,
+      maximumFractionDigits: 2,
+    });
+  }
 
   return (
     <Container service={service}>
       <Block label="technitium.totalQueries" value={`${t("common.number", { value: statsData.totalQueries })}`} />
       <Block
         label="technitium.totalNoError"
-        value={`${t("common.number", { value: statsData.totalNoError })} (${t("common.percent", {
-          value: noErrorPercent,
-        })})`}
+        value={`${t("common.number", { value: statsData.totalNoError })} (${toPercent(
+          statsData.totalNoError / statsData.totalQueries,
+        )})`}
       />
       <Block
         label="technitium.totalServerFailure"
-        value={`${t("common.number", { value: statsData.totalServerFailure })} (${t("common.percent", {
-          value: failurePercent,
-        })})`}
+        value={`${t("common.number", { value: statsData.totalServerFailure })} (${toPercent(
+          statsData.totalServerFailure / statsData.totalQueries,
+        )})`}
       />
       <Block
         label="technitium.totalNxDomain"
-        value={`${t("common.number", { value: statsData.totalNxDomain })} (${t("common.percent", {
-          value: nxDomainPercent,
-        })})`}
+        value={`${t("common.number", { value: statsData.totalNxDomain })} (${toPercent(
+          statsData.totalNxDomain / statsData.totalQueries,
+        )})`}
       />
       <Block
         label="technitium.totalRefused"
-        value={`${t("common.number", { value: statsData.totalRefused })} (${t("common.percent", {
-          value: refusedPercent,
-        })})`}
+        value={`${t("common.number", { value: statsData.totalRefused })} (${toPercent(
+          statsData.totalRefused / statsData.totalQueries,
+        )})`}
       />
       <Block
         label="technitium.totalAuthoritative"
-        value={`${t("common.number", { value: statsData.totalAuthoritative })} (${t("common.percent", {
-          value: authoritativePercent,
-        })})`}
+        value={`${t("common.number", { value: statsData.totalAuthoritative })} (${toPercent(
+          statsData.totalAuthoritative / statsData.totalQueries,
+        )})`}
       />
       <Block
         label="technitium.totalRecursive"
-        value={`${t("common.number", { value: statsData.totalRecursive })} (${t("common.percent", {
-          value: recursivePercent,
-        })})`}
+        value={`${t("common.number", { value: statsData.totalRecursive })} (${toPercent(
+          statsData.totalRecursive / statsData.totalQueries,
+        )})`}
       />
       <Block
         label="technitium.totalCached"
-        value={`${t("common.number", { value: statsData.totalCached })} (${t("common.percent", {
-          value: cachedPercent,
-        })})`}
+        value={`${t("common.number", { value: statsData.totalCached })} (${toPercent(
+          statsData.totalCached / statsData.totalQueries,
+        )})`}
       />
       <Block
         label="technitium.totalBlocked"
-        value={`${t("common.number", { value: statsData.totalBlocked })} (${t("common.percent", {
-          value: blockedPercent,
-        })})`}
+        value={`${t("common.number", { value: statsData.totalBlocked })} (${toPercent(
+          statsData.totalBlocked / statsData.totalQueries,
+        )})`}
       />
       <Block
         label="technitium.totalDropped"
-        value={`${t("common.number", { value: statsData.totalDropped })} (${t("common.percent", {
-          value: droppedPercent,
-        })})`}
+        value={`${t("common.number", { value: statsData.totalDropped })} (${toPercent(
+          statsData.totalDropped / statsData.totalQueries,
+        )})`}
       />
       <Block label="technitium.totalClients" value={`${t("common.number", { value: statsData.totalClients })}`} />
     </Container>

--- a/src/widgets/technitium/widget.js
+++ b/src/widgets/technitium/widget.js
@@ -1,0 +1,17 @@
+import genericProxyHandler from "utils/proxy/handlers/generic";
+import { asJson } from "utils/proxy/api-helpers";
+
+const widget = {
+  api: "{url}/api/{endpoint}?token={key}&utc=true",
+  proxyHandler: genericProxyHandler,
+  mappings: {
+    stats: {
+      endpoint: "dashboard/stats/get",
+      validate: ["response", "status"],
+      params: ["type"],
+      map: (data) => asJson(data).response.stats,
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -103,6 +103,7 @@ import swagdashboard from "./swagdashboard/widget";
 import tailscale from "./tailscale/widget";
 import tandoor from "./tandoor/widget";
 import tautulli from "./tautulli/widget";
+import technitium from "./technitium/widget";
 import tdarr from "./tdarr/widget";
 import traefik from "./traefik/widget";
 import transmission from "./transmission/widget";
@@ -228,6 +229,7 @@ const widgets = {
   tailscale,
   tandoor,
   tautulli,
+  technitium,
   tdarr,
   traefik,
   transmission,


### PR DESCRIPTION
## Proposed change

Adds a new service widget for Technitium DNS Server, based on their [Dashboard API](https://github.com/TechnitiumSoftware/DnsServer/blob/master/APIDOCS.md#dashboard-api-calls)

The above API call takes the format of: `<server ip / domain>/api/dashboard/stats/get?token=<api-token>&type=<time_range>&utc=true`

The following query string parameters are used
- `token`: Is the api token that can be created on the Technitium DNS dashboard, this is a permanant token that wont expire, that is specifically used to API calls.
- `type`: Is really a date range, and can be one of: `[LastHour, LastDay, LastWeek, LastMonth, LastYear]`

The response of this API call returns a lot of information, but the one this widget cares about, is the `response.stats` property that has the following data:

```json
{
	"response": {
		"stats": {
			"totalQueries": 52321,
			"totalNoError": 49112,
			"totalServerFailure": 107,
			"totalNxDomain": 3102,
			"totalRefused": 0,
			"totalAuthoritative": 3393,
			"totalRecursive": 36952,
			"totalCached": 11976,
			"totalBlocked": 0,
			"totalDropped": 0,
			"totalClients": 4,
			"zones": 11,
			"cachedEntries": 15867,
			"allowedZones": 0,
			"blockedZones": 0,
			"allowListZones": 0,
			"blockListZones": 0
		},
	// additional properties removed for brevity ...
}
```

The above block is what gets translated to the data the component gets using the `useWidgetAPI` call.

I have a max 4 fields set as a default (as i saw utilized in other widgets), and a user can select which fields they would like to use.

Here is an example of its service configuration:
```yaml
    - Technitium:
        icon: technitium.png
        href: https://tdns.example.org
        description: T-DNS
        widget:
            type: technitium
            url: https://tdns.example.org
            key: <api_token>
            range: LastDay # optional, defaults to LastHour
```

Here is a screenshot of how i would personally use it, next to my Pi Hole widgets:

![image](https://github.com/user-attachments/assets/a895b463-5004-4696-a488-fb4b4d546b71)

And here is a screenshot of the actual Technitium DNS dashboard for comparison:

![image](https://github.com/user-attachments/assets/dbb69a78-360d-45f8-96f5-361ef9796a9f)

I saw Technitium was mentioned back in 2023, with a handful of upvotes, so I thought Id take a stab at it.

Related issue: https://github.com/gethomepage/homepage/issues/1152
Related discussion: https://github.com/gethomepage/homepage/discussions/1319 (20 upvotes as of 8/2024)

## Type of change

- [X] New service widget

## Checklist:

- [X] If applicable, I have added corresponding documentation changes.
- [X] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [X] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).

