### PR TITLE
Documentation: change authentik port to generic placeholder

### DIFF
--- a/docs/widgets/services/authentik.md
+++ b/docs/widgets/services/authentik.md
@@ -23,4 +23,3 @@ widget:
   url: http://authentik.host.or.ip:port
   key: api_token
 ```
-The port should be the one you specified in the environment variables `COMPOSE_PORT_HTTP` or `COMPOSE_PORT_HTTPS` when installing Authentik. If you are using a reverse proxy alternatively you can just enter the domain.

--- a/docs/widgets/services/authentik.md
+++ b/docs/widgets/services/authentik.md
@@ -20,6 +20,7 @@ Allowed fields: `["users", "loginsLast24H", "failedLoginsLast24H"]`.
 ```yaml
 widget:
   type: authentik
-  url: http://authentik.host.or.ip:22070
+  url: http://authentik.host.or.ip:port
   key: api_token
 ```
+The port should be the one you specified in the environment variables `COMPOSE_PORT_HTTP` or `COMPOSE_PORT_HTTPS` when installing Authentik. If you are using a reverse proxy alternatively you can just enter the domain.


### PR DESCRIPTION
## Proposed change
There is no default port 22070 for the configuration of this widget. You can either use the Port specified while installing Authentik or use the domain when using a reverse proxy. See: https://docs.goauthentik.io/docs/developer-docs/api/
<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
