### PR TITLE
Documentation: clarify account type for Unifi Controller widget

### DIFF
--- a/docs/widgets/services/unifi-controller.md
+++ b/docs/widgets/services/unifi-controller.md
@@ -9,6 +9,8 @@ _(Find the Unifi Controller information widget [here](../info/unifi_controller.m
 
 You can display general connectivity status from your Unifi (Network) Controller. When authenticating you will want to use an account that has at least read privileges.
 
+If connecting to Ubiquiti hardware, create a local-only user in the console settings with read privileges for the Network app.
+
 An optional 'site' parameter can be supplied, if it is not the widget will use the default site for the controller.
 
 Allowed fields: `["uptime", "wan", "lan", "lan_users", "lan_devices", "wlan", "wlan_users", "wlan_devices"]` (maximum of four). Fields unsupported by the unifi device will not be shown.

--- a/docs/widgets/services/unifi-controller.md
+++ b/docs/widgets/services/unifi-controller.md
@@ -7,9 +7,7 @@ Learn more about [Unifi Controller](https://ui.com/).
 
 _(Find the Unifi Controller information widget [here](../info/unifi_controller.md))_
 
-You can display general connectivity status from your Unifi (Network) Controller. When authenticating you will want to use an account that has at least read privileges.
-
-If connecting to Ubiquiti hardware, create a local-only user in the console settings with read privileges for the Network app.
+You can display general connectivity status from your Unifi (Network) Controller. When authenticating you will want to use a local account that has at least read privileges.
 
 An optional 'site' parameter can be supplied, if it is not the widget will use the default site for the controller.
 


### PR DESCRIPTION
Added clearer instructions for the Unifi Controller widget when using Ubiquiti hardware.

## Proposed change

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

Closes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
