### PR TITLE
Fix broken Immich service endpoints

### DIFF
--- a/src/widgets/immich/widget.js
+++ b/src/widgets/immich/widget.js
@@ -6,13 +6,13 @@ const widget = {
 
   mappings: {
     version: {
-      endpoint: "server-info/version",
+      endpoint: "server/version",
     },
     statistics: {
-      endpoint: "server-info/statistics",
+      endpoint: "server/statistics",
     },
     stats: {
-      endpoint: "server-info/stats",
+      endpoint: "server/stats",
     },
     version_v2: {
       endpoint: "server/version",


### PR DESCRIPTION
## Proposed change

Update immich endpoints which were broken in [v1.118.0](https://github.com/immich-app/immich/releases/tag/v1.118.0)

This will probably break the widget when users use older versions of Immich? Not sure if there's a non-breaking way of doing this.

Closes # (issue)

## Type of change
- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
