### PR TITLE
Add Kagi search provider

### DIFF
--- a/docs/configs/settings.md
+++ b/docs/configs/settings.md
@@ -389,7 +389,7 @@ quicklaunch:
   hideInternetSearch: true
   showSearchSuggestions: true
   hideVisitURL: true
-  provider: google # google, duckduckgo, bing, baidu, brave or custom
+  provider: google # google, duckduckgo, bing, baidu, brave, kagi or custom
 ```
 
 or for a custom search:

--- a/docs/widgets/info/search.md
+++ b/docs/widgets/info/search.md
@@ -3,7 +3,7 @@ title: Search
 description: Search Information Widget Configuration
 ---
 
-You can add a search bar to your top widget area that can search using Google, Duckduckgo, Bing, Baidu, Brave or any other custom provider that supports the basic `?q=` search query param.
+You can add a search bar to your top widget area that can search using Google, Duckduckgo, Bing, Baidu, Brave, Kagi or any other custom provider that supports the basic `?q=` search query param.
 
 ```yaml
 - search:

--- a/src/components/widgets/search/search.jsx
+++ b/src/components/widgets/search/search.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, Fragment } from "react";
 import { useTranslation } from "next-i18next";
 import { FiSearch } from "react-icons/fi";
-import { SiDuckduckgo, SiMicrosoftbing, SiGoogle, SiBaidu, SiBrave } from "react-icons/si";
+import { SiDuckduckgo, SiMicrosoftbing, SiGoogle, SiBaidu, SiBrave, SiKagi } from "react-icons/si";
 import { Listbox, Transition, Combobox } from "@headlessui/react";
 import classNames from "classnames";
 
@@ -38,6 +38,12 @@ export const searchProviders = {
     url: "https://search.brave.com/search?q=",
     suggestionUrl: "https://search.brave.com/api/suggest?&rich=false&q=",
     icon: SiBrave,
+  },
+  kagi: {
+    name: "Kagi",
+    url: "https://kagi.com/search?q=",
+    suggestionUrl: "https://kagi.com/api/autosuggest?q=",
+    icon: SiKagi,
   },
   custom: {
     name: "Custom",


### PR DESCRIPTION
## Proposed change

Just added Kagi, based on ab2c3c641255877f43dd57cec477296e6a2ab6c5.

Closes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.

I realise this doesn't have a 10-upvote request, but it's a fairly minor addition and Kagi is quite a popular alternative search engine these days.