### PR TITLE
Feature/unifi default

### DIFF
--- a/src/components/widgets/unifi_console/unifi_console.jsx
+++ b/src/components/widgets/unifi_console/unifi_console.jsx
@@ -24,7 +24,7 @@ export default function Widget({ options }) {
 
   const defaultSite = options.site
     ? statsData?.data.find((s) => s.desc === options.site)
-    : (statsData?.data?.find((s) => s.name === "default") ?? statsData?.data.at(0));
+    : (statsData?.data?.find((s) => s.name === "default") ?? statsData?.data?.at(0));
 
   if (!defaultSite) {
     return (

--- a/src/components/widgets/unifi_console/unifi_console.jsx
+++ b/src/components/widgets/unifi_console/unifi_console.jsx
@@ -24,7 +24,7 @@ export default function Widget({ options }) {
 
   const defaultSite = options.site
     ? statsData?.data.find((s) => s.desc === options.site)
-    : statsData?.data?.find((s) => s.name === "default");
+    : (statsData?.data?.find((s) => s.name === "default") ?? statsData?.data.at(0));
 
   if (!defaultSite) {
     return (

--- a/src/widgets/unifi/component.jsx
+++ b/src/widgets/unifi/component.jsx
@@ -17,7 +17,7 @@ export default function Component({ service }) {
 
   const defaultSite = widget.site
     ? statsData?.data.find((s) => s.desc === widget.site)
-    : (statsData?.data?.find((s) => s.name === "default") ?? statsData?.data.at(0));
+    : (statsData?.data?.find((s) => s.name === "default") ?? statsData?.data?.at(0));
 
   if (!defaultSite) {
     if (widget.site) {

--- a/src/widgets/unifi/component.jsx
+++ b/src/widgets/unifi/component.jsx
@@ -17,7 +17,7 @@ export default function Component({ service }) {
 
   const defaultSite = widget.site
     ? statsData?.data.find((s) => s.desc === widget.site)
-    : statsData?.data?.find((s) => s.name === "default");
+    : (statsData?.data?.find((s) => s.name === "default") ?? statsData?.data.at(0));
 
   if (!defaultSite) {
     if (widget.site) {


### PR DESCRIPTION
## Proposed change

The `site` property of unifi widgets is optional and defaults to `default`, but many users rename their site.  This change will use the first item in the data array if `site` is not specified and `default` is not found.  This will hopefully reduce the number of "it doesn't work" support requests.

Closes # (issue)

## Type of change

Not a bug fix, just changing the behavior to what some users expect.

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
