### PR TITLE
Favicons

### DIFF
--- a/docs/configs/favicons.md
+++ b/docs/configs/favicons.md
@@ -1,0 +1,55 @@
+---
+title: Favicons
+description: Favicon Configuration
+---
+
+Favicons are configured in the `favicons.yaml` file. They function much the same as [Bookmarks](bookmarks.md), in how groups and lists work. They're just simple icons with no extra features other than being a link out.
+
+The design of homepage expects `abbr` to be 2 letters, but is not otherwise forced. The `abbr` shows if the icon is not specified.
+
+You should use an icon for favicons similar to the [options for service icons](services.md#icons). If both icon and abbreviation are supplied, the icon takes precedence.
+
+
+```yaml
+---
+- Developer:
+    - Github:
+        - abbr: GH
+          name: Github
+          icon: github.png
+          href: https://github.com/
+    - Gitlab:
+        - abbr: GL
+          name: Gitlab
+          icon: gitlab.png
+          href: https://gitlab.com
+
+- Media:
+    - Jellyfin:
+        - abbr: JE
+          name: jellyfin
+          icon: jellyfin.png
+          href: https://jellyfin.org
+    - Emby:
+        - abbr: EM
+          name: emby
+          icon: emby.png
+          href: https://emby.media
+    - Youtube:
+        - abbr: YT
+          name: youtube
+          icon: youtube.png
+          href: https://youtube.com/
+    - Spotify:
+        - abbr: SP
+          name: spotify
+          icon: spotify.png
+          href: https://spotify.com/
+
+```
+
+which renders to (depending on your theme):
+
+<img width="1000" alt="Favicons" src="">
+
+The default [favicons.yaml](https://github.com/gethomepage/homepage/blob/main/src/skeleton/favicons.yaml) is a working example.

--- a/src/components/favicons/group.jsx
+++ b/src/components/favicons/group.jsx
@@ -1,0 +1,77 @@
+import { useRef, useEffect } from "react";
+import classNames from "classnames";
+import { Disclosure, Transition } from "@headlessui/react";
+import { MdKeyboardArrowDown } from "react-icons/md";
+
+import ErrorBoundary from "components/errorboundry";
+import List from "components/favicons/list";
+import ResolvedIcon from "components/resolvedicon";
+
+export default function FaviconsGroup({ favicons, layout, disableCollapse, groupsInitiallyCollapsed }) {
+  const panel = useRef();
+  console.log('+++++')
+  console.log(favicons)
+  useEffect(() => {
+    if (layout?.initiallyCollapsed ?? groupsInitiallyCollapsed) panel.current.style.height = `0`;
+  }, [layout, groupsInitiallyCollapsed]);
+
+  return (
+    <div
+      key={favicons.name}
+      className={classNames(
+        "favicon-group",
+        layout?.style === "row" ? "basis-full" : "basis-full md:basis-1/4 lg:basis-1/5 xl:basis-1/6",
+        layout?.header === false ? "flex-1 px-1 -my-1 overflow-hidden" : "flex-1 p-1 overflow-hidden",
+      )}
+    >
+      <Disclosure defaultOpen={!(layout?.initiallyCollapsed ?? groupsInitiallyCollapsed) ?? true}>
+        {({ open }) => (
+          <>
+            {layout?.header !== false && (
+              <Disclosure.Button disabled={disableCollapse} className="flex w-full select-none items-center group">
+                {layout?.icon && (
+                  <div className="flex-shrink-0 mr-2 w-7 h-7 favicon-group-icon">
+                    <ResolvedIcon icon={layout.icon} />
+                  </div>
+                )}
+                <h2 className="text-theme-800 dark:text-theme-300 text-xl font-medium favicon-group-name">
+                  {favicons.name}
+                </h2>
+                <MdKeyboardArrowDown
+                  className={classNames(
+                    disableCollapse ? "hidden" : "",
+                    "transition-all opacity-0 group-hover:opacity-100 ml-auto text-theme-800 dark:text-theme-300 text-xl",
+                    open ? "" : "rotate-180",
+                  )}
+                />
+              </Disclosure.Button>
+            )}
+            <Transition
+              // Otherwise the transition group does display: none and cancels animation
+              className="!block"
+              unmount={false}
+              beforeLeave={() => {
+                panel.current.style.height = `${panel.current.scrollHeight}px`;
+                setTimeout(() => {
+                  panel.current.style.height = `0`;
+                }, 1);
+              }}
+              beforeEnter={() => {
+                panel.current.style.height = `0px`;
+                setTimeout(() => {
+                  panel.current.style.height = `${panel.current.scrollHeight}px`;
+                }, 1);
+              }}
+            >
+              <Disclosure.Panel className="transition-all overflow-hidden duration-300 ease-out" ref={panel} static>
+                <ErrorBoundary>
+                  <List favicons={favicons.bookmarks} layout={layout} />
+                </ErrorBoundary>
+              </Disclosure.Panel>
+            </Transition>
+          </>
+        )}
+      </Disclosure>
+    </div>
+  );
+}

--- a/src/components/favicons/item.jsx
+++ b/src/components/favicons/item.jsx
@@ -1,0 +1,33 @@
+import { useContext } from "react";
+import classNames from "classnames";
+
+import { SettingsContext } from "utils/contexts/settings";
+import ResolvedIcon from "components/resolvedicon";
+
+export default function Item({ favicon }) {
+  const description = favicon.description ?? new URL(favicon.href).hostname;
+  const { settings } = useContext(SettingsContext);
+
+  return (
+    <li key={favicon.name} id={favicon.id} className="favicon" data-name={favicon.name}>
+      <a
+        href={favicon.href}
+        title={favicon.name}
+        rel="noreferrer"
+        target={favicon.target ?? settings.target ?? "_blank"}
+        className={classNames(
+          settings.cardBlur !== undefined && `backdrop-blur${settings.cardBlur.length ? "-" : ""}${settings.cardBlur}`,
+          "",
+        )}
+      >
+        <div className="">
+            {favicon.icon && (
+                <ResolvedIcon icon={favicon.icon} alt={favicon.abbr} />
+            )}
+            {!favicon.icon && favicon.abbr}
+
+        </div>
+      </a>
+    </li>
+  );
+}

--- a/src/components/favicons/list.jsx
+++ b/src/components/favicons/list.jsx
@@ -1,0 +1,17 @@
+import classNames from "classnames";
+
+import { columnMap } from "../../utils/layout/columns";
+
+import Item from "components/favicons/item";
+
+export default function List({ favicons, layout }) {
+  return (
+    <ul
+      className="favicon-list"
+    >
+      {favicons.map((favicon) => (
+        <Item key={`${favicon.name}-${favicon.href}`} favicon={favicon} />
+      ))}
+    </ul>
+  );
+}

--- a/src/pages/api/favicons.js
+++ b/src/pages/api/favicons.js
@@ -1,0 +1,5 @@
+import { faviconsResponse } from "utils/config/api-response";
+
+export default async function handler(req, res) {
+  res.send(await faviconsResponse());
+}

--- a/src/pages/api/hash.js
+++ b/src/pages/api/hash.js
@@ -9,6 +9,7 @@ const configs = [
   "settings.yaml",
   "services.yaml",
   "bookmarks.yaml",
+  "favicons.yaml",
   "widgets.yaml",
   "custom.css",
   "custom.js",

--- a/src/pages/api/validate.js
+++ b/src/pages/api/validate.js
@@ -1,6 +1,6 @@
 import checkAndCopyConfig from "utils/config/config";
 
-const configs = ["docker.yaml", "settings.yaml", "services.yaml", "bookmarks.yaml"];
+const configs = ["docker.yaml", "favicons.yaml", "settings.yaml", "services.yaml", "bookmarks.yaml"];
 
 export default async function handler(req, res) {
   const errors = configs.map((config) => checkAndCopyConfig(config)).filter((status) => status !== true);

--- a/src/skeleton/favicons.yaml
+++ b/src/skeleton/favicons.yaml
@@ -1,0 +1,47 @@
+---
+# For configuration options and examples, please see:
+# https://gethomepage.dev/configs/favicons
+- Developer:
+  - Github:
+    - abbr: GH
+      name: Github
+      icon: github.png
+      href: https://github.com
+  - Gitlab:
+    - abbr: GL
+      name: Gitlab
+      icon: gitlab.png
+      href: https://gitlab.com
+
+- Media:
+  - Jellyfin:
+    - abbr: JE
+      name: jellyfin
+      icon: jellyfin.png
+      href: https://jellyfin.org
+  - Emby:
+    - abbr: EM
+      name: emby
+      icon: emby.png
+      href: https://emby.media
+  - Youtube:
+    - abbr: YT
+      name: youtube
+      icon: youtube.png
+      href: https://youtube.com
+  - Spotify:
+    - abbr: SP
+      name: spotify
+      icon: spotify.png
+      href: https://spotify.com
+- Social:
+  - Facebook:
+    - abbr: FB
+      name: facebook
+      icon: facebook.png
+      href: https://facebook.com
+  - Reddit:
+    - abbr: RE
+      name: reddit
+      icon: reddit.png
+      href: https://reddit.com

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -25,6 +25,12 @@ body {
   padding: 0;
 }
 
+.favicon {
+  display: inline-block;
+  margin-right: 0.5em;
+}
+
+
 .light {
   --bg-color: var(--color-50);
   --scrollbar-thumb: rgb(var(--color-300));


### PR DESCRIPTION
## Proposed change
The bookmarks component uses a lot of horizontal space and I was looking for a mechanism to add a row of icons each linking to a corresponding URL. I have copied much of the existing bookmarks code to create a favicons component controlled by additions to a `favicons.yaml` config file. The example screenshot below shows some favicons under the traditional bookmarks:
![favicons](https://github.com/user-attachments/assets/408e557f-03b8-460a-8e4a-25cba829b68b)

Discussion [here](https://github.com/gethomepage/homepage/discussions/4294)

Please feel free to suggest changes.

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
