### PR TITLE
Highlight more so the fact that Unifi widget needs local account 

### DIFF
--- a/docs/widgets/info/unifi_controller.md
+++ b/docs/widgets/info/unifi_controller.md
@@ -5,7 +5,11 @@ description: Unifi Controller Information Widget Configuration
 
 _(Find the Unifi Controller service widget [here](../services/unifi-controller.md))_
 
-You can display general connectivity status from your Unifi (Network) Controller. When authenticating you will want to use a local account that has at least read privileges.
+You can display general connectivity status from your Unifi (Network) Controller. 
+
+!!!
+
+    When authenticating you will want to use a local account that has at least read privileges.
 
 An optional 'site' parameter can be supplied, if it is not the widget will use the default site for the controller.
 

--- a/docs/widgets/services/unifi-controller.md
+++ b/docs/widgets/services/unifi-controller.md
@@ -7,7 +7,11 @@ Learn more about [Unifi Controller](https://ui.com/).
 
 _(Find the Unifi Controller information widget [here](../info/unifi_controller.md))_
 
-You can display general connectivity status from your Unifi (Network) Controller. When authenticating you will want to use a local account that has at least read privileges.
+You can display general connectivity status from your Unifi (Network) Controller. 
+
+!!!
+
+    When authenticating you will want to use a local account that has at least read privileges.
 
 An optional 'site' parameter can be supplied, if it is not the widget will use the default site for the controller.
 


### PR DESCRIPTION
## Proposed change

As per pull request [4288](https://github.com/gethomepage/homepage/pull/4288), I have changed the docs just to make the need for a local account more obvious

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
