### PR TITLE
add support for using an API key with Kavita

### DIFF
--- a/docs/widgets/services/kavita.md
+++ b/docs/widgets/services/kavita.md
@@ -15,4 +15,5 @@ widget:
   url: http://kavita.host.or.ip:port
   username: username
   password: password
+  apiKey: apikeyapikeyapikeyapikeyapikey
 ```

--- a/src/widgets/kavita/proxy.js
+++ b/src/widgets/kavita/proxy.js
@@ -14,7 +14,7 @@ async function login(widget, service) {
   const endpoint = "Account/login";
   const api = widgets?.[widget.type]?.api;
   const loginUrl = new URL(formatApiCall(api, { endpoint, ...widget }));
-  const loginBody = { username: widget.username, password: widget.password };
+  const loginBody = { username: widget.username || "", password: widget.password || "", apiKey: widget.apiKey || "" };
   const headers = { "Content-Type": "application/json", accept: "text/plain" };
 
   const [, , data] = await httpProxy(loginUrl, {


### PR DESCRIPTION
## Proposed change

The Kavita widget was created to use `username` and `password`, but didn't include the `apiKey` option which is the prefered method of 3rd party service auth in Kavita.
Kavita API docs for the relevant request: https://www.kavitareader.com/docs/api/#/Account/post_api_Account_login

Tested my end and all works exactly as expected/as the username and password auth works:
![Screenshot 2024-10-07 at 19-37-03 Homepage](https://github.com/user-attachments/assets/976b8ba2-0aaa-4632-bb8c-2f19a3733e49)

Example `services.yaml` used for testing:
```yaml
---
# For configuration options and examples, please see:
# https://gethomepage.dev/configs/services

- My First Group:
    - Kavita:
        icon: kavita.png
        href: http://localhost:5000
        description: books
        widget:
          type: kavita
          url: http://localhost:5000
          apiKey: YOUR-API-KEY-HERE

```

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

Arguably a bug fix, as it should have been built to use an API key rather than user credentials in the first place, but I can see the perspective of calling it a 'New Feature' as well :shrug: 

## Checklist:

- [X] If applicable, I have added corresponding documentation changes.
- [X] If applicable, I have reviewed the [feature](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [X] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [X] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.


I have not logged an issue for this as it's such a tiny change (happy to log one if it's required your end).
The string used for the `apiKey` field in the docs was copied from how most other service widgets seem to display it.