### PR TITLE
Enhancement: add maxShowNowPlayingCount option for Emby and Jellyfin …

### DIFF
--- a/docs/widgets/services/emby.md
+++ b/docs/widgets/services/emby.md
@@ -9,6 +9,8 @@ You can create an API key from inside Emby at `Settings > Advanced > Api Keys`.
 
 As of v0.6.11 the widget supports fields `["movies", "series", "episodes", "songs"]`. These blocks are disabled by default but can be enabled with the `enableBlocks` option, and the "Now Playing" feature (enabled by default) can be disabled with the `enableNowPlaying` option.
 
+After version v0.9.10, Add `maxShowNowPlayingCount` option to limit the number of Now Playing items displayed.
+
 ```yaml
 widget:
   type: emby
@@ -19,4 +21,5 @@ widget:
   enableUser: true # optional, defaults to false
   showEpisodeNumber: true # optional, defaults to false
   expandOneStreamToTwoRows: false # optional, defaults to true
+  maxShowNowPlayingCount: 2 # optional, defaults to Infinity
 ```

--- a/docs/widgets/services/jellyfin.md
+++ b/docs/widgets/services/jellyfin.md
@@ -9,6 +9,8 @@ You can create an API key from inside Jellyfin at `Settings > Advanced > Api Key
 
 As of v0.6.11 the widget supports fields `["movies", "series", "episodes", "songs"]`. These blocks are disabled by default but can be enabled with the `enableBlocks` option, and the "Now Playing" feature (enabled by default) can be disabled with the `enableNowPlaying` option.
 
+After version v0.9.10, Add `maxShowNowPlayingCount` option to limit the number of Now Playing items displayed.
+
 ```yaml
 widget:
   type: jellyfin
@@ -19,4 +21,5 @@ widget:
   enableUser: true # optional, defaults to false
   showEpisodeNumber: true # optional, defaults to false
   expandOneStreamToTwoRows: false # optional, defaults to true
+  maxShowNowPlayingCount: 2 # optional, defaults to Infinity
 ```

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -397,6 +397,7 @@ export function cleanServiceGroups(groups) {
           // emby, jellyfin
           enableBlocks,
           enableNowPlaying,
+          maxShowNowPlayingCount,
 
           // emby, jellyfin, tautulli
           enableUser,
@@ -543,6 +544,7 @@ export function cleanServiceGroups(groups) {
         if (["emby", "jellyfin"].includes(type)) {
           if (enableBlocks !== undefined) cleanedService.widget.enableBlocks = JSON.parse(enableBlocks);
           if (enableNowPlaying !== undefined) cleanedService.widget.enableNowPlaying = JSON.parse(enableNowPlaying);
+          if (maxShowNowPlayingCount !== undefined) cleanedService.widget.maxShowNowPlayingCount = JSON.parse(maxShowNowPlayingCount);
         }
         if (["emby", "jellyfin", "tautulli"].includes(type)) {
           if (expandOneStreamToTwoRows !== undefined)

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -544,7 +544,8 @@ export function cleanServiceGroups(groups) {
         if (["emby", "jellyfin"].includes(type)) {
           if (enableBlocks !== undefined) cleanedService.widget.enableBlocks = JSON.parse(enableBlocks);
           if (enableNowPlaying !== undefined) cleanedService.widget.enableNowPlaying = JSON.parse(enableNowPlaying);
-          if (maxShowNowPlayingCount !== undefined) cleanedService.widget.maxShowNowPlayingCount = JSON.parse(maxShowNowPlayingCount);
+          if (maxShowNowPlayingCount !== undefined)
+            cleanedService.widget.maxShowNowPlayingCount = JSON.parse(maxShowNowPlayingCount);
         }
         if (["emby", "jellyfin", "tautulli"].includes(type)) {
           if (expandOneStreamToTwoRows !== undefined)

--- a/src/widgets/emby/component.jsx
+++ b/src/widgets/emby/component.jsx
@@ -241,6 +241,7 @@ export default function Component({ service }) {
   const enableUser = !!service.widget?.enableUser; // default is false
   const expandOneStreamToTwoRows = service.widget?.expandOneStreamToTwoRows !== false; // default is true
   const showEpisodeNumber = !!service.widget?.showEpisodeNumber; // default is false
+  const maxShowNowPlayingCount = service.widget?.maxShowNowPlayingCount ?? Infinity; // default is Infinity
 
   if (!sessionsData || !countData) {
     return (
@@ -273,7 +274,8 @@ export default function Component({ service }) {
           return -1;
         }
         return 0;
-      });
+      })
+      .slice(0, maxShowNowPlayingCount);
 
     if (playing.length === 0) {
       return (


### PR DESCRIPTION

## Proposed change

add `maxShowNowPlayingCount` option for Emby and Jellyfin, this can help keep it aligned with other widgets.

![longshot20240924192714](https://github.com/user-attachments/assets/f8aa8d08-713b-4c83-a283-1d74454185c1)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/latest/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/latest/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/latest/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/latest/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
