### PR TITLE
Add Spoolman Widget

### DIFF
--- a/docs/widgets/services/spoolman.md
+++ b/docs/widgets/services/spoolman.md
@@ -1,0 +1,15 @@
+---
+title: Spoolman
+description: Spoolman Widget Configuration
+---
+
+Learn more about [Spoolman](https://github.com/Donkie/Spoolman).
+
+Keep track of your inventory of 3D-printer filament spools.
+Spoolman is a self-hosted web service designed to help you efficiently manage your 3D printer filament spools and monitor their usage. It acts as a centralized database that seamlessly integrates with popular 3D printing software like OctoPrint and Klipper/Moonraker. When connected, it automatically updates spool weights as printing progresses, giving you real-time insights into filament usage.
+
+```yaml
+widget:
+  type: spoolman
+  url: http://spoolman.host.or.ip
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -131,6 +131,7 @@ nav:
           - widgets/services/scrutiny.md
           - widgets/services/sonarr.md
           - widgets/services/speedtest-tracker.md
+          - widgets/services/spoolman.md
           - widgets/services/stash.md
           - widgets/services/stocks.md
           - widgets/services/swagdashboard.md

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -105,6 +105,7 @@ const components = {
   scrutiny: dynamic(() => import("./scrutiny/component")),
   sonarr: dynamic(() => import("./sonarr/component")),
   speedtest: dynamic(() => import("./speedtest/component")),
+  spoolman: dynamic(() => import("./spoolman/component")),
   stash: dynamic(() => import("./stash/component")),
   stocks: dynamic(() => import("./stocks/component")),
   strelaysrv: dynamic(() => import("./strelaysrv/component")),

--- a/src/widgets/spoolman/component.jsx
+++ b/src/widgets/spoolman/component.jsx
@@ -1,0 +1,41 @@
+import { useTranslation } from "next-i18next";
+
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+  const { widget } = service;
+
+  const { data: spoolData, error: spoolError } = useWidgetAPI(widget, "spools");
+
+  if (spoolError) {
+    return <Container service={service} error={spoolError} />;
+  }
+
+  if (!spoolData) {
+    return (
+      <Container service={service}>
+        <Block label="spoolman.spool1" />
+        <Block label="spoolman.spool2" />
+      </Container>
+    );
+  }
+
+  if (spoolData.error || spoolData.message) {
+    return <Container service={service} error={spoolData?.error ?? spoolData} />;
+  }
+
+  return (
+    <Container service={service}>
+      {spoolData.map((spool) => (
+        <Block
+          key={spool.id}
+          label={`${spool.filament.name}`}
+          value={`${t("common.percent", { value: (100-(spool.used_weight / spool.initial_weight)*100)})}`} 
+        />
+      ))}
+    </Container>
+  );
+}

--- a/src/widgets/spoolman/component.jsx
+++ b/src/widgets/spoolman/component.jsx
@@ -33,7 +33,7 @@ export default function Component({ service }) {
         <Block
           key={spool.id}
           label={`${spool.filament.name}`}
-          value={`${t("common.percent", { value: (100-(spool.used_weight / spool.initial_weight)*100)})}`} 
+          value={`${t("common.percent", { value: ((spool.remaining_weight / spool.initial_weight)*100)})}`} 
         />
       ))}
     </Container>

--- a/src/widgets/spoolman/widget.js
+++ b/src/widgets/spoolman/widget.js
@@ -1,0 +1,14 @@
+import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
+
+const widget = {
+  api: "{url}/api/v1/{endpoint}",
+  proxyHandler: credentialedProxyHandler,
+
+  mappings: {
+    spools : {
+      endpoint: "spool",
+    }
+  },
+};
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -96,6 +96,7 @@ import sabnzbd from "./sabnzbd/widget";
 import scrutiny from "./scrutiny/widget";
 import sonarr from "./sonarr/widget";
 import speedtest from "./speedtest/widget";
+import spoolman from "./spoolman/widget";
 import stash from "./stash/widget";
 import stocks from "./stocks/widget";
 import strelaysrv from "./strelaysrv/widget";
@@ -223,6 +224,7 @@ const widgets = {
   scrutiny,
   sonarr,
   speedtest,
+  spoolman,
   stash,
   stocks,
   strelaysrv,


### PR DESCRIPTION
## Proposed change

Adds a Spoolman widget. Each spool will be rendered into a dedicated `<Block>` showing the filament name and remaining filament in %.

Widget:

<img width="675" alt="image" src="https://github.com/user-attachments/assets/1cf65bd8-9557-495d-a95f-975922a5e3f5">

Spoolman:

<img width="1258" alt="image" src="https://github.com/user-attachments/assets/550b3957-322b-48b1-a79b-13ff114d12db">


Closes #3958

## Type of change

- [x] New service widget

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
