### PR TITLE
Documentation: add changedetection.io fields

### DIFF
--- a/docs/widgets/services/changedetectionio.md
+++ b/docs/widgets/services/changedetectionio.md
@@ -7,6 +7,8 @@ Learn more about [Changedetection.io](https://github.com/dgtlmoon/changedetectio
 
 Find your API key under `Settings > API`.
 
+Allowed fields: `["diffsDetected", "totalObserved"]`.
+
 ```yaml
 widget:
   type: changedetectionio


### PR DESCRIPTION
Just added additional documentation for the ChangeDetecion.io widget.

These fields are usable but wasn't listed previously in the documation. ["diffsDetected", "totalObserved"].

