### PR TITLE
Fix: lubelogger vehicleID not working with labels

### DIFF
--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -631,7 +631,7 @@ export function cleanServiceGroups(groups) {
           if (range !== undefined) cleanedService.widget.range = range;
         }
         if (type === "lubelogger") {
-          if (vehicleID !== undefined) cleanedService.widget.vehicleID = vehicleID;
+          if (vehicleID !== undefined) cleanedService.widget.vehicleID = parseInt(vehicleID, 10);
         }
       }
 


### PR DESCRIPTION
## Proposed change

```yaml
        labels:
          - homepage.group=Testing
          - homepage.name=lubelogger_labels
          - homepage.widget.type=lubelogger
          - homepage.widget.url=https://demo.lubelogger.com
          - homepage.widget.username=test
          - homepage.widget.password=1234
          - homepage.widget.vehicleID=1
```

<img width="491" alt="Screenshot 2024-09-30 at 1 59 04 PM" src="https://github.com/user-attachments/assets/1e05b5a8-734c-4a13-88ee-d033717ae993">


Closes #4058

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
