### PR TITLE
Feature: Local URL for services

### DIFF
--- a/docs/configs/services.md
+++ b/docs/configs/services.md
@@ -12,50 +12,56 @@ Groups are defined as top-level array entries.
 ```yaml
 - Group A:
     - Service A:
-        href: http://localhost/
+        href: http://my.service.url/
+        href_local: http://10.1.1.11:3000
 
 - Group B:
     - Service B:
-        href: http://localhost/
+        href: http://my.service.url/
 ```
 
 <img width="1038" alt="Service Groups" src="https://user-images.githubusercontent.com/82196/187040754-28065242-4534-4409-881c-93d1921c6141.png">
 
 ## Services
 
-Services are defined as array entries on groups,
+Services are defined as array entries on groups.
+A service can have either a external and a local URL or both.
+Homepage will check automaticly whether the local or the external URL is used, based on the URL that is used to access the page.
+If only one type of URL is given, it will be used nomatter the connection type.
 
 ```yaml
 - Group A:
     - Service A:
-        href: http://localhost/
+        href: http://my.service.url/
+        href_local: http://10.1.1.11:3000
 
     - Service B:
-        href: http://localhost/
+        href: http://my.service.url/
 
     - Service C:
-        href: http://localhost/
+        href_local: http://localhost:3000
 
 - Group B:
     - Service D:
-        href: http://localhost/
+        href: http://my.service.url/
 ```
 
 <img width="1038" alt="Service Services" src="https://user-images.githubusercontent.com/82196/187040763-038023a2-8bee-4d87-b5cc-13447e7365a4.png">
 
 ## Descriptions
 
-Services may have descriptions,
+Services may have descriptions.
 
 ```yaml
 - Group A:
     - Service A:
-        href: http://localhost/
+        href: http://my.service.url/
+        href_local: http://10.1.1.11:3000
         description: This is my service
 
 - Group B:
     - Service B:
-        href: http://localhost/
+        href: http://my.service.url/
         description: This is another service
 ```
 
@@ -156,14 +162,14 @@ Services may be connected to a Docker container, either running on the local mac
 ```yaml
 - Group A:
     - Service A:
-        href: http://localhost/
+        href: http://my.service.url/
         description: This is my service
         server: my-server
         container: my-container
 
 - Group B:
     - Service B:
-        href: http://localhost/
+        href: http://my.service.url/
         description: This is another service
         server: other-server
         container: other-container


### PR DESCRIPTION
## Proposed change
Added the functionality to provide a local URL in the services.yaml by using "href_local".
The "Item" function will then check whether "href_local" or "href" is used based on the "window.location.href".
This allows to access the services directly without any reverse-proxy and furthermore keep the traffic inside the local network.
The changes will not impact current installations.

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

Closed discussion [#1208](https://github.com/gethomepage/homepage/discussions/1208)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service 
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
