### PR TITLE
Documentation: fix mkdocs admonition in unraid.md

### DIFF
--- a/docs/installation/unraid.md
+++ b/docs/installation/unraid.md
@@ -31,15 +31,15 @@ You may need to set the permissions of the folders to be able to edit the files.
 
 - To use the [Docker integration](../configs/docker.md), you only need to use the `container:` parameter. There is no need to set the server.
 
-  !!! note
+!!! note
 
-        To view detailed container statistics (CPU, RAM, etc.), or if you use a remote docker socket, `container:` will still need to be set. For example:
+      To view detailed container statistics (CPU, RAM, etc.), or if you use a remote docker socket, `container:` will still need to be set. For example:
 
-  ```
-      - Plex:
-          icon: /icons/plex.png
-          href: https://app.plex.com
-          container: plex
-  ```
+```
+    - Plex:
+        icon: /icons/plex.png
+        href: https://app.plex.com
+        container: plex
+```
 
 - When you upload a new image into the **/images** folder, you will need to restart the container for it to show up in the WebUI. Please see the [service icons](../configs/services.md#icons) for more information.


### PR DESCRIPTION
## Proposed change

There were extra tabs before a MkDocs admonition declaration preventing the admonitions from rendering properly.

## Type of change

- [X] Documentation only

