### PR TITLE
Feature: Zabbix service widget

### DIFF
--- a/docs/widgets/authoring/proxies.md
+++ b/docs/widgets/authoring/proxies.md
@@ -79,7 +79,21 @@ By default the key is passed as an `X-API-Key` header. If you need to pass the k
 
 ### `jsonrpcProxyHandler`
 
-A proxy handler that makes authenticated JSON-RPC requests to the specified API endpoint. Where the endpoint is the method to call.
+A proxy handler that makes authenticated JSON-RPC requests to the specified API endpoint, either using username + password or an API token.
+The endpoint is the method to call and queryParams are used as the parameters.
+
+=== "component.js"
+
+    ```js
+    import Container from "components/services/widget/container";
+    import useWidgetAPI from "utils/proxy/use-widget-api";
+
+    export default function Component({ service }) {
+      const { widget } = service;
+
+      const { data, error } = useWidgetAPI(widget, 'trigger', { "triggerids": "14062", "output": "extend", "selectFunctions": "extend" });
+    }
+    ```
 
 === "widget.js"
 
@@ -93,6 +107,7 @@ A proxy handler that makes authenticated JSON-RPC requests to the specified API 
       mappings: {
         total: { endpoint: "total" },
         average: { endpoint: "average" },
+        trigger: { endpoint: "trigger.get" },
       },
     };
     ```
@@ -108,6 +123,16 @@ A proxy handler that makes authenticated JSON-RPC requests to the specified API 
           url: http://127.0.0.1:1337
           username: your-username
           password: your-password
+    ```
+
+    ```yaml
+    - Your Widget:
+        icon: yourwidget.svg
+        href: https://example.com/
+        widget:
+          type: yourwidget
+          url: http://127.0.0.1:1337
+          key: your-api-token
     ```
 
 ### `synologyProxyHandler`

--- a/docs/widgets/services/index.md
+++ b/docs/widgets/services/index.md
@@ -127,3 +127,4 @@ You can also find a list of all available service widgets in the sidebar navigat
 - [WGEasy](wgeasy.md)
 - [WhatsUpDocker](whatsupdocker.md)
 - [xTeVe](xteve.md)
+- [Zabbix](zabbix.md)

