### PR TITLE
Added Kubernetes CRDs

### DIFF
--- a/docs/configs/kubernetes.md
+++ b/docs/configs/kubernetes.md
@@ -143,3 +143,41 @@ If the `href` attribute is not present, Homepage will ignore the specific Ingres
 ## Caveats
 
 Similarly to Docker service discovery, there currently is no rigid ordering to discovered services and discovered services will be displayed above those specified in the `services.yaml`.
+
+## CRDs
+
+Homepage also comes with Kubernetes CRDs for services. These CRDs have same structure and properties as regular service YAML definition, with added properties of `group`, `weight`, `podSelector` and `instances`, used as described above. 
+
+Compared to annotations, CRD approach can use Kubernetes secrets and configMaps to populate attributes of the `widget` object. To do this, instead of using the name, ex. `key`, use `keyFrom`, to match kubernetes standards. Then use either `secretKeyRef` or `configMapKeyRef` object, see example:
+
+```yaml
+apiVersion: gethomepage.dev/v1
+kind: HomepageService
+metadata:
+  labels:
+    app.kubernetes.io/instance: sonarr
+  name: sonarr
+  namespace: media
+spec:
+  description: TV Show Management Application
+  group: Media
+  href: 'https://sonarr.example.org/'
+  icon: sonarr.svg
+  widget:
+    type: sonarr
+    url: 'http://sonarr.media.svc.cluster.local:8989'
+    keyFrom:
+      secretKeyRef:
+        key: SONARR_API_KEY
+        name: arr-secrets
+```
+
+Some attributes have values inferred from the definition itself, `app` is read from *app.kubernetes.io/name* annotation or metadata.name, namespace is also read from metadata.
+
+For secrets and configMaps, if `namespace` is not specified in ref object, it assumes it's in the same namespace as CRD. If you want to specify a default namespace (for example for security reason when assigning secrets:read permission for only one namespace), you can specify `defaultSecretNamespace` and `defaultConfigMapNamespace` in `kubernetes.yaml` file.
+
+```yaml
+---
+mode: cluster
+defaultSecretNamespace: homepage
+```

--- a/docs/configs/kubernetes.md
+++ b/docs/configs/kubernetes.md
@@ -146,7 +146,7 @@ Similarly to Docker service discovery, there currently is no rigid ordering to d
 
 ## CRDs
 
-Homepage also comes with Kubernetes CRDs for services. These CRDs have same structure and properties as regular service YAML definition, with added properties of `group`, `weight`, `podSelector` and `instances`, used as described above. 
+Homepage also comes with Kubernetes CRDs for services. These CRDs have same structure and properties as regular service YAML definition, with added properties of `group`, `weight`, `podSelector` and `instances`, used as described above.
 
 Compared to annotations, CRD approach can use Kubernetes secrets and configMaps to populate attributes of the `widget` object. To do this, instead of using the name, ex. `key`, use `keyFrom`, to match kubernetes standards. Then use either `secretKeyRef` or `configMapKeyRef` object, see example:
 
@@ -161,18 +161,18 @@ metadata:
 spec:
   description: TV Show Management Application
   group: Media
-  href: 'https://sonarr.example.org/'
+  href: "https://sonarr.example.org/"
   icon: sonarr.svg
   widget:
     type: sonarr
