### PR TITLE
Feature: suwayomi Service Widget

### DIFF
--- a/docs/widgets/services/suwayomi.md
+++ b/docs/widgets/services/suwayomi.md
@@ -5,28 +5,16 @@ description: Suwayomi Widget Configuration
 
 Learn more about [Suwayomi](https://github.com/Suwayomi/Suwayomi-Server).
 
-all supported fields shown in example yaml, though a max of 4 will show at one time.
-The default fields are download, nondownload, read and unread.
-category defaults to "all" if left unset or set to not a number.
-The category ID can be obtained from the url when navigating to it, `?tab={categoryID}`.
-username and password are available if you have basic auth setup for Suwayomi.
+Allowed fields:["download", "nondownload", "read", "unread", "downloadedread", "downloadedunread", "nondownloadedread", "nondownloadedunread"]
+
+The widget defaults to the first four above. If more than four fields are provided, only the first 4 are displayed.
+Category IDs can be obtained from the url when navigating to it, `?tab={categoryID}`.
 
 ```yaml
 widget:
-  icon: https://raw.githubusercontent.com/Suwayomi/Suwayomi-Server/refs/heads/master/server/src/main/resources/icon/faviconlogo-128.png
-  widget:
-    type: suwayomi
-    url: http://suwayomi.host.or.ip
-    username: username
-    password: password
-    category: 0
-    fields:
-      - download
-      - nondownload
-      - read
-      - unread
-      - downloadedRead
-      - downloadedunread
-      - nondownloadedread
-      - nondownloadedunread
+  type: suwayomi
+  url: http://suwayomi.host.or.ip
+  username: username #optional
+  password: password #optional
+  category: 0 #optional, defaults to all categories
 ```

--- a/docs/widgets/services/suwayomi.md
+++ b/docs/widgets/services/suwayomi.md
@@ -6,6 +6,7 @@ description: Suwayomi Widget Configuration
 Learn more about [Suwayomi](https://github.com/Suwayomi/Suwayomi-Server).
 
 all supported fields shown in example yaml, though a max of 4 will show at one time.
+The default fields are download, nondownload, read and unread.
 username and password are available if you have basic auth setup for Suwayomi.
 
 ```yaml

--- a/docs/widgets/services/suwayomi.md
+++ b/docs/widgets/services/suwayomi.md
@@ -8,6 +8,7 @@ Learn more about [Suwayomi](https://github.com/Suwayomi/Suwayomi-Server).
 all supported fields shown in example yaml, though a max of 4 will show at one time.
 The default fields are download, nondownload, read and unread.
 category defaults to "all" if left unset or set to not a number.
+The category ID can be obtained from the url when navigating to it, `?tab={categoryID}`.
 username and password are available if you have basic auth setup for Suwayomi.
 
 ```yaml

--- a/docs/widgets/services/suwayomi.md
+++ b/docs/widgets/services/suwayomi.md
@@ -5,7 +5,7 @@ description: Suwayomi Widget Configuration
 
 Learn more about [Suwayomi](https://github.com/Suwayomi/Suwayomi-Server).
 
-Allowed fields:["download", "nondownload", "read", "unread", "downloadedread", "downloadedunread", "nondownloadedread", "nondownloadedunread"]
+Allowed fields: ["download", "nondownload", "read", "unread", "downloadedread", "downloadedunread", "nondownloadedread", "nondownloadedunread"]
 
 The widget defaults to the first four above. If more than four fields are provided, only the first 4 are displayed.
 Category IDs can be obtained from the url when navigating to it, `?tab={categoryID}`.

--- a/docs/widgets/services/suwayomi.md
+++ b/docs/widgets/services/suwayomi.md
@@ -1,0 +1,29 @@
+---
+title: Suwayomi
+description: Suwayomi Widget Configuration
+---
+
+Learn more about [Suwayomi](https://github.com/Suwayomi/Suwayomi-Server).
+
+all supported fields shown in example yaml, though a max of 4 will show at one time.
+username and password are available if you have basic auth setup for Suwayomi.
+
+```yaml
+widget:
+  icon: https://raw.githubusercontent.com/Suwayomi/Suwayomi-Server/refs/heads/master/server/src/main/resources/icon/faviconlogo-128.png
+  widget:
+    type: suwayomi
+    url: http://suwayomi.host.or.ip
+    username: username # if u have basic auth setup
+    password: password # if u have basic auth setup
+    category: 0 # to use a given categoryID defaults to all categories
+    fields:
+      - download
+      - nondownload
+      - read
+      - unread
+      - downloadedRead
+      - downloadedunread
+      - nondownloadedread
+      - nondownloadedunread
+```

--- a/docs/widgets/services/suwayomi.md
+++ b/docs/widgets/services/suwayomi.md
@@ -7,6 +7,7 @@ Learn more about [Suwayomi](https://github.com/Suwayomi/Suwayomi-Server).
 
 all supported fields shown in example yaml, though a max of 4 will show at one time.
 The default fields are download, nondownload, read and unread.
+category defaults to "all" if left unset or set to not a number.
 username and password are available if you have basic auth setup for Suwayomi.
 
 ```yaml
@@ -15,9 +16,9 @@ widget:
   widget:
     type: suwayomi
     url: http://suwayomi.host.or.ip
-    username: username # if u have basic auth setup
-    password: password # if u have basic auth setup
-    category: 0 # to use a given categoryID defaults to all categories
+    username: username
+    password: password
+    category: 0
     fields:
       - download
       - nondownload

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -309,6 +309,16 @@
         "stopped": "Stopped",
         "total": "Total"
     },
+    "suwayomi": {
+      "download": "Downloaded",
+      "nondownload": "Non-Downloaded",
+      "read": "Read",
+      "unread": "Unread",
+      "downloadedread": "Downloaded & Read",
+      "downloadedunread": "Downloaded & Unread",
+      "nondownloadedread": "Non-Downloaded & Read",
+      "nondownloadedunread": "Non-Downloaded & Unread"
+    },
     "tailscale": {
         "address": "Address",
         "expires": "Expires",

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -114,6 +114,7 @@ const components = {
   stocks: dynamic(() => import("./stocks/component")),
   strelaysrv: dynamic(() => import("./strelaysrv/component")),
   swagdashboard: dynamic(() => import("./swagdashboard/component")),
+  suwayomi: dynamic(() => import("./suwayomi/component")),
   tailscale: dynamic(() => import("./tailscale/component")),
   tandoor: dynamic(() => import("./tandoor/component")),
   tautulli: dynamic(() => import("./tautulli/component")),

--- a/src/widgets/suwayomi/component.jsx
+++ b/src/widgets/suwayomi/component.jsx
@@ -27,7 +27,7 @@ export default function Component({ service }) {
   /** @type {{widget: { fields: string[]|null }}} */
   const { widget } = service;
 
-  /** @type { { data: { label: string, count: number }[], error: unk }} */
+  /** @type { { data: { label: string, count: number }[], error: unknown }} */
   const { data: suwayomiData, error: suwayomiError } = useWidgetAPI(widget);
 
   if (suwayomiError) {

--- a/src/widgets/suwayomi/component.jsx
+++ b/src/widgets/suwayomi/component.jsx
@@ -20,7 +20,6 @@ export default function Component({ service }) {
       widget.fields = ["download", "nondownload", "read", "unread"];
     } else if (widget.fields.length > 4) {
       widget.fields = widget.fields.slice(0, 4);
-      widget.fields = widget.fields.map((field) => field.toLowerCase());
     }
     return (
       <Container service={service}>

--- a/src/widgets/suwayomi/component.jsx
+++ b/src/widgets/suwayomi/component.jsx
@@ -10,6 +10,7 @@ export default function Component({ service }) {
   /** @type {{widget: { fields: string[] }}} */
   const { widget } = service;
 
+  /** @type { { data: { label: string, count: number }[], error: unknown }} */
   const { data: suwayomiData, error: suwayomiError } = useWidgetAPI(widget);
 
   if (suwayomiError) {

--- a/src/widgets/suwayomi/component.jsx
+++ b/src/widgets/suwayomi/component.jsx
@@ -38,10 +38,9 @@ export default function Component({ service }) {
     const fields = makeFields(widget.fields);
     return (
       <Container service={service}>
-        {fields.map((Field) => {
-          const field = Field.toLowerCase();
-          return <Block key={field} label={`suwayomi.${field}`} />;
-        })}
+        {fields.map((field) => (
+          <Block key={field} label={`suwayomi.${field}`} />
+        ))}
       </Container>
     );
   }

--- a/src/widgets/suwayomi/component.jsx
+++ b/src/widgets/suwayomi/component.jsx
@@ -29,7 +29,7 @@ export default function Component({ service }) {
   }
 
   // i would like to be able to do something like this but i guess not
-  // widget.service_name += suwayomiData.name ? `-${suwayomiData.name}` : "";
+  // service.description += suwayomiData.name;
 
   return (
     <Container service={service}>

--- a/src/widgets/suwayomi/component.jsx
+++ b/src/widgets/suwayomi/component.jsx
@@ -4,10 +4,27 @@ import Container from "components/services/widget/container";
 import Block from "components/services/widget/block";
 import useWidgetAPI from "utils/proxy/use-widget-api";
 
+/**
+ * @param {string[]|null} Fields
+ * @returns {string[]}
+ */
+function makeFields(Fields = []) {
+  let fields = Fields ?? [];
+  if (fields.length === 0) {
+    fields = ["download", "nondownload", "read", "unread"];
+  }
+  if (fields.length > 4) {
+    fields.length = 4;
+  }
+  fields = fields.map((f) => f.toLowerCase());
+
+  return fields;
+}
+
 export default function Component({ service }) {
   const { t } = useTranslation();
 
-  /** @type {{widget: { fields: string[] }}} */
+  /** @type {{widget: { fields: string[]|null }}} */
   const { widget } = service;
 
   /** @type { { data: { label: string, count: number }[], error: unk }} */
@@ -18,9 +35,7 @@ export default function Component({ service }) {
   }
 
   if (!suwayomiData) {
-    if (widget.fields.length > 4) {
-      widget.fields.length = 4;
-    }
+    widget.fields = makeFields(widget.fields);
     return (
       <Container service={service}>
         {widget.fields.map((Field) => {

--- a/src/widgets/suwayomi/component.jsx
+++ b/src/widgets/suwayomi/component.jsx
@@ -35,10 +35,10 @@ export default function Component({ service }) {
   }
 
   if (!suwayomiData) {
-    widget.fields = makeFields(widget.fields);
+    const fields = makeFields(widget.fields);
     return (
       <Container service={service}>
-        {widget.fields.map((Field) => {
+        {fields.map((Field) => {
           const field = Field.toLowerCase();
           return <Block key={field} label={`suwayomi.${field}`} />;
         })}

--- a/src/widgets/suwayomi/component.jsx
+++ b/src/widgets/suwayomi/component.jsx
@@ -28,9 +28,6 @@ export default function Component({ service }) {
     );
   }
 
-  // i would like to be able to do something like this but i guess not
-  // service.description += suwayomiData.name;
-
   return (
     <Container service={service}>
       {suwayomiData.map((data) => (

--- a/src/widgets/suwayomi/component.jsx
+++ b/src/widgets/suwayomi/component.jsx
@@ -10,7 +10,7 @@ export default function Component({ service }) {
   /** @type {{widget: { fields: string[] }}} */
   const { widget } = service;
 
-  /** @type { { data: { label: string, count: number }[], error: unknown }} */
+  /** @type { { data: { label: string, count: number }[], error: unk }} */
   const { data: suwayomiData, error: suwayomiError } = useWidgetAPI(widget);
 
   if (suwayomiError) {
@@ -18,7 +18,9 @@ export default function Component({ service }) {
   }
 
   if (!suwayomiData) {
-    widget.fields.length = 4;
+    if (widget.fields.length > 4) {
+      widget.fields.length = 4;
+    }
     return (
       <Container service={service}>
         {widget.fields.map((Field) => {

--- a/src/widgets/suwayomi/component.jsx
+++ b/src/widgets/suwayomi/component.jsx
@@ -4,43 +4,11 @@ import Container from "components/services/widget/container";
 import Block from "components/services/widget/block";
 import useWidgetAPI from "utils/proxy/use-widget-api";
 
-/**
- * @param {string[]|null} Fields
- * @returns {string[]}
- */
-function makeFields(Fields = []) {
-  let fields = Fields ?? [];
-  if (fields.length === 0) {
-    fields = ["download", "nonDownload", "read", "unRead"];
-  }
-  if (fields.length > 4) {
-    fields.length = 4;
-  }
-  fields = fields.map((field) => field.toLowerCase());
-
-  return fields;
-}
-
 export default function Component({ service }) {
   const { t } = useTranslation();
 
-  /**
-   * @type {{
-   *   widget: {
-   *     fields: string[]|null
-   *   }
-   * }}
-   */
   const { widget } = service;
 
-  /**
-   * @type {{
-   *   error: unknown
-   *   data: ({
-   *     label: string, count: number
-   *   }[]),
-   * }}
-   */
   const { data: suwayomiData, error: suwayomiError } = useWidgetAPI(widget);
 
   if (suwayomiError) {
@@ -48,10 +16,15 @@ export default function Component({ service }) {
   }
 
   if (!suwayomiData) {
-    const fields = makeFields(widget.fields);
+    if (!widget.fields || widget.fields.length === 0) {
+      widget.fields = ["download", "nondownload", "read", "unread"];
+    } else if (widget.fields.length > 4) {
+      widget.fields = widget.fields.slice(0, 4);
+      widget.fields = widget.fields.map((field) => field.toLowerCase());
+    }
     return (
       <Container service={service}>
-        {fields.map((field) => (
+        {widget.fields.map((field) => (
           <Block key={field} label={`suwayomi.${field}`} />
         ))}
       </Container>

--- a/src/widgets/suwayomi/component.jsx
+++ b/src/widgets/suwayomi/component.jsx
@@ -24,10 +24,23 @@ function makeFields(Fields = []) {
 export default function Component({ service }) {
   const { t } = useTranslation();
 
-  /** @type {{widget: { fields: string[]|null }}} */
+  /**
+   * @type {{
+   *   widget: {
+   *     fields: string[]|null
+   *   }
+   * }}
+   */
   const { widget } = service;
 
-  /** @type { { data: { label: string, count: number }[], error: unknown }} */
+  /**
+   * @type {{
+   *   error: unknown
+   *   data: ({
+   *     label: string, count: number
+   *   }[]),
+   * }}
+   */
   const { data: suwayomiData, error: suwayomiError } = useWidgetAPI(widget);
 
   if (suwayomiError) {

--- a/src/widgets/suwayomi/component.jsx
+++ b/src/widgets/suwayomi/component.jsx
@@ -11,12 +11,12 @@ import useWidgetAPI from "utils/proxy/use-widget-api";
 function makeFields(Fields = []) {
   let fields = Fields ?? [];
   if (fields.length === 0) {
-    fields = ["download", "nondownload", "read", "unread"];
+    fields = ["download", "nonDownload", "read", "unRead"];
   }
   if (fields.length > 4) {
     fields.length = 4;
   }
-  fields = fields.map((f) => f.toLowerCase());
+  fields = fields.map((field) => field.toLowerCase());
 
   return fields;
 }

--- a/src/widgets/suwayomi/component.jsx
+++ b/src/widgets/suwayomi/component.jsx
@@ -1,0 +1,41 @@
+import { useTranslation } from "next-i18next";
+
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+
+  /** @type {{widget: { fields: string[] }}} */
+  const { widget } = service;
+
+  const { data: suwayomiData, error: suwayomiError } = useWidgetAPI(widget);
+
+  if (suwayomiError) {
+    return <Container service={service} error={suwayomiError} />;
+  }
+
+  if (!suwayomiData) {
+    widget.fields.length = 4;
+    return (
+      <Container service={service}>
+        {widget.fields.map((Field) => {
+          const field = Field.toLowerCase();
+          return <Block key={field} label={`suwayomi.${field}`} />;
+        })}
+      </Container>
+    );
+  }
+
+  // i would like to be able to do something like this but i guess not
+  // widget.service_name += suwayomiData.name ? `-${suwayomiData.name}` : "";
+
+  return (
+    <Container service={service}>
+      {suwayomiData.map((data) => (
+        <Block key={data.label} label={data.label} value={t("common.number", { value: data.count })} />
+      ))}
+    </Container>
+  );
+}

--- a/src/widgets/suwayomi/proxy.js
+++ b/src/widgets/suwayomi/proxy.js
@@ -13,33 +13,6 @@ const logger = createLogger(proxyName);
  * @property {string} gqlCondition
  */
 
-/** @type {Record<string, countsToExtractItem>} */
-const countsToExtract = {
-  download: {
-    condition: (c) => c.isDownloaded,
-    gqlCondition: "isDownloaded: true",
-  },
-  nondownload: {
-    condition: (c) => !c.isDownloaded,
-    gqlCondition: "isDownloaded: false",
-  },
-  read: { condition: (c) => c.isRead, gqlCondition: "isRead: true" },
-  unread: { condition: (c) => !c.isRead, gqlCondition: "isRead: false" },
-  downloadedread: { condition: (c) => c.isDownloaded && c.isRead, gqlCondition: "isDownloaded: true, isRead: true" },
-  downloadedunread: {
-    condition: (c) => c.isDownloaded && !c.isRead,
-    gqlCondition: "isDownloaded: true, isRead: false",
-  },
-  nondownloadedread: {
-    condition: (c) => !c.isDownloaded && c.isRead,
-    gqlCondition: "isDownloaded: false, isRead: true",
-  },
-  nondownloadedunread: {
-    condition: (c) => !c.isDownloaded && !c.isRead,
-    gqlCondition: "isDownloaded: false, isRead: false",
-  },
-};
-
 /**
  * @typedef totalCount
  * @type {object}
@@ -86,6 +59,42 @@ const countsToExtract = {
  *   }
  * }}
  */
+
+/**
+ * @typedef {object} widget
+ * @property {string} username
+ * @property {string} password
+ * @property {string[]|null} fields
+ * @property {string|number|undefined} category
+ * @property {keyof typeof widgets} type
+ */
+
+/** @type {Record<string, countsToExtractItem>} */
+const countsToExtract = {
+  download: {
+    condition: (c) => c.isDownloaded,
+    gqlCondition: "isDownloaded: true",
+  },
+  nondownload: {
+    condition: (c) => !c.isDownloaded,
+    gqlCondition: "isDownloaded: false",
+  },
+  read: { condition: (c) => c.isRead, gqlCondition: "isRead: true" },
+  unread: { condition: (c) => !c.isRead, gqlCondition: "isRead: false" },
+  downloadedread: { condition: (c) => c.isDownloaded && c.isRead, gqlCondition: "isDownloaded: true, isRead: true" },
+  downloadedunread: {
+    condition: (c) => c.isDownloaded && !c.isRead,
+    gqlCondition: "isDownloaded: true, isRead: false",
+  },
+  nondownloadedread: {
+    condition: (c) => !c.isDownloaded && c.isRead,
+    gqlCondition: "isDownloaded: false, isRead: true",
+  },
+  nondownloadedunread: {
+    condition: (c) => !c.isDownloaded && !c.isRead,
+    gqlCondition: "isDownloaded: false, isRead: false",
+  },
+};
 
 /**
  * Makes a GraphQL query body based on the provided fieldsSet and category.
@@ -188,15 +197,6 @@ function makeFields(Fields = []) {
 
   return fields;
 }
-
-/**
- * @typedef {object} widget
- * @property {string} username
- * @property {string} password
- * @property {string[]|null} fields
- * @property {string|number|undefined} category
- * @property {keyof typeof widgets} type
- */
 
 /**
  * @param {widget} widget

--- a/src/widgets/suwayomi/proxy.js
+++ b/src/widgets/suwayomi/proxy.js
@@ -240,6 +240,11 @@ export default async function suwayomiProxyHandler(req, res) {
   }
   /** @type {{ fields: string[],category: string|number|undefined, type: keyof typeof widgets }} */
   const widget = await getServiceWidget(group, service);
+
+  if (widget.fields.length === 0) {
+    widget.fields = ["download", "nondownload", "read", "unread"];
+  }
+
   widget.fields.length = 4;
   widget.fields = widget.fields.map((f) => f.toLowerCase());
   /** @type {Set<string>} */

--- a/src/widgets/suwayomi/proxy.js
+++ b/src/widgets/suwayomi/proxy.js
@@ -221,7 +221,13 @@ export default async function suwayomiProxyHandler(req, res) {
   }
 
   if (status !== 200) {
-    logger.error("Error getting data from Suwayomi: %d.  Data: %s", status, data);
+    logger.error(
+      "Error getting data from Suwayomi for service '%s' in group '%s': %d.  Data: %s",
+      service,
+      group,
+      status,
+      data,
+    );
     return res.status(status).send({ error: { message: "Error getting data. body: %s, data: %s", body, data } });
   }
 

--- a/src/widgets/suwayomi/proxy.js
+++ b/src/widgets/suwayomi/proxy.js
@@ -9,7 +9,7 @@ const logger = createLogger(proxyName);
 
 /**
  * @typedef {object} countsToExtractItem
- * @property {(c: chapter) => boolean} condition
+ * @property {(chapter: chapter) => boolean} condition
  * @property {string} gqlCondition
  */
 

--- a/src/widgets/suwayomi/proxy.js
+++ b/src/widgets/suwayomi/proxy.js
@@ -63,15 +63,15 @@ const logger = createLogger(proxyName);
 /**
  * Makes a GraphQL query body based on the provided fieldsSet and category.
  *
- * @param {Set} fieldsSet - Set of fields to include in the query.
+ * @param {string[]} fields - Array of field names.
  * @param {string|number|undefined} [category="all"] - Category ID or "all" for general counts.
  * @param {Record<string, countsToExtractItem>} countsToExtract - Object containing counts to extract.
  * @returns {string} - The JSON stringified query body.
  */
-function makeBody(fieldsSet, countsToExtract, category = "all") {
+function makeBody(fields, countsToExtract, category = "all") {
   if (Number.isNaN(Number(category))) {
     let query = "";
-    fieldsSet.forEach((f) => {
+    fields.forEach((f) => {
       query += `
       ${f}: chapters(
         condition: {${countsToExtract[f].gqlCondition}}
@@ -114,10 +114,11 @@ function makeBody(fieldsSet, countsToExtract, category = "all") {
 }
 
 /**
+ * Extracts the counts from the response JSON object based on the provided fields and countsToExtract object.
  *
- * @param {ResponseJSON|ResponseJSONcategory} responseJSON
- * @param {string[]} fields
- * @param {Record<string, countsToExtractItem>} countsToExtract
+ * @param {ResponseJSON|ResponseJSONcategory} responseJSON - The response JSON object.
+ * @param {string[]} fields - Array of field names.
+ * @param {Record<string, countsToExtractItem>} countsToExtract - Object containing counts to extract.
  * @returns
  */
 function extractCounts(responseJSON, fields, countsToExtract) {
@@ -162,8 +163,6 @@ export default async function suwayomiProxyHandler(req, res) {
 
   widget.fields.length = 4;
   widget.fields = widget.fields.map((f) => f.toLowerCase());
-  /** @type {Set<string>} */
-  const fieldsSet = new Set(widget.fields);
 
   /** @type {Record<string, countsToExtractItem>} */
   const countsToExtract = {
@@ -199,7 +198,7 @@ export default async function suwayomiProxyHandler(req, res) {
 
   const url = new URL(formatApiCall(widgets[widget.type].api, { endpoint, ...widget }));
 
-  const body = makeBody(fieldsSet, countsToExtract, widget.category);
+  const body = makeBody(widget.fields, countsToExtract, widget.category);
 
   const headers = {
     "Content-Type": "application/json",

--- a/src/widgets/suwayomi/proxy.js
+++ b/src/widgets/suwayomi/proxy.js
@@ -173,11 +173,11 @@ function extractCounts(responseJSON, fields) {
 }
 
 /**
- * @param {string[]} Fields
+ * @param {string[]|null} Fields
  * @returns {string[]}
  */
-function makeFields(Fields) {
-  let fields = Fields;
+function makeFields(Fields = []) {
+  let fields = Fields ?? [];
   if (fields.length === 0) {
     fields = ["download", "nondownload", "read", "unread"];
   }
@@ -193,7 +193,7 @@ function makeFields(Fields) {
  * @typedef {object} widget
  * @property {string} username
  * @property {string} password
- * @property {string[]} fields
+ * @property {string[]|null} fields
  * @property {string|number|undefined} category
  * @property {keyof typeof widgets} type
  */

--- a/src/widgets/suwayomi/proxy.js
+++ b/src/widgets/suwayomi/proxy.js
@@ -291,11 +291,9 @@ export default async function suwayomiProxyHandler(req, res) {
   };
 
   const returnData = widget.fields.map((name) => extractCounts(responseJSON, name, countsToExtract[name]));
-
+  // this would be used for setting the service.description if it was possible
   // if ("category" in responseJSON.data){
   //   returnData.name = responseJSON.data.category.name
-  //   // i would like to be able to do something like this but i guess not
-  //   // widget.service_name += `-${responseJSON.data.category.name}`;
   // }
 
   if (contentType) res.setHeader("Content-Type", contentType);

--- a/src/widgets/suwayomi/proxy.js
+++ b/src/widgets/suwayomi/proxy.js
@@ -166,10 +166,9 @@ function makeBody(fieldsSet, category = "all") {
     query: `
     query category($id: Int!) {
       category(id: $id) {
-        name
+        # name
         mangas {
           nodes {
-            title
             chapters {
               nodes {
                 isRead

--- a/src/widgets/suwayomi/proxy.js
+++ b/src/widgets/suwayomi/proxy.js
@@ -1,0 +1,303 @@
+import { httpProxy } from "utils/proxy/http";
+import { formatApiCall } from "utils/proxy/api-helpers";
+import getServiceWidget from "utils/config/service-helpers";
+import createLogger from "utils/logger";
+import widgets from "widgets/widgets";
+
+const proxyName = "suwayomiProxyHandler";
+const logger = createLogger(proxyName);
+
+/**
+ * @typedef totalCount
+ * @type {object}
+ * @property {string} totalCount - count
+ */
+
+/**
+ * @typedef ResponseJSON
+ * @type {{
+ *   data: {
+ *     download: totalCount,
+ *     nondownload: totalCount,
+ *     read: totalCount,
+ *     unread: totalCount,
+ *     downloadedRead: totalCount,
+ *     downloadedunread: totalCount,
+ *     nondownloadedread: totalCount,
+ *     nondownloadedunread: totalCount,
+ *   }
+ * }}
+ */
+
+/**
+ * @typedef ResponseJSONcategory
+ * @type {{
+ *   data: {
+ *     category: {
+ *       mangas: {
+ *         nodes: {
+ *           chapters: {
+ *             nodes: {
+ *               isRead: boolean,
+ *               isDownloaded: boolean
+ *             }
+ *           }
+ *         }
+ *       }
+ *     }
+ *   }
+ * }}
+ */
+
+/**
+ * Makes a GraphQL query body based on the provided fieldsSet and category.
+ *
+ * @param {Set} fieldsSet - Set of fields to include in the query.
+ * @param {string|number|undefined} [category="all"] - Category ID or "all" for general counts.
+ * @returns {string} - The JSON stringified query body.
+ */
+function makeBody(fieldsSet, category = "all") {
+  if (Number.isNaN(Number(category))) {
+    return JSON.stringify({
+      operationName: "Counts",
+      query: `
+      query Counts {
+        ${
+          fieldsSet.has("download")
+            ? `
+        download: chapters(
+          condition: {isDownloaded: true}
+          filter: {inLibrary: {equalTo: true}}
+        ) {
+          totalCount
+        }`
+            : ""
+        }
+        ${
+          fieldsSet.has("nondownload")
+            ? `
+        nondownload: chapters(
+          condition: {isDownloaded: true}
+          filter: {inLibrary: {equalTo: true}}
+        ) {
+          totalCount
+        }
+        `
+            : ""
+        }
+        ${
+          fieldsSet.has("read")
+            ? `
+        read: chapters(
+          condition: {isRead: true}
+          filter: {inLibrary: {equalTo: true}}
+        ) {
+          totalCount
+        }
+        `
+            : ""
+        }
+        ${
+          fieldsSet.has("unread")
+            ? `
+        unread: chapters(
+          condition: {isRead: false}
+          filter: {inLibrary: {equalTo: true}}
+        ) {
+          totalCount
+        }
+        `
+            : ""
+        }
+        ${
+          fieldsSet.has("downloadedread")
+            ? `
+        downloadedread: chapters(
+          condition: {isDownloaded: true, isRead: true}
+          filter: {inLibrary: {equalTo: true}}
+        ) {
+          totalCount
+        }
+        `
+            : ""
+        }
+        ${
+          fieldsSet.has("downloadedunread")
+            ? `
+        downloadedunread: chapters(
+          condition: {isDownloaded: true, isRead: false}
+          filter: {inLibrary: {equalTo: true}}
+        ) {
+          totalCount
+        }
+        `
+            : ""
+        }
+        ${
+          fieldsSet.has("nondownloadedread")
+            ? `
+        nondownloadedread: chapters(
+          condition: {isDownloaded: false, isRead: true}
+          filter: {inLibrary: {equalTo: true}}
+        ) {
+          totalCount
+        }
+        `
+            : ""
+        }
+        ${
+          fieldsSet.has("nondownloadedunread")
+            ? `
+        nondownloadedunread: chapters(
+          condition: {isDownloaded: false, isRead: false}
+          filter: {inLibrary: {equalTo: true}}
+        ) {
+          totalCount
+        }
+        `
+            : ""
+        }
+      }`,
+    });
+  }
+
+  return JSON.stringify({
+    operationName: "category",
+    query: `
+    query category($id: Int!) {
+      category(id: $id) {
+        name
+        mangas {
+          nodes {
+            title
+            chapters {
+              nodes {
+                isRead
+                isDownloaded
+              }
+            }
+          }
+        }
+      }
+    }`,
+    variables: {
+      id: Number(category),
+    },
+  });
+}
+
+/**
+ * Makes a Basic Authentication token encoded in base64.
+ *
+ * @param {string|undefined} username - The username for authentication.
+ * @param {string|undefined} password - The password for authentication.
+ * @returns {string|null} A Basic Authentication token, or null if username or password is missing.
+ */
+function makeAuth(username, password) {
+  if (username && password) {
+    // Combine username and password, and encode them in base64
+    return `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`;
+  }
+  // Return null if either username or password is not provided
+  return null;
+}
+
+/**
+ * Extracts count data from the response JSON and appends it to the returnData array.
+ *
+ * @param {ResponseJSON|ResponseJSONcategory} responseJSON - The JSON response containing the data.
+ * @param {keyof ResponseJSON["data"]} fieldName - The name of the field to extract.
+ * @param {Function} condition - A function to compare and determine the count condition.
+ * @returns {{ count: number, label: string }} - An object containing the count and label.
+ */
+function extractCounts(responseJSON, fieldName, condition) {
+  if (fieldName in responseJSON.data) {
+    return {
+      count: responseJSON.data[fieldName].totalCount,
+      label: `suwayomi.${fieldName}`,
+    };
+  }
+  return {
+    count: responseJSON.data.category.mangas.nodes.reduce(
+      (aa, cc) =>
+        cc.chapters.nodes.reduce((a, c) => {
+          if (condition(c)) {
+            return a + 1;
+          }
+          return a;
+        }, 0) + aa,
+      0,
+    ),
+    label: `suwayomi.${fieldName}`,
+  };
+}
+
+export default async function suwayomiProxyHandler(req, res) {
+  const { group, service, endpoint } = req.query;
+
+  if (!group || !service) {
+    logger.debug("Invalid or missing service '%s' or group '%s'", service, group);
+    return res.status(400).json({ error: "Invalid proxy service type" });
+  }
+  /** @type {{ fields: string[],category: string|number|undefined, type: keyof typeof widgets }} */
+  const widget = await getServiceWidget(group, service);
+  widget.fields.length = 4;
+  widget.fields = widget.fields.map((f) => f.toLowerCase());
+  /** @type {Set<string>} */
+  const fieldsSet = new Set(widget.fields);
+
+  if (!widget) {
+    logger.debug("Invalid or missing widget for service '%s' in group '%s'", service, group);
+    return res.status(400).json({ error: "Invalid proxy service type" });
+  }
+
+  const url = new URL(formatApiCall(widgets[widget.type].api, { endpoint, ...widget }));
+
+  const body = makeBody(fieldsSet, widget.category);
+
+  const [status, contentType, data] = await httpProxy(url, {
+    method: "POST",
+    body,
+    headers: {
+      "content-type": "application/json",
+      Authorization: makeAuth(widget.username, widget.password),
+    },
+  });
+
+  if (status === 401) {
+    logger.error("unauthorized username or password for Suwayomi is incorrect.");
+    return res
+      .status(401)
+      .send({ error: { message: "401: unauthorized username or password for Suwayomi is incorrect." } });
+  }
+
+  if (status !== 200) {
+    logger.error("Error getting data from Suwayomi: %d.  Data: %s", status, data);
+    return res.status(status).send({ error: { message: "Error getting data from Suwayomi", body, data } });
+  }
+
+  /** @type {ResponseJSON|ResponseJSONcategory} */
+  const responseJSON = JSON.parse(data);
+
+  const countsToExtract = {
+    download: (c) => c.isDownloaded,
+    nondownload: (c) => !c.isDownloaded,
+    read: (c) => c.isRead,
+    unread: (c) => !c.isRead,
+    downloadedread: (c) => c.isDownloaded && c.isRead,
+    downloadedunread: (c) => c.isDownloaded && !c.isRead,
+    nondownloadedread: (c) => !c.isDownloaded && c.isRead,
+    nondownloadedunread: (c) => !c.isDownloaded && !c.isRead,
+  };
+
+  const returnData = widget.fields.map((name) => extractCounts(responseJSON, name, countsToExtract[name]));
+
+  // if ("category" in responseJSON.data){
+  //   returnData.name = responseJSON.data.category.name
+  //   // i would like to be able to do something like this but i guess not
+  //   // widget.service_name += `-${responseJSON.data.category.name}`;
+  // }
+
+  if (contentType) res.setHeader("Content-Type", contentType);
+  return res.status(status).send(returnData);
+}

--- a/src/widgets/suwayomi/proxy.js
+++ b/src/widgets/suwayomi/proxy.js
@@ -97,10 +97,10 @@ const countsToExtract = {
 function makeBody(fields, category = "all") {
   if (Number.isNaN(Number(category))) {
     let query = "";
-    fields.forEach((f) => {
+    fields.forEach((field) => {
       query += `
-      ${f}: chapters(
-        condition: {${countsToExtract[f].gqlCondition}}
+      ${field}: chapters(
+        condition: {${countsToExtract[field].gqlCondition}}
         filter: {inLibrary: {equalTo: true}}
       ) {
         totalCount
@@ -179,7 +179,7 @@ function extractCounts(responseJSON, fields) {
 function makeFields(Fields = []) {
   let fields = Fields ?? [];
   if (fields.length === 0) {
-    fields = ["download", "nondownload", "read", "unread"];
+    fields = ["download", "nonDownload", "read", "unRead"];
   }
   if (fields.length > 4) {
     fields.length = 4;

--- a/src/widgets/suwayomi/proxy.js
+++ b/src/widgets/suwayomi/proxy.js
@@ -216,15 +216,13 @@ export default async function suwayomiProxyHandler(req, res) {
   });
 
   if (status === 401) {
-    logger.error("unauthorized username or password for Suwayomi is incorrect.");
-    return res
-      .status(401)
-      .send({ error: { message: "401: unauthorized username or password for Suwayomi is incorrect." } });
+    logger.error("Invalid or missing username or password for service '%s' in group '%s'", service, group);
+    return res.status(401).send({ error: { message: "401: unauthorized, username or password is incorrect." } });
   }
 
   if (status !== 200) {
     logger.error("Error getting data from Suwayomi: %d.  Data: %s", status, data);
-    return res.status(status).send({ error: { message: "Error getting data from Suwayomi", body, data } });
+    return res.status(status).send({ error: { message: "Error getting data. body: %s, data: %s", body, data } });
   }
 
   /** @type {ResponseJSON|ResponseJSONcategory} */

--- a/src/widgets/suwayomi/proxy.js
+++ b/src/widgets/suwayomi/proxy.js
@@ -172,6 +172,10 @@ function extractCounts(responseJSON, fields) {
   }));
 }
 
+/**
+ * @param {string[]} Fields
+ * @returns {string[]}
+ */
 function makeFields(Fields) {
   let fields = Fields;
   if (fields.length === 0) {
@@ -183,6 +187,19 @@ function makeFields(Fields) {
   return fields;
 }
 
+/**
+ * @typedef {object} widget
+ * @property {string} username
+ * @property {string} password
+ * @property {string[]} fields
+ * @property {string|number|undefined} category
+ * @property {keyof typeof widgets} type
+ */
+
+/**
+ * @param {widget} widget
+ * @returns {{ "Content-Type": string, Authorization?: string }}
+ */
 function makeHeaders(widget) {
   const headers = {
     "Content-Type": "application/json",
@@ -202,7 +219,7 @@ export default async function suwayomiProxyHandler(req, res) {
     return res.status(400).json({ error: "Invalid proxy service type" });
   }
 
-  /** @type {{ fields: string[],category: string|number|undefined, type: keyof typeof widgets }} */
+  /** @type {widget} */
   const widget = await getServiceWidget(group, service);
 
   if (!widget) {

--- a/src/widgets/suwayomi/proxy.js
+++ b/src/widgets/suwayomi/proxy.js
@@ -132,7 +132,6 @@ export default async function suwayomiProxyHandler(req, res) {
     widget.fields = ["download", "nondownload", "read", "unread"];
   } else if (widget.fields.length > 4) {
     widget.fields = widget.fields.slice(0, 4);
-    widget.fields = widget.fields.map((field) => field.toLowerCase());
   }
 
   const url = new URL(formatApiCall(widgets[widget.type].api, { endpoint, ...widget }));
@@ -169,9 +168,7 @@ export default async function suwayomiProxyHandler(req, res) {
     return res.status(status).send({ error: { message: "Error getting data. body: %s, data: %s", body, data } });
   }
 
-  const responseJSON = JSON.parse(data);
-
-  const returnData = extractCounts(responseJSON, widget.fields);
+  const returnData = extractCounts(JSON.parse(data), widget.fields);
 
   if (contentType) res.setHeader("Content-Type", contentType);
   return res.status(status).send(returnData);

--- a/src/widgets/suwayomi/proxy.js
+++ b/src/widgets/suwayomi/proxy.js
@@ -229,11 +229,11 @@ export default async function suwayomiProxyHandler(req, res) {
     return res.status(400).json({ error: "Invalid proxy service type" });
   }
 
-  widget.fields = makeFields(widget.fields);
+  const fields = makeFields(widget.fields);
 
   const url = new URL(formatApiCall(widgets[widget.type].api, { endpoint, ...widget }));
 
-  const body = makeBody(widget.fields, widget.category);
+  const body = makeBody(fields, widget.category);
 
   const headers = makeHeaders(widget);
 
@@ -262,7 +262,7 @@ export default async function suwayomiProxyHandler(req, res) {
   /** @type {ResponseJSON|ResponseJSONcategory} */
   const responseJSON = JSON.parse(data);
 
-  const returnData = extractCounts(responseJSON, widget.fields);
+  const returnData = extractCounts(responseJSON, fields);
 
   if (contentType) res.setHeader("Content-Type", contentType);
   return res.status(status).send(returnData);

--- a/src/widgets/suwayomi/proxy.js
+++ b/src/widgets/suwayomi/proxy.js
@@ -181,7 +181,9 @@ function makeFields(Fields) {
   if (fields.length === 0) {
     fields = ["download", "nondownload", "read", "unread"];
   }
-  fields.length = 4;
+  if (fields.length > 4) {
+    fields.length = 4;
+  }
   fields = fields.map((f) => f.toLowerCase());
 
   return fields;

--- a/src/widgets/suwayomi/proxy.js
+++ b/src/widgets/suwayomi/proxy.js
@@ -295,10 +295,6 @@ export default async function suwayomiProxyHandler(req, res) {
   };
 
   const returnData = widget.fields.map((name) => extractCounts(responseJSON, name, countsToExtract[name]));
-  // this would be used for setting the service.description if it was possible
-  // if ("category" in responseJSON.data){
-  //   returnData.name = responseJSON.data.category.name
-  // }
 
   if (contentType) res.setHeader("Content-Type", contentType);
   return res.status(status).send(returnData);

--- a/src/widgets/suwayomi/widget.js
+++ b/src/widgets/suwayomi/widget.js
@@ -1,4 +1,3 @@
-// import genericProxyHandler from "utils/proxy/handlers/generic";
 import suwayomiProxyHandler from "./proxy";
 
 const widget = {

--- a/src/widgets/suwayomi/widget.js
+++ b/src/widgets/suwayomi/widget.js
@@ -1,0 +1,9 @@
+// import genericProxyHandler from "utils/proxy/handlers/generic";
+import suwayomiProxyHandler from "./proxy";
+
+const widget = {
+  api: "{url}/api/graphql",
+  proxyHandler: suwayomiProxyHandler,
+};
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -105,6 +105,7 @@ import stash from "./stash/widget";
 import stocks from "./stocks/widget";
 import strelaysrv from "./strelaysrv/widget";
 import swagdashboard from "./swagdashboard/widget";
+import suwayomi from "./suwayomi/widget";
 import tailscale from "./tailscale/widget";
 import tandoor from "./tandoor/widget";
 import tautulli from "./tautulli/widget";
@@ -238,6 +239,7 @@ const widgets = {
   stocks,
   strelaysrv,
   swagdashboard,
+  suwayomi,
   tailscale,
   tandoor,
   tautulli,


### PR DESCRIPTION
## Proposed change
add a [Suwayomi](https://github.com/Suwayomi/Suwayomi-Server) Service widget
Closes #2972

![image](https://github.com/user-attachments/assets/f5782051-89bc-4d17-a2fa-f7076122d577)

I had to use a custom proxy because i needed GraphQL variables for variable category selection.
in the case of `category: all` the response from Suwayomi would look like.
```json
{
  "data": {
    "downloadCount": {
      "totalCount": 46428
    },
    "nonDownloadCount": {
      "totalCount": 46428
    },
    "readCount": {
      "totalCount": 31345
    },
    "UnreadCount": {
      "totalCount": 33770
    }
  }
}
```
~200B

in the case of `category: {number}`
```json
{
  "data": {
    "category": {
      "mangas": {
        "nodes": [
          {
            "chapters": {
              "nodes": [
                {
                  "isRead": false,
                  "isDownloaded": true
                },
                {
                  "isRead": true,
                  "isDownloaded": true
                },
                ...
              ]
            }
          },
          ...
        ]
      }
    }
  }
}
```
~6Kib (for a massive library)
you can't filter chapters by what category they are in or filter chapters from the mangas or category queries
so this was the best solution.

The response sent to the homepage client would be
```json
[
  {
    "count": 46428,
    "label": "suwayomi.download"
  },
  {
    "count": 46428,
    "label": "suwayomi.nondownload"
  },
  {
    "count": 31345,
    "label": "suwayomi.read"
  },
  {
    "count": 33770,
    "label": "suwayomi.unread"
  }
]
```
~400B
regardless of category value

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.


New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [x] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