--- a/docs/widgets/services/zabbix.md
+++ b/docs/widgets/services/zabbix.md
@@ -1,0 +1,19 @@
+---
+title: Zabbix
+description: Zabbix Widget Configuration
+---
+
+Learn more about [Zabbix](https://github.com/zabbix/zabbix).
+
+See the [Zabbix documentation](https://www.zabbix.com/documentation/current/en/manual/web_interface/frontend_sections/users/api_tokens) for details on generating API tokens.
+
+The widget supports (at least) Zibbax server version 7.0.
+
+Allowed fields: `["warning", "average", "high", "disaster"]`.
+
+```yaml
+widget:
+  type: zabbix
+  url: http://zabbix.host.or.ip/zabbix
+  key: your-api-key
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -151,6 +151,7 @@ nav:
           - widgets/services/wgeasy.md
           - widgets/services/whatsupdocker.md
           - widgets/services/xteve.md
+          - widgets/services/zabbix.md
       - "Information Widgets":
           - widgets/info/index.md
           - widgets/info/datetime.md

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -918,5 +918,11 @@
         "links": "Links",
         "collections": "Collections",
         "tags": "Tags"
+    },
+    "zabbix": {
+      "warning": "Warning",
+      "average": "Average",
+      "high": "High",
+      "disaster": "Disaster"
     }
 }

--- a/src/utils/proxy/handlers/jsonrpc.js
+++ b/src/utils/proxy/handlers/jsonrpc.js
@@ -10,8 +10,8 @@ const logger = createLogger("jsonrpcProxyHandler");
 
 export async function sendJsonRpcRequest(url, method, params, widget) {
   const headers = {
-    Accept: "application/json-rpc",
-    "Content-Type": "application/json-rpc",
+    "content-type": "application/json",
+    accept: "application/json",
   };
 
   if (widget.username && widget.password) {

--- a/src/utils/proxy/handlers/jsonrpc.js
+++ b/src/utils/proxy/handlers/jsonrpc.js
@@ -65,12 +65,14 @@ export async function sendJsonRpcRequest(url, method, params, widget) {
 }
 
 export default async function jsonrpcProxyHandler(req, res) {
-  const { group, service, endpoint: method, query } = req.query;
-  const params = query ? JSON.parse(query) : null;
+  const { group, service, endpoint: method } = req.query;
 
   if (group && service) {
     const widget = await getServiceWidget(group, service);
     const api = widgets?.[widget.type]?.api;
+
+    const [, mapping] = Object.entries(widgets?.[widget.type]?.mappings).find(([, value]) => value.endpoint === method);
+    const params = mapping?.params ?? null;
 
     if (!api) {
       return res.status(403).json({ error: "Service does not support API calls" });
@@ -79,8 +81,7 @@ export default async function jsonrpcProxyHandler(req, res) {
     if (widget) {
       const url = formatApiCall(api, { ...widget });
 
-      // eslint-disable-next-line no-unused-vars
-      const [status, contentType, data] = await sendJsonRpcRequest(url, method, params, widget);
+      const [status, , data] = await sendJsonRpcRequest(url, method, params, widget);
       return res.status(status).end(data);
     }
   }

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -126,6 +126,7 @@ const components = {
   wgeasy: dynamic(() => import("./wgeasy/component")),
   whatsupdocker: dynamic(() => import("./whatsupdocker/component")),
   xteve: dynamic(() => import("./xteve/component")),
+  zabbix: dynamic(() => import("./zabbix/component")),
 };
 
 export default components;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -118,6 +118,7 @@ import whatsupdocker from "./whatsupdocker/widget";
 import xteve from "./xteve/widget";
 import urbackup from "./urbackup/widget";
 import romm from "./romm/widget";
+import zabbix from "./zabbix/widget";
 
 const widgets = {
   adguard,
@@ -243,6 +244,7 @@ const widgets = {
   wgeasy,
   whatsupdocker,
   xteve,
+  zabbix,
 };
 
 export default widgets;

--- a/src/widgets/zabbix/component.jsx
+++ b/src/widgets/zabbix/component.jsx
@@ -9,21 +9,11 @@ const PriorityAverage = "3";
 const PriorityHigh = "4";
 const PriorityDisaster = "5";
 
-const triggerParams = {
-  output: ["triggerid", "description", "priority"],
-  filter: {
-    value: 1,
-  },
-  sortfield: "priority",
-  sortorder: "DESC",
-  monitored: "true",
-};
-
 export default function Component({ service }) {
   const { t } = useTranslation();
   const { widget } = service;
 
-  const { data: zabbixData, error: zabbixError } = useWidgetAPI(widget, "trigger", triggerParams);
+  const { data: zabbixData, error: zabbixError } = useWidgetAPI(widget, "trigger");
 
   if (zabbixError) {
     return <Container service={service} error={zabbixError} />;

--- a/src/widgets/zabbix/component.jsx
+++ b/src/widgets/zabbix/component.jsx
@@ -1,0 +1,56 @@
+import { useTranslation } from "next-i18next";
+
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+const PriorityWarning = "2";
+const PriorityAverage = "3";
+const PriorityHigh = "4";
+const PriorityDisaster = "5";
+
+const triggerParams = {
+  output: ["triggerid", "description", "priority"],
+  filter: {
+    value: 1,
+  },
+  sortfield: "priority",
+  sortorder: "DESC",
+  monitored: "true",
+};
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+  const { widget } = service;
+
+  const { data: zabbixData, error: zabbixError } = useWidgetAPI(widget, "trigger", triggerParams);
+
+  if (zabbixError) {
+    return <Container service={service} error={zabbixError} />;
+  }
+
+  if (!zabbixData) {
+    return (
+      <Container service={service}>
+        <Block label="zabbix.warning" />
+        <Block label="zabbix.average" />
+        <Block label="zabbix.high" />
+        <Block label="zabbix.disaster" />
+      </Container>
+    );
+  }
+
+  const warning = zabbixData.filter((item) => item.priority === PriorityWarning).length;
+  const average = zabbixData.filter((item) => item.priority === PriorityAverage).length;
+  const high = zabbixData.filter((item) => item.priority === PriorityHigh).length;
+  const disaster = zabbixData.filter((item) => item.priority === PriorityDisaster).length;
+
+  return (
+    <Container service={service}>
+      <Block label="zabbix.warning" value={t("common.number", { value: warning })} />
+      <Block label="zabbix.average" value={t("common.number", { value: average })} />
+      <Block label="zabbix.high" value={t("common.number", { value: high })} />
+      <Block label="zabbix.disaster" value={t("common.number", { value: disaster })} />
+    </Container>
+  );
+}

--- a/src/widgets/zabbix/widget.js
+++ b/src/widgets/zabbix/widget.js
@@ -5,7 +5,18 @@ const widget = {
   proxyHandler: jsonrpcProxyHandler,
 
   mappings: {
-    trigger: { endpoint: "trigger.get" },
+    trigger: {
+      endpoint: "trigger.get",
+      params: {
+        output: ["triggerid", "description", "priority"],
+        filter: {
+          value: 1,
+        },
+        sortfield: "priority",
+        sortorder: "DESC",
+        monitored: "true",
+      },
+    },
   },
 };
 

--- a/src/widgets/zabbix/widget.js
+++ b/src/widgets/zabbix/widget.js
@@ -1,0 +1,12 @@
+import jsonrpcProxyHandler from "utils/proxy/handlers/jsonrpc";
+
+const widget = {
+  api: "{url}/api_jsonrpc.php",
+  proxyHandler: jsonrpcProxyHandler,
+
+  mappings: {
+    trigger: { endpoint: "trigger.get" },
+  },
+};
+
+export default widget;


### PR DESCRIPTION
## Proposed change

![image](https://github.com/user-attachments/assets/86e68fe0-41df-4325-8f2f-022b4de9e833)

The user will be able to add the widget to the `services.yaml` file using the following configuration:

```yaml
widget:
  type: zabbix
  url: http://zabbix.host.or.ip/zabbix
  key: your-api-key
```

Relevant feature request: https://github.com/gethomepage/homepage/discussions/1953

### Notes

I did somewhat break the Service Widget Guidelines.

- Zabbix exposes 6 alert fields by default, but I can cut it down to just 4.
- Zabbix requires an `auth`-field in the JSON RPC call for API tokens, which I could not figure out how to do with the generic jsonrpc proxy.
  
Let me know what I should change to have a valid pull request.  

## Type of change

- [x] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