-    url: 'http://sonarr.media.svc.cluster.local:8989'
+    url: "http://sonarr.media.svc.cluster.local:8989"
     keyFrom:
       secretKeyRef:
         key: SONARR_API_KEY
         name: arr-secrets
 ```
 
-Some attributes have values inferred from the definition itself, `app` is read from *app.kubernetes.io/name* annotation or metadata.name, namespace is also read from metadata.
+Some attributes have values inferred from the definition itself, `app` is read from _app.kubernetes.io/name_ annotation or metadata.name, namespace is also read from metadata.
 
 For secrets and configMaps, if `namespace` is not specified in ref object, it assumes it's in the same namespace as CRD. If you want to specify a default namespace (for example for security reason when assigning secrets:read permission for only one namespace), you can specify `defaultSecretNamespace` and `defaultConfigMapNamespace` in `kubernetes.yaml` file.
 

--- a/src/pages/api/kubernetes/stats/[...service].js
+++ b/src/pages/api/kubernetes/stats/[...service].js
@@ -1,6 +1,6 @@
 import { CoreV1Api, Metrics } from "@kubernetes/client-node";
 
-import getKubeConfig from "../../../../utils/config/kubernetes";
+import getKubernetesConfig, { makeKubeConfig } from "../../../../utils/config/kubernetes";
 import { parseCpu, parseMemory } from "../../../../utils/kubernetes/kubernetes-utils";
 import createLogger from "../../../../utils/logger";
 
@@ -20,7 +20,7 @@ export default async function handler(req, res) {
   const labelSelector = podSelector !== undefined ? podSelector : `${APP_LABEL}=${appName}`;
 
   try {
-    const kc = getKubeConfig();
+    const kc = makeKubeConfig(getKubernetesConfig());
     if (!kc) {
       res.status(500).send({
         error: "No kubernetes configuration",

--- a/src/pages/api/kubernetes/status/[...service].js
+++ b/src/pages/api/kubernetes/status/[...service].js
@@ -1,6 +1,6 @@
 import { CoreV1Api } from "@kubernetes/client-node";
 
-import getKubeConfig from "../../../../utils/config/kubernetes";
+import getKubernetesConfig, { makeKubeConfig } from "../../../../utils/config/kubernetes";
 import createLogger from "../../../../utils/logger";
 
 const logger = createLogger("kubernetesStatusService");
@@ -18,7 +18,7 @@ export default async function handler(req, res) {
   }
   const labelSelector = podSelector !== undefined ? podSelector : `${APP_LABEL}=${appName}`;
   try {
-    const kc = getKubeConfig();
+    const kc = makeKubeConfig(getKubernetesConfig())
     if (!kc) {
       res.status(500).send({
         error: "No kubernetes configuration",

--- a/src/pages/api/widgets/kubernetes.js
+++ b/src/pages/api/widgets/kubernetes.js
@@ -1,6 +1,6 @@
 import { CoreV1Api, Metrics } from "@kubernetes/client-node";
 
-import getKubeConfig from "../../../utils/config/kubernetes";
+import getKubernetesConfig, { makeKubeConfig } from "../../../utils/config/kubernetes";
 import { parseCpu, parseMemory } from "../../../utils/kubernetes/kubernetes-utils";
 import createLogger from "../../../utils/logger";
 
@@ -8,7 +8,7 @@ const logger = createLogger("kubernetes-widget");
 
 export default async function handler(req, res) {
   try {
-    const kc = getKubeConfig();
+    const kc = makeKubeConfig(getKubernetesConfig())
     if (!kc) {
       return res.status(500).send({
         error: "No kubernetes configuration",

--- a/src/pages/api/widgets/kubernetes.js
+++ b/src/pages/api/widgets/kubernetes.js
@@ -8,7 +8,7 @@ const logger = createLogger("kubernetes-widget");
 
 export default async function handler(req, res) {
   try {
-    const kc = makeKubeConfig(getKubernetesConfig())
+    const kc = makeKubeConfig(getKubernetesConfig());
     if (!kc) {
       return res.status(500).send({
         error: "No kubernetes configuration",

--- a/src/utils/config/kubernetes.js
+++ b/src/utils/config/kubernetes.js
@@ -6,13 +6,16 @@ import { KubeConfig } from "@kubernetes/client-node";
 
 import checkAndCopyConfig, { CONF_DIR, substituteEnvironmentVars } from "utils/config/config";
 
-export default function getKubeConfig() {
+export default function getKubernetesConfig() {
   checkAndCopyConfig("kubernetes.yaml");
 
   const configFile = path.join(CONF_DIR, "kubernetes.yaml");
   const rawConfigData = readFileSync(configFile, "utf8");
   const configData = substituteEnvironmentVars(rawConfigData);
-  const config = yaml.load(configData);
+  return yaml.load(configData);
+}
+
+export function makeKubeConfig(config) {
   const kc = new KubeConfig();
 
   switch (config?.mode) {

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -414,7 +414,6 @@ export async function servicesFromKubernetes() {
 
     return mappedServiceGroups;
   } catch (e) {
-    console.log(e);
     if (e) logger.error(e);
     throw e;
   }


### PR DESCRIPTION
## Proposed change

Added CRDs as an option of Kubernetes service definition. This is useful if you want to keep the service configuration in yaml and coupled with your services instead of updating configmap for homepage after every service deployment. 

It also allows for using secretKeyRef and configMapKeyRef for widgets, to keep your secrets secret instead of having them readable in annotation. This was the primary reason for creating this PR (also resolves #2685)

### Testing:

To use or test the functionality, you need to create the CRD (should be added to helm chart after PR completion).

```yaml
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition
metadata:
  name: homepageservices.gethomepage.dev
spec:
  group: gethomepage.dev
  versions:
    - name: v1
      served: true
      storage: true
      schema:
        openAPIV3Schema:
          type: object
          properties:
            spec:
              type: object
              properties:
                enabled:
                  type: boolean
                instances:
                  type: array
                  items:
                    type: string
                app:
                  type: string
                namespace:
                  type: string
                href:
                  type: string
                name:
                  type: string
                group:
                  type: string
                weight:
                  type: integer
                icon:
                  type: string
                description:
                  type: string
                external:
                  type: boolean
                podSelector:
                  type: string
                ping:
                  type: string
                siteMonitor:
                  type: string
                statusStyle:
                  type: string
                widget:
                  type: object
                  properties:
                    type:
                      type: string
                  required:
                  - type
                  x-kubernetes-preserve-unknown-fields: true
                  # x-kubernetes-validations: 
                  # - rule: "self.all(key, !(key.matches('.+From$')) || (has(self[key].secretKeyRef.name) && has(self[key].secretKeyRef.key)) || (has(self[key].configMapKeyRef.name) && has(self[key].configMapKeyRef.key)))"
                  #   message: Some widget property ends with From, but doesn't contain secretKeyRef nor configMapKeyRef
  scope: Namespaced
  names:
    plural: homepageservices
    singular: homepageservice
    kind: HomepageService
```

You also need to allow your serviceAccount to list and get the custom resources and get secrets/configMaps (don't include list for this, as you specify name directly). This is very simple with current helm chart, just use extraClusterRoles:

```
 extraClusterRoles:
    - apiGroups:
        - gethomepage.dev
      resources:
        - homepageservices
      verbs:
        - get
        - list
    - apiGroups:
        - ""
      resources:
        - secrets
        - configmaps
      verbs:
        - get
```

In case you would just want to allow reading in a single namespace, it needs to be done manually as there's no regular roles and roleassignments in the helm chart.

To simplify testing, I've also pushed the modified app to public ghcr repo: **ghcr.io/rikpat/homepage:v1**



<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/latest/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

Closes #2685

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
