### PR TITLE
Fix: Support Gluetun widget auth

### DIFF
--- a/docs/widgets/services/gluetun.md
+++ b/docs/widgets/services/gluetun.md
@@ -11,8 +11,11 @@ Learn more about [Gluetun](https://github.com/qdm12/gluetun).
 
 Allowed fields: `["public_ip", "region", "country"]`.
 
+To setup authentication, follow [the official Gluetun documentation](https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md#authentication).
+
 ```yaml
 widget:
   type: gluetun
   url: http://gluetun.host.or.ip:port
+  key: gluetunkey # Not required if /v1/publicip/ip endpoint is configured with `auth = none`
 ```

--- a/src/widgets/gluetun/widget.js
+++ b/src/widgets/gluetun/widget.js
@@ -1,8 +1,8 @@
-import genericProxyHandler from "utils/proxy/handlers/generic";
+import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
 
 const widget = {
   api: "{url}/v1/{endpoint}",
-  proxyHandler: genericProxyHandler,
+  proxyHandler: credentialedProxyHandler,
 
   mappings: {
     ip: {


### PR DESCRIPTION
## Proposed change

As of release v3.41.0, all Gluetun control server routes will be private by default as described [here](https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md#authentication). The existing Gluetun widget implementation does not support authentication. This PR adds support for apikey auth for the widget and is related to https://github.com/gethomepage/homepage/discussions/4026

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
