### PR TITLE
Fix: use session_key instead of Id in tautulli component to resolve unique key warning

### DIFF
--- a/src/widgets/tautulli/component.jsx
+++ b/src/widgets/tautulli/component.jsx
@@ -205,7 +205,7 @@ export default function Component({ service }) {
     <div className="flex flex-col pb-1 mx-1">
       {playing.map((session) => (
         <SessionEntry
-          key={session.Id}
+          key={session.session_key}
           session={session}
           enableUser={enableUser}
           showEpisodeNumber={showEpisodeNumber}


### PR DESCRIPTION
## Proposed change

The tautulli widget is using session.Id as the unique key, but for whatever reason the tautulli api gives a blank id for each session as shown in the snippet below:

```
session_key: "5"
id: ""
session_id: "x24yt3vaw2r4tququrjg"
container: "mkv"
bitrate: "957"
```

This caused a react warning: ```Warning: Each child in a list should have a unique "key" prop.``` Note that this warning only shows up if sessions are present.

Using session_key fixes this since each session gets a unique key. Session_id (not session.id) could also be used if preferred.

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
