### PR TITLE
Feature: Garage Widget

### DIFF
--- a/docs/widgets/services/garage.md
+++ b/docs/widgets/services/garage.md
@@ -1,0 +1,17 @@
+---
+title: Garage
+description: Garage Widget Configuration
+---
+
+Learn more about [Garage](https://git.deuxfleurs.fr/Deuxfleurs/garage).
+
+Use the admin token key. Information about the token can be found in the [Garage configuration file documentation](https://garagehq.deuxfleurs.fr/documentation/reference-manual/configuration/).
+
+Allowed fields: `["status", "knownNodes", "connectedNodes", "storageNodes", "storageNodesOk", "partitions", "partitionsQuorum", "partitionsAllOk"]`.
+
+```yaml
+widget:
+  type: garage
+  url: http://garage.host.or.ip:port
+  key: token
+```

--- a/docs/widgets/services/index.md
+++ b/docs/widgets/services/index.md
@@ -38,6 +38,7 @@ You can also find a list of all available service widgets in the sidebar navigat
 - [Frigate](frigate.md)
 - [Fritz!Box](fritzbox.md)
 - [GameDig](gamedig.md)
+- [Garage](garage.md)
 - [Gatus](gatus.md)
 - [Ghostfolio](ghostfolio.md)
 - [Gitea](gitea.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,7 @@ nav:
           - widgets/services/frigate.md
           - widgets/services/fritzbox.md
           - widgets/services/gamedig.md
+          - widgets/services/garage.md
           - widgets/services/gatus.md
           - widgets/services/ghostfolio.md
           - widgets/services/gitea.md

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -998,5 +998,18 @@
         "progressing": "Progressing",
         "missing": "Missing",
         "suspended": "Suspended"
+    },
+    "garage": {
+        "status": "Status",
+        "healthy": "Healthy",
+        "degraded": "Degraded",
+        "unavailable": "Unavailable",
+        "knownNodes": "Known nodes",
+        "connectedNodes": "Connected nodes",
+        "storageNodes": "Storage nodes",
+        "storageNodesOk": "Storage OK",
+        "partitions": "Total partitions",
+        "partitionsQuorum": "Quorum reached",
+        "partitionsAllOk": "Partitions OK"
     }
 }

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -953,5 +953,18 @@
         "reminders": "Reminders",
         "nextReminder": "Next Reminder",
         "none": "None"
+    },
+    "garage": {
+        "status": "Statut",
+        "healthy": "En bonne santé",
+        "degraded": "Dégradé",
+        "unavailable": "Indisponible",
+        "knownNodes": "Nœuds connus",
+        "connectedNodes": "Nœuds connectés",
+        "storageNodes": "Nœuds de stockage",
+        "storageNodesOk": "Stockage OK",
+        "partitions": "Partitions totales",
+        "partitionsQuorum": "Quorum atteint",
+        "partitionsAllOk": "Partitions OK"
     }
 }

--- a/src/utils/proxy/handlers/credentialed.js
+++ b/src/utils/proxy/handlers/credentialed.js
@@ -48,6 +48,7 @@ export default async function credentialedProxyHandler(req, res, map) {
           "tandoor",
           "pterodactyl",
           "vikunja",
+          "garage",
         ].includes(widget.type)
       ) {
         headers.Authorization = `Bearer ${widget.key}`;

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -35,6 +35,7 @@ const components = {
   frigate: dynamic(() => import("./frigate/component")),
   fritzbox: dynamic(() => import("./fritzbox/component")),
   gamedig: dynamic(() => import("./gamedig/component")),
+  garage: dynamic(() => import("./garage/component")),
   gatus: dynamic(() => import("./gatus/component")),
   ghostfolio: dynamic(() => import("./ghostfolio/component")),
   gitea: dynamic(() => import("./gitea/component")),

--- a/src/widgets/garage/component.jsx
+++ b/src/widgets/garage/component.jsx
@@ -1,0 +1,45 @@
+import { useTranslation } from "next-i18next";
+
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+
+  const { widget } = service;
+
+  const { data, error } = useWidgetAPI(widget, "health");
+
+  if (error) {
+    return <Container service={service} error={error} />;
+  }
+
+  if (!data) {
+    return (
+      <Container service={service}>
+        <Block label="garage.status" />
+        <Block label="garage.knownNodes" />
+        <Block label="garage.connectedNodes" />
+        <Block label="garage.storageNodes" />
+        <Block label="garage.storageNodesOk" />
+        <Block label="garage.partitions" />
+        <Block label="garage.partitionsQuorum" />
+        <Block label="garage.partitionsAllOk" />
+      </Container>
+    );
+  }
+
+  return (
+    <Container service={service}>
+      <Block label="garage.status" value={t(`garage.${data.status}`)} />
+      <Block label="garage.knownNodes" value={t("common.number", { value: data.knownNodes })} />
+      <Block label="garage.connectedNodes" value={t("common.number", { value: data.connectedNodes })} />
+      <Block label="garage.storageNodes" value={t("common.number", { value: data.storageNodes })} />
+      <Block label="garage.storageNodesOk" value={t("common.number", { value: data.storageNodesOk })} />
+      <Block label="garage.partitions" value={t("common.number", { value: data.partitions })} />
+      <Block label="garage.partitionsQuorum" value={t("common.number", { value: data.partitionsQuorum })} />
+      <Block label="garage.partitionsAllOk" value={t("common.number", { value: data.partitionsAllOk })} />
+    </Container>
+  );
+}

--- a/src/widgets/garage/widget.js
+++ b/src/widgets/garage/widget.js
@@ -1,0 +1,14 @@
+import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
+
+const widget = {
+  api: "{url}/v1/{endpoint}",
+  proxyHandler: credentialedProxyHandler,
+
+  mappings: {
+    health: {
+      endpoint: "health",
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -29,6 +29,7 @@ import freshrss from "./freshrss/widget";
 import frigate from "./frigate/widget";
 import fritzbox from "./fritzbox/widget";
 import gamedig from "./gamedig/widget";
+import garage from "./garage/widget";
 import gatus from "./gatus/widget";
 import ghostfolio from "./ghostfolio/widget";
 import gitea from "./gitea/widget";
@@ -160,6 +161,7 @@ const widgets = {
   frigate,
   fritzbox,
   gamedig,
+  garage,
   gatus,
   ghostfolio,
   gitea,


### PR DESCRIPTION
## Proposed change

Add a Garage widget to display the health and status statistics of the nodes as well as the system.

Widget:

![image](https://github.com/user-attachments/assets/c208f822-8ce5-41a9-ad1b-25720b11301c)

Garage:
`curl --header "Authorization: Bearer kz8XSmZ8fgLDge5852pws/kvTTghzBQ95/ck1GuAbXc=" https://garage/v1/health`

```
{
  "status": "healthy",
  "knownNodes": 2,
  "connectedNodes": 2,
  "storageNodes": 2,
  "storageNodesOk": 2,
  "partitions": 256,
  "partitionsQuorum": 256,
  "partitionsAllOk": 256
}
```

Closes #4314 

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [x] New service widget

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
