### PR TITLE
Enhancement: support netalertX token for password-protected instances

### DIFF
--- a/docs/widgets/services/netalertx.md
+++ b/docs/widgets/services/netalertx.md
@@ -9,8 +9,11 @@ _Note that the project was renamed from PiAlert to NetAlertX._
 
 Allowed fields: `["total", "connected", "new_devices", "down_alerts"]`.
 
+If you have enabled a password on your NetAlertX instance, you will need to provide the `SYNC_api_token` as the `key` in your config.
+
 ```yaml
 widget:
   type: netalertx
   url: http://ip:port
+  key: netalertxsyncapitoken # optional, only if password is enabled
 ```

--- a/src/utils/proxy/handlers/credentialed.js
+++ b/src/utils/proxy/handlers/credentialed.js
@@ -41,6 +41,7 @@ export default async function credentialedProxyHandler(req, res, map) {
           "ghostfolio",
           "linkwarden",
           "mealie",
+          "netalertx",
           "tailscale",
           "tandoor",
           "pterodactyl",

--- a/src/widgets/netalertx/widget.js
+++ b/src/widgets/netalertx/widget.js
@@ -1,8 +1,8 @@
-import genericProxyHandler from "utils/proxy/handlers/generic";
+import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
 
 const widget = {
   api: "{url}/php/server/devices.php?action=getDevicesTotals",
-  proxyHandler: genericProxyHandler,
+  proxyHandler: credentialedProxyHandler,
 
   mappings: {
     data: {


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

Closes https://github.com/jokob-sk/NetAlertX/issues/838

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
