### PR TITLE
Add section about UI 2FA accounts not working

### DIFF
--- a/docs/widgets/info/unifi_controller.md
+++ b/docs/widgets/info/unifi_controller.md
@@ -15,6 +15,20 @@ An optional 'site' parameter can be supplied, if it is not the widget will use t
 
 <img width="162" alt="unifi_infowidget" src="https://user-images.githubusercontent.com/4887959/197706832-f5a8706b-7282-4892-a666-b7d999752562.png">
 
+!!!
+
+    A UI account with 2FA will not work, to get around this:
+
+    1. Create a new user.
+    2. Check `Restrict to local access only`.
+    3. Set the username. eg. `remote_stats`.
+    4. Set a strong password.
+    5. Set permissions:
+        1. Uncheck `Use a pre-defined role`.
+        2. Set `Network` to `View Only`
+        3. Set all other options to `None`
+    6. Click `Add`
+
 ```yaml
 - unifi_console:
     url: https://unifi.host.or.ip:port

--- a/docs/widgets/services/unifi-controller.md
+++ b/docs/widgets/services/unifi-controller.md
@@ -17,6 +17,18 @@ Allowed fields: `["uptime", "wan", "lan", "lan_users", "lan_devices", "wlan", "w
 
     If you enter e.g. incorrect credentials and receive an "API Error", you may need to recreate the container to clear the cache.
 
+A UI account with 2FA will not work, to get around this:
+
+1. Create a new user.
+2. Check `Restrict to local access only`.
+3. Set the username. eg. `remote_stats`.
+4. Set a strong password.
+5. Set permissions:
+    1. Uncheck `Use a pre-defined role`.
+    2. Set `Network` to `View Only`
+    3. Set all other options to `None`
+6. Click `Add`
+
 ```yaml
 widget:
   type: unifi

--- a/docs/widgets/services/unifi-controller.md
+++ b/docs/widgets/services/unifi-controller.md
@@ -17,17 +17,19 @@ Allowed fields: `["uptime", "wan", "lan", "lan_users", "lan_devices", "wlan", "w
 
     If you enter e.g. incorrect credentials and receive an "API Error", you may need to recreate the container to clear the cache.
 
-A UI account with 2FA will not work, to get around this:
+!!!
 
-1. Create a new user.
-2. Check `Restrict to local access only`.
-3. Set the username. eg. `remote_stats`.
-4. Set a strong password.
-5. Set permissions:
-    1. Uncheck `Use a pre-defined role`.
-    2. Set `Network` to `View Only`
-    3. Set all other options to `None`
-6. Click `Add`
+    A UI account with 2FA will not work, to get around this:
+
+    1. Create a new user.
+    2. Check `Restrict to local access only`.
+    3. Set the username. eg. `remote_stats`.
+    4. Set a strong password.
+    5. Set permissions:
+        1. Uncheck `Use a pre-defined role`.
+        2. Set `Network` to `View Only`
+        3. Set all other options to `None`
+    6. Click `Add`
 
 ```yaml
 widget:


### PR DESCRIPTION
Add section about UI 2FA accounts not working

## Proposed change

I had to create a local account for the UI widget to work, Synology Disk Station had a similar section so I thought I'd add one.

Moreover the existing line about using a local account was easy to miss

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
