### PR TITLE
Chore: filter Radarr movie response

### DIFF
--- a/src/widgets/radarr/widget.js
+++ b/src/widgets/radarr/widget.js
@@ -12,7 +12,10 @@ const widget = {
         wanted: jsonArrayFilter(data, (item) => item.monitored && !item.hasFile && item.isAvailable).length,
         have: jsonArrayFilter(data, (item) => item.hasFile).length,
         missing: jsonArrayFilter(data, (item) => item.monitored && !item.hasFile).length,
-        all: asJson(data),
+        all: asJson(data).map((entry) => ({
+          title: entry.title,
+          id: entry.id
+        })),
       }),
     },
     "queue/status": {

--- a/src/widgets/radarr/widget.js
+++ b/src/widgets/radarr/widget.js
@@ -14,7 +14,7 @@ const widget = {
         missing: jsonArrayFilter(data, (item) => item.monitored && !item.hasFile).length,
         all: asJson(data).map((entry) => ({
           title: entry.title,
-          id: entry.id
+          id: entry.id,
         })),
       }),
     },


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

The current usage of `/api/v3/movie`'s `all` mapping is only for mapping queue IDs to movie titles. Originally I planned to move to using the queue details title, but that is the full download title and not strictly just the movie title. To not change the UI, we can at least remove unnecessary attributes from the response which is currently very bloated. If it's fine to change from movie title to download title, then `all` can be removed completely.

A user reported for a library of ~10k movies the response was >4MB:
```
[2024-10-26T07:29:29.928Z] warn: API response for /api/services/proxy?group=Movies+and+Series+Management&service=Radarr&endpoint=movie exceeds 4MB. API Routes are meant to respond quickly. https://nextjs.org/docs/messages/api-routes-response-size-limit
```

This change won't fix the overall issue of the size of the radarr response, but will at least filter down to what the frontend needs.

The Sonarr API already does filtering like this. In my testing this reduced my response size with a library of 308 movies from 1.1 MB to 12.86 kB.

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
