### PR TITLE
Feature: Add ArgoCD widget

### DIFF
--- a/docs/widgets/services/argocd.md
+++ b/docs/widgets/services/argocd.md
@@ -5,7 +5,7 @@ description: ArgoCD Widget Configuration
 
 Learn more about [ArgoCD](https://argo-cd.readthedocs.io/en/stable/).
 
-Allowed fields: `["apps", "synced", "outOfSync", "healthy", "progressing", "degraded", "suspended", "missing"]`
+Allowed fields (limited to a max of 4): `["apps", "synced", "outOfSync", "healthy", "progressing", "degraded", "suspended", "missing"]`
 
 ```yaml
 widget:

--- a/docs/widgets/services/argocd.md
+++ b/docs/widgets/services/argocd.md
@@ -1,0 +1,33 @@
+---
+title: ArgoCD
+description: ArgoCD Widget Configuration
+---
+
+Learn more about [ArgoCD](https://argo-cd.readthedocs.io/en/stable/).
+
+Allowed fields: `["apps", "synced", "outOfSync", "healthy", "progressing", "degraded", "suspended", "missing"]`
+
+```yaml
+widget:
+  type: argocd
+  url: http://argocd.host.or.ip:port
+  key: argocdapikey
+```
+
+You can generate an API key either by creating a bearer token for an existing account, see [Authorization](https://argo-cd.readthedocs.io/en/latest/developer-guide/api-docs/#authorization) (not recommended) or create a new local user account with limited privileges and generate an authentication token for this account. To do this the steps are:
+
+- [Create a new local user](https://argo-cd.readthedocs.io/en/stable/operator-manual/user-management/#create-new-user) and give it the `apiKey` capability
+- Setup [RBAC configuration](https://argo-cd.readthedocs.io/en/stable/operator-manual/rbac/#rbac-configuration) for your the user and give it readonly access to your ArgoCD resources, e.g. by giving it the `role:readonly` role.
+- In your ArgoCD project under _Settings / Accounts_ open the newly created account and in the _Tokens_ section click on _Generate New_ to generate an access token, optionally specifying an expiry date.
+
+If you installed ArgoCD via the official Helm chart, the account creation and rbac config can be achived by overriding these helm values:
+
+```yaml
+configs:
+  cm:
+    accounts.readonly: apiKey
+  rbac:
+    policy.csv: "g, readonly, role:readonly"
+```
+
+This creates a new account called `readonly` and attaches the `role:readonly` role to it.

--- a/docs/widgets/services/index.md
+++ b/docs/widgets/services/index.md
@@ -8,7 +8,7 @@ search:
 You can also find a list of all available service widgets in the sidebar navigation.
 
 - [Adguard Home](adguard-home.md)
-- [ArgoCD](atsumeru.md)
+- [ArgoCD](argocd.md)
 - [Atsumeru](atsumeru.md)
 - [Audiobookshelf](audiobookshelf.md)
 - [Authentik](authentik.md)

--- a/docs/widgets/services/index.md
+++ b/docs/widgets/services/index.md
@@ -8,6 +8,7 @@ search:
 You can also find a list of all available service widgets in the sidebar navigation.
 
 - [Adguard Home](adguard-home.md)
+- [ArgoCD](atsumeru.md)
 - [Atsumeru](atsumeru.md)
 - [Audiobookshelf](audiobookshelf.md)
 - [Authentik](authentik.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,7 @@ nav:
       - "Service Widgets":
           - widgets/services/index.md
           - widgets/services/adguard-home.md
+          - widgets/services/argocd.md
           - widgets/services/atsumeru.md
           - widgets/services/audiobookshelf.md
           - widgets/services/authentik.md

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -992,7 +992,7 @@
     "argocd": {
         "apps": "Apps",
         "synced": "Synced",
-        "outOfSync": "OutOfSync",
+        "outOfSync": "Out Of Sync",
         "healthy": "Healthy",
         "degraded": "Degraded",
         "progressing": "Progressing",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -988,5 +988,15 @@
       "memory": "MEM",
       "disk": "Disk",
       "network": "NET"
+    },
+    "argocd": {
+        "apps": "Apps",
+        "synced": "Synced",
+        "outOfSync": "OutOfSync",
+        "healthy": "Healthy",
+        "degraded": "Degraded",
+        "progressing": "Progressing",
+        "missing": "Missing",
+        "suspended": "Suspended"
     }
 }

--- a/src/utils/proxy/handlers/credentialed.js
+++ b/src/utils/proxy/handlers/credentialed.js
@@ -36,6 +36,7 @@ export default async function credentialedProxyHandler(req, res, map) {
         headers["X-gotify-Key"] = `${widget.key}`;
       } else if (
         [
+          "argocd",
           "authentik",
           "cloudflared",
           "ghostfolio",

--- a/src/widgets/argocd/component.jsx
+++ b/src/widgets/argocd/component.jsx
@@ -10,18 +10,20 @@ export default function Component({ service }) {
   }
 
   const MAX_ALLOWED_FIELDS = 4;
-  if (widget.fields?.length > MAX_ALLOWED_FIELDS) {
+  if (widget.fields.length > MAX_ALLOWED_FIELDS) {
     widget.fields = widget.fields.slice(0, MAX_ALLOWED_FIELDS);
   }
 
   const { data: appsData, error: appsError } = useWidgetAPI(widget, "applications");
 
-  const appCounts = widget.fields?.map((status) => {
+  const appCounts = widget.fields.map((status) => {
     if (status === "apps") {
       return { status, count: appsData?.items?.length };
     }
     const count = appsData?.items?.filter(
-      (item) => item.status?.sync?.status.toLowerCase() === status.toLowerCase() || item.status?.health?.status.toLowerCase() === status.toLowerCase(),
+      (item) =>
+        item.status?.sync?.status.toLowerCase() === status.toLowerCase() ||
+        item.status?.health?.status.toLowerCase() === status.toLowerCase(),
     ).length;
     return { status, count };
   });
@@ -33,7 +35,7 @@ export default function Component({ service }) {
   if (!appsData) {
     return (
       <Container service={service}>
-        {appCounts?.map((a) => (
+        {appCounts.map((a) => (
           <Block label={`argocd.${a.status}`} key={a.status} />
         ))}
       </Container>
@@ -42,7 +44,7 @@ export default function Component({ service }) {
 
   return (
     <Container service={service}>
-      {appCounts?.map((a) => (
+      {appCounts.map((a) => (
         <Block label={`argocd.${a.status}`} key={a.status} value={a.count} />
       ))}
     </Container>

--- a/src/widgets/argocd/component.jsx
+++ b/src/widgets/argocd/component.jsx
@@ -1,0 +1,44 @@
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { widget } = service;
+
+  const { data: appsData, error: appsError } = useWidgetAPI(widget, "applications");
+
+  const appCounts = ["apps", "synced", "outOfSync", "healthy", "progressing", "degraded", "suspended", "missing"].map(
+    (status) => {
+      if (status === "apps") {
+        return { status, count: appsData?.items?.length };
+      }
+      const apiStatus = status.charAt(0).toUpperCase() + status.slice(1);
+      const count = appsData?.items?.filter(
+        (item) => item.status?.sync?.status === apiStatus || item.status?.health?.status === apiStatus,
+      ).length;
+      return { status, count };
+    },
+  );
+
+  if (appsError) {
+    return <Container service={service} error={appsError} />;
+  }
+
+  if (!appsData) {
+    return (
+      <Container service={service}>
+        {appCounts.map((a) => (
+          <Block label={`argocd.${a.status}`} key={a.status} />
+        ))}
+      </Container>
+    );
+  }
+
+  return (
+    <Container service={service}>
+      {appCounts.map((a) => (
+        <Block label={`argocd.${a.status}`} key={a.status} value={a.count} />
+      ))}
+    </Container>
+  );
+}

--- a/src/widgets/argocd/component.jsx
+++ b/src/widgets/argocd/component.jsx
@@ -20,9 +20,8 @@ export default function Component({ service }) {
     if (status === "apps") {
       return { status, count: appsData?.items?.length };
     }
-    const apiStatus = status.charAt(0).toUpperCase() + status.slice(1);
     const count = appsData?.items?.filter(
-      (item) => item.status?.sync?.status === apiStatus || item.status?.health?.status === apiStatus,
+      (item) => item.status?.sync?.status.toLowerCase() === status.toLowerCase() || item.status?.health?.status.toLowerCase() === status.toLowerCase(),
     ).length;
     return { status, count };
   });

--- a/src/widgets/argocd/component.jsx
+++ b/src/widgets/argocd/component.jsx
@@ -5,20 +5,28 @@ import useWidgetAPI from "utils/proxy/use-widget-api";
 export default function Component({ service }) {
   const { widget } = service;
 
+  // Limits fields to available statuses
+  const validFields = ["apps", "synced", "outOfSync", "healthy", "progressing", "degraded", "suspended", "missing"];
+  widget.fields = widget.fields.filter((field) => validFields.includes(field));
+
+  // Limits max number of displayed fields
+  const MAX_ALLOWED_FIELDS = 4;
+  if (widget.fields != null && widget.fields.length > MAX_ALLOWED_FIELDS) {
+    widget.fields = widget.fields.slice(0, MAX_ALLOWED_FIELDS);
+  }
+
   const { data: appsData, error: appsError } = useWidgetAPI(widget, "applications");
 
-  const appCounts = ["apps", "synced", "outOfSync", "healthy", "progressing", "degraded", "suspended", "missing"].map(
-    (status) => {
-      if (status === "apps") {
-        return { status, count: appsData?.items?.length };
-      }
-      const apiStatus = status.charAt(0).toUpperCase() + status.slice(1);
-      const count = appsData?.items?.filter(
-        (item) => item.status?.sync?.status === apiStatus || item.status?.health?.status === apiStatus,
-      ).length;
-      return { status, count };
-    },
-  );
+  const appCounts = widget.fields.map((status) => {
+    if (status === "apps") {
+      return { status, count: appsData?.items?.length };
+    }
+    const apiStatus = status.charAt(0).toUpperCase() + status.slice(1);
+    const count = appsData?.items?.filter(
+      (item) => item.status?.sync?.status === apiStatus || item.status?.health?.status === apiStatus,
+    ).length;
+    return { status, count };
+  });
 
   if (appsError) {
     return <Container service={service} error={appsError} />;

--- a/src/widgets/argocd/component.jsx
+++ b/src/widgets/argocd/component.jsx
@@ -5,11 +5,10 @@ import useWidgetAPI from "utils/proxy/use-widget-api";
 export default function Component({ service }) {
   const { widget } = service;
 
-  // Limits fields to available statuses
-  const validFields = ["apps", "synced", "outOfSync", "healthy", "progressing", "degraded", "suspended", "missing"];
-  widget.fields = widget.fields?.filter((field) => validFields.includes(field));
+  if (!widget.fields) {
+    widget.fields = ["apps", "synced", "outOfSync", "healthy"];
+  }
 
-  // Limits max number of displayed fields
   const MAX_ALLOWED_FIELDS = 4;
   if (widget.fields?.length > MAX_ALLOWED_FIELDS) {
     widget.fields = widget.fields.slice(0, MAX_ALLOWED_FIELDS);

--- a/src/widgets/argocd/component.jsx
+++ b/src/widgets/argocd/component.jsx
@@ -7,17 +7,17 @@ export default function Component({ service }) {
 
   // Limits fields to available statuses
   const validFields = ["apps", "synced", "outOfSync", "healthy", "progressing", "degraded", "suspended", "missing"];
-  widget.fields = widget.fields.filter((field) => validFields.includes(field));
+  widget.fields = widget.fields?.filter((field) => validFields.includes(field));
 
   // Limits max number of displayed fields
   const MAX_ALLOWED_FIELDS = 4;
-  if (widget.fields != null && widget.fields.length > MAX_ALLOWED_FIELDS) {
+  if (widget.fields?.length > MAX_ALLOWED_FIELDS) {
     widget.fields = widget.fields.slice(0, MAX_ALLOWED_FIELDS);
   }
 
   const { data: appsData, error: appsError } = useWidgetAPI(widget, "applications");
 
-  const appCounts = widget.fields.map((status) => {
+  const appCounts = widget.fields?.map((status) => {
     if (status === "apps") {
       return { status, count: appsData?.items?.length };
     }
@@ -35,7 +35,7 @@ export default function Component({ service }) {
   if (!appsData) {
     return (
       <Container service={service}>
-        {appCounts.map((a) => (
+        {appCounts?.map((a) => (
           <Block label={`argocd.${a.status}`} key={a.status} />
         ))}
       </Container>
@@ -44,7 +44,7 @@ export default function Component({ service }) {
 
   return (
     <Container service={service}>
-      {appCounts.map((a) => (
+      {appCounts?.map((a) => (
         <Block label={`argocd.${a.status}`} key={a.status} value={a.count} />
       ))}
     </Container>

--- a/src/widgets/argocd/widget.js
+++ b/src/widgets/argocd/widget.js
@@ -1,0 +1,14 @@
+import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
+
+const widget = {
+  api: "{url}/api/v1/{endpoint}",
+  proxyHandler: credentialedProxyHandler,
+
+  mappings: {
+    applications: {
+      endpoint: "applications",
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -2,6 +2,7 @@ import dynamic from "next/dynamic";
 
 const components = {
   adguard: dynamic(() => import("./adguard/component")),
+  argocd: dynamic(() => import("./argocd/component")),
   atsumeru: dynamic(() => import("./atsumeru/component")),
   audiobookshelf: dynamic(() => import("./audiobookshelf/component")),
   authentik: dynamic(() => import("./authentik/component")),

--- a/src/widgets/prometheusmetric/component.jsx
+++ b/src/widgets/prometheusmetric/component.jsx
@@ -5,6 +5,7 @@ import Block from "components/services/widget/block";
 import useWidgetAPI from "utils/proxy/use-widget-api";
 
 function formatValue(t, metric, rawValue) {
+  if (!metric?.format) return rawValue;
   if (!rawValue) return "-";
 
   let value = rawValue;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -1,4 +1,5 @@
 import adguard from "./adguard/widget";
+import argocd from "./argocd/widget";
 import atsumeru from "./atsumeru/widget";
 import audiobookshelf from "./audiobookshelf/widget";
 import authentik from "./authentik/widget";
@@ -130,6 +131,7 @@ import zabbix from "./zabbix/widget";
 
 const widgets = {
   adguard,
+  argocd,
   atsumeru,
   audiobookshelf,
   authentik,


### PR DESCRIPTION
## Proposed change

This adds a widget for [ArgoCD](https://argo-cd.readthedocs.io/en/latest/). It can list the count of apps present in an ArgoCD instance by app status, e.g. `synced` or `healthy`.

<img width="411" alt="image" src="https://github.com/user-attachments/assets/d86661ea-7c08-4bf9-adce-5f9c6cb36dcd">


Closes #2644

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [x] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
