### PR TITLE
Fix: Technitium widget percentage display

### DIFF
--- a/src/widgets/technitium/component.jsx
+++ b/src/widgets/technitium/component.jsx
@@ -52,8 +52,9 @@ export default function Component({ service }) {
   }
 
   function toPercent(value, total) {
+    const percentage = (value / total) * 100;
     return t("common.percent", {
-      value: !Number.isNaN(value / total) ? value / total : 0,
+      value: !Number.isNaN(percentage) ? percentage : 0,
       maximumFractionDigits: 2,
     });
   }
@@ -64,55 +65,64 @@ export default function Component({ service }) {
       <Block
         label="technitium.totalNoError"
         value={`${t("common.number", { value: statsData.totalNoError })} (${toPercent(
-          statsData.totalNoError / statsData.totalQueries,
+          statsData.totalNoError,
+          statsData.totalQueries,
         )})`}
       />
       <Block
         label="technitium.totalServerFailure"
         value={`${t("common.number", { value: statsData.totalServerFailure })} (${toPercent(
-          statsData.totalServerFailure / statsData.totalQueries,
+          statsData.totalServerFailure,
+          statsData.totalQueries,
         )})`}
       />
       <Block
         label="technitium.totalNxDomain"
         value={`${t("common.number", { value: statsData.totalNxDomain })} (${toPercent(
-          statsData.totalNxDomain / statsData.totalQueries,
+          statsData.totalNxDomain,
+          statsData.totalQueries,
         )})`}
       />
       <Block
         label="technitium.totalRefused"
         value={`${t("common.number", { value: statsData.totalRefused })} (${toPercent(
-          statsData.totalRefused / statsData.totalQueries,
+          statsData.totalRefused,
+          statsData.totalQueries,
         )})`}
       />
       <Block
         label="technitium.totalAuthoritative"
         value={`${t("common.number", { value: statsData.totalAuthoritative })} (${toPercent(
-          statsData.totalAuthoritative / statsData.totalQueries,
+          statsData.totalAuthoritative,
+          statsData.totalQueries,
         )})`}
       />
       <Block
         label="technitium.totalRecursive"
         value={`${t("common.number", { value: statsData.totalRecursive })} (${toPercent(
-          statsData.totalRecursive / statsData.totalQueries,
+          statsData.totalRecursive,
+          statsData.totalQueries,
         )})`}
       />
       <Block
         label="technitium.totalCached"
         value={`${t("common.number", { value: statsData.totalCached })} (${toPercent(
-          statsData.totalCached / statsData.totalQueries,
+          statsData.totalCached,
+          statsData.totalQueries,
         )})`}
       />
       <Block
         label="technitium.totalBlocked"
         value={`${t("common.number", { value: statsData.totalBlocked })} (${toPercent(
-          statsData.totalBlocked / statsData.totalQueries,
+          statsData.totalBlocked,
+          statsData.totalQueries,
         )})`}
       />
       <Block
         label="technitium.totalDropped"
         value={`${t("common.number", { value: statsData.totalDropped })} (${toPercent(
-          statsData.totalDropped / statsData.totalQueries,
+          statsData.totalDropped,
+          statsData.totalQueries,
         )})`}
       />
       <Block label="technitium.totalClients" value={`${t("common.number", { value: statsData.totalClients })}`} />

--- a/src/widgets/technitium/component.jsx
+++ b/src/widgets/technitium/component.jsx
@@ -52,9 +52,8 @@ export default function Component({ service }) {
   }
 
   function toPercent(value, total) {
-    const percentage = (value / total) * 100;
     return t("common.percent", {
-      value: !Number.isNaN(percentage) ? percentage : 0,
+      value: !Number.isNaN(value / total) ? 100 * (value / total) : 0,
       maximumFractionDigits: 2,
     });
   }

--- a/src/widgets/technitium/widget.js
+++ b/src/widgets/technitium/widget.js
@@ -9,7 +9,7 @@ const widget = {
       endpoint: "dashboard/stats/get",
       validate: ["response", "status"],
       params: ["type"],
-      map: (data) => asJson(data).response.stats,
+      map: (data) => asJson(data).response?.stats,
     },
   },
 };


### PR DESCRIPTION
## Proposed change

During the cleanup commit from the original PR, the multiply by 100 while calculating the percentage number was accidently removed. Original code: https://github.com/gethomepage/homepage/pull/3904/commits/d8e45a2fbcc9ae1474a5d826cd5133edcd43154c#diff-bd42a75b6a61d8468c8570e33b7f13dfffcf6d6dca4997677b4d303ef56daab6R55

On my v9.8 dashboard, you can see the problem: 

![image](https://github.com/user-attachments/assets/46f9bfec-d7fe-494f-8bd9-dddc112ed8d7)

And on the test bed you can see the fix:

![image](https://github.com/user-attachments/assets/28a47a6f-bcb0-400d-9976-4a9a18b9fde4)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [X] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
