### PR TITLE
Enhancement: Add app password support to Photoprism

### DIFF
--- a/docs/widgets/services/photoprism.md
+++ b/docs/widgets/services/photoprism.md
@@ -14,3 +14,12 @@ widget:
   username: admin
   password: password
 ```
+
+If using app passwords, you can create one and specify that for authorization.
+
+```yaml
+widget:
+  type: photoprism
+  url: http://photoprism.host.or.ip:port
+  authToken: <app password from Photoprism>
+```

--- a/src/widgets/photoprism/proxy.js
+++ b/src/widgets/photoprism/proxy.js
@@ -32,6 +32,12 @@ export default async function photoprismProxyHandler(req, res) {
       username: widget.username,
       password: widget.password,
     });
+  } else if (widget.authToken) {
+    params.headers = { "Content-Type": "application/json", Authorization: `Bearer ${widget.authToken}` };
+
+    params.body = JSON.stringify({
+      authToken: widget.authToken,
+    });
   }
 
   const [status, contentType, data] = await httpProxy(url, params);


### PR DESCRIPTION
## Proposed change

This PR add app-password support to the Photoprism widget. This is a security benefit since Photoprism added two-factor authentication to the application. Previously, the username and password fields were used for this same function, but if somebody adds 2FA to their account, this will no longer work, requiring the use of a less secure form of authentication (e.g. disabling 2FA).

Users can now generate an application specific password within Photoprism, and further limit what that can do. For the purposes of this PR they can create a "Metrics" app password to further secure the application and its data.

Closes # [3351](https://github.com/gethomepage/homepage/discussions/3351)

## Type of change

- [✅] New feature (non-breaking change which adds functionality)

## Checklist:

- [✅] If applicable, I have added corresponding documentation changes.
- [✅] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [✅] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
