### PR TITLE
Feature: gitlab service widget

### DIFF
--- a/docs/widgets/services/gitlab.md
+++ b/docs/widgets/services/gitlab.md
@@ -7,11 +7,14 @@ Learn more about [Gitlab](https://gitlab.com).
 
 API requires a personal access token with either `read_api` or `api` permission. See the [gitlab documentation](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#create-a-personal-access-token) for details on generating one.
 
-Allowed fields: `["events", "openIssues", "openMergeRequests"]`.
+Your Gitlab user ID can be found on [your profile page](https://support.circleci.com/hc/en-us/articles/20761157174043-How-to-find-your-GitLab-User-ID).
+
+Allowed fields: `["events", "issues", "merges", "projects"]`.
 
 ```yaml
 widget:
   type: gitlab
   url: http://gitlab.host.or.ip:port
   key: personal-access-token
+  user_id: 123456
 ```

--- a/docs/widgets/services/gitlab.md
+++ b/docs/widgets/services/gitlab.md
@@ -7,14 +7,11 @@ Learn more about [Gitlab](https://gitlab.com).
 
 API requires a personal access token with either `read_api` or `api` permission. See the [gitlab documentation](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#create-a-personal-access-token) for details on generating one.
 
-Allowed fields: `["events", "issues", "openIssues", "closedIssues", "mergeRequests", "openMergeRequests",
-"closedMergeRequests"]`.
+Allowed fields: `["events", "openIssues", "openMergeRequests"]`.
 
 ```yaml
 widget:
   type: gitlab
   url: http://gitlab.host.or.ip:port
   key: personal-access-token
-  issueState: all # supports "opened", "closed" and defaults to "all"
-  mergeRequestState: all # supports "opened", "closed", "locked" and defaults to "all"
 ```

--- a/docs/widgets/services/gitlab.md
+++ b/docs/widgets/services/gitlab.md
@@ -1,0 +1,20 @@
+---
+title: Gitlab
+description: Gitlab Widget Configuration
+---
+
+Learn more about [Gitlab](https://gitlab.com).
+
+API requires a personal access token with either `read_api` or `api` permission. See the [gitlab documentation](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#create-a-personal-access-token) for details on generating one.
+
+Allowed fields: `["events", "issues", "openIssues", "closedIssues", "mergeRequests", "openMergeRequests",
+"closedMergeRequests"]`.
+
+```yaml
+widget:
+  type: gitlab
+  url: http://gitlab.host.or.ip:port
+  key: personal-access-token
+  issueState: all # supports "opened", "closed" and defaults to "all"
+  mergeRequestState: all # supports "opened", "closed", "locked" and defaults to "all"
+```

--- a/docs/widgets/services/index.md
+++ b/docs/widgets/services/index.md
@@ -40,6 +40,7 @@ You can also find a list of all available service widgets in the sidebar navigat
 - [Gatus](gatus.md)
 - [Ghostfolio](ghostfolio.md)
 - [Gitea](gitea.md)
+- [Gitlab](gitlab.md)
 - [Glances](glances.md)
 - [Gluetun](gluetun.md)
 - [Gotify](gotify.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
           - widgets/services/gatus.md
           - widgets/services/ghostfolio.md
           - widgets/services/gitea.md
+          - widgets/services/gitlab.md
           - widgets/services/glances.md
           - widgets/services/gluetun.md
           - widgets/services/gotify.md

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1003,8 +1003,9 @@
         "loading": "Loading"
     },
     "gitlab": {
-        "events": "Events",
+        "groups": "Groups",
         "issues": "Issues",
-        "merges": "Merge Requests"
+        "merges": "Merge Requests",
+        "projects": "Projects"
     }
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1005,10 +1005,6 @@
     "gitlab": {
         "events": "Events",
         "issues": "Issues",
-        "issuesOpen": "Open Issues",
-        "issuesClosed": "Closed Issues",
-        "merges": "Merge Requests",
-        "mergesOpen": "Open Merge Requests",
-        "mergesClosed": "Closed Merge Requests"
+        "merges": "Merge Requests"
     }
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -988,5 +988,14 @@
       "memory": "MEM",
       "disk": "Disk",
       "network": "NET"
+    },
+    "gitlab": {
+        "events": "Events",
+        "issues": "Issues",
+        "issuesOpen": "Open Issues",
+        "issuesClosed": "Closed Issues",
+        "merges": "Merge Requests",
+        "mergesOpen": "Open Merge Requests",
+        "mergesClosed": "Closed Merge Requests"
     }
 }

--- a/src/utils/proxy/handlers/credentialed.js
+++ b/src/utils/proxy/handlers/credentialed.js
@@ -93,6 +93,8 @@ export default async function credentialedProxyHandler(req, res, map) {
         }
       } else if (widget.type === "wgeasy") {
         headers.Authorization = widget.password;
+      } else if (widget.type === "gitlab") {
+        headers["PRIVATE-TOKEN"] = widget.key
       } else {
         headers["X-API-Key"] = `${widget.key}`;
       }

--- a/src/utils/proxy/handlers/credentialed.js
+++ b/src/utils/proxy/handlers/credentialed.js
@@ -94,7 +94,7 @@ export default async function credentialedProxyHandler(req, res, map) {
       } else if (widget.type === "wgeasy") {
         headers.Authorization = widget.password;
       } else if (widget.type === "gitlab") {
-        headers["PRIVATE-TOKEN"] = widget.key
+        headers["PRIVATE-TOKEN"] = widget.key;
       } else {
         headers["X-API-Key"] = `${widget.key}`;
       }

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -37,6 +37,7 @@ const components = {
   gatus: dynamic(() => import("./gatus/component")),
   ghostfolio: dynamic(() => import("./ghostfolio/component")),
   gitea: dynamic(() => import("./gitea/component")),
+  gitlab: dynamic(() => import("./gitlab/component")),
   glances: dynamic(() => import("./glances/component")),
   gluetun: dynamic(() => import("./gluetun/component")),
   gotify: dynamic(() => import("./gotify/component")),

--- a/src/widgets/gitlab/component.jsx
+++ b/src/widgets/gitlab/component.jsx
@@ -9,12 +9,14 @@ export default function Component({ service }) {
   const { widget } = service;
 
   const { data: gitlabEvents, error: gitlabEventsError } = useWidgetAPI(widget, "events");
+  const { data: gitlabIssues, error: gitlabIssuesError } = useWidgetAPI(widget, "issues");
+  const { data: gitlabMerges, error: gitlabMergesError } = useWidgetAPI(widget, "merges");
 
-  if (gitlabEventsError) {
-    return <Container service={service} error={gitlabEvents} />;
+  if (gitlabEventsError || gitlabIssuesError || gitlabMergesError) {
+    return <Container service={service} error={gitlabEventsError ?? gitlabIssuesError ?? gitlabMergesError} />;
   }
 
-  if (!gitlabEvents) {
+  if (!gitlabEvents || !gitlabIssues || !gitlabMerges) {
     return (
       <Container service={service}>
         <Block label="gitlab.events" />
@@ -24,14 +26,11 @@ export default function Component({ service }) {
     );
   }
 
-  const openIssues = gitlabEvents.issues.filter((event) => event.action_name.toLowerCase() === "opened").length;
-  const openMerges = gitlabEvents.merges.filter((event) => event.action_name.toLowerCase() === "opened").length;
-
   return (
     <Container service={service}>
-      <Block label="gitlab.events" value={t("common.number", { value: gitlabEvents.events })} />
-      <Block label="gitlab.issues" value={t("common.number", { value: openIssues })} />
-      <Block label="gitlab.merges" value={t("common.number", { value: openMerges })} />
+      <Block label="gitlab.events" value={t("common.number", { value: gitlabEvents.count })} />
+      <Block label="gitlab.issues" value={t("common.number", { value: gitlabIssues.count })} />
+      <Block label="gitlab.merges" value={t("common.number", { value: gitlabMerges.count })} />
     </Container>
   );
 }

--- a/src/widgets/gitlab/component.jsx
+++ b/src/widgets/gitlab/component.jsx
@@ -8,29 +8,29 @@ export default function Component({ service }) {
   const { t } = useTranslation();
   const { widget } = service;
 
-  const { data: gitlabEvents, error: gitlabEventsError } = useWidgetAPI(widget, "events");
-  const { data: gitlabIssues, error: gitlabIssuesError } = useWidgetAPI(widget, "issues");
-  const { data: gitlabMerges, error: gitlabMergesError } = useWidgetAPI(widget, "merges");
+  const { data: gitlabCounts, error: gitlabCountsError } = useWidgetAPI(widget, "counts");
 
-  if (gitlabEventsError || gitlabIssuesError || gitlabMergesError) {
-    return <Container service={service} error={gitlabEventsError ?? gitlabIssuesError ?? gitlabMergesError} />;
+  if (gitlabCountsError) {
+    return <Container service={service} error={gitlabCountsError} />;
   }
 
-  if (!gitlabEvents || !gitlabIssues || !gitlabMerges) {
+  if (!gitlabCounts) {
     return (
       <Container service={service}>
-        <Block label="gitlab.events" />
+        <Block label="gitlab.groups" />
         <Block label="gitlab.issues" />
         <Block label="gitlab.merges" />
+        <Block label="gitlab.projects" />
       </Container>
     );
   }
 
   return (
     <Container service={service}>
-      <Block label="gitlab.events" value={t("common.number", { value: gitlabEvents.count })} />
-      <Block label="gitlab.issues" value={t("common.number", { value: gitlabIssues.count })} />
-      <Block label="gitlab.merges" value={t("common.number", { value: gitlabMerges.count })} />
+      <Block label="gitlab.groups" value={t("common.number", { value: gitlabCounts.groups_count })} />
+      <Block label="gitlab.issues" value={t("common.number", { value: gitlabCounts.issues_count })} />
+      <Block label="gitlab.merges" value={t("common.number", { value: gitlabCounts.merge_requests_count })} />
+      <Block label="gitlab.projects" value={t("common.number", { value: gitlabCounts.projects_count })} />
     </Container>
   );
 }

--- a/src/widgets/gitlab/component.jsx
+++ b/src/widgets/gitlab/component.jsx
@@ -19,36 +19,19 @@ export default function Component({ service }) {
       <Container service={service}>
         <Block label="gitlab.events" />
         <Block label="gitlab.issues" />
-        <Block label="gitlab.issuesOpen" />
-        <Block label="gitlab.issuesClosed" />
         <Block label="gitlab.merges" />
-        <Block label="gitlab.mergesOpen" />
-        <Block label="gitlab.mergesClosed" />
       </Container>
     );
   }
 
-  const issues = {
-    open: gitlabEvents.issues.filter((event) => event.action_name.toLowerCase() === "opened").length,
-    closed: gitlabEvents.issues.filter((event) => event.action_name.toLowerCase() === "closed").length,
-    count: gitlabEvents.issues.length,
-  };
-
-  const merges = {
-    open: gitlabEvents.merges.filter((event) => event.action_name.toLowerCase() === "opened").length,
-    closed: gitlabEvents.merges.filter((event) => event.action_name.toLowerCase() === "closed").length,
-    count: gitlabEvents.merges.length,
-  };
+  const openIssues = gitlabEvents.issues.filter((event) => event.action_name.toLowerCase() === "opened").length;
+  const openMerges = gitlabEvents.merges.filter((event) => event.action_name.toLowerCase() === "opened").length;
 
   return (
     <Container service={service}>
       <Block label="gitlab.events" value={t("common.number", { value: gitlabEvents.events })} />
-      <Block label="gitlab.issues" value={t("common.number", { value: issues.count })} />
-      <Block label="gitlab.issuesOpen" value={t("common.number", { value: issues.open })} />
-      <Block label="gitlab.issuesClosed" value={t("common.number", { value: issues.closed })} />
-      <Block label="gitlab.merges" value={t("common.number", { value: merges.count })} />
-      <Block label="gitlab.mergesOpen" value={t("common.number", { value: merges.open })} />
-      <Block label="gitlab.mergesClosed" value={t("common.number", { value: merges.closed })} />
+      <Block label="gitlab.issues" value={t("common.number", { value: openIssues })} />
+      <Block label="gitlab.merges" value={t("common.number", { value: openMerges })} />
     </Container>
   );
 }

--- a/src/widgets/gitlab/component.jsx
+++ b/src/widgets/gitlab/component.jsx
@@ -1,8 +1,11 @@
+import { useTranslation } from "next-i18next";
+
 import Container from "components/services/widget/container";
 import Block from "components/services/widget/block";
 import useWidgetAPI from "utils/proxy/use-widget-api";
 
 export default function Component({ service }) {
+  const { t } = useTranslation();
   const { widget } = service;
 
   const { data: gitlabEvents, error: gitlabEventsError } = useWidgetAPI(widget, "events");
@@ -26,26 +29,26 @@ export default function Component({ service }) {
   }
 
   const issues = {
-    open: gitlabEvents.issues.filter(event => event.action_name.toLowerCase() === "opened").length,
-    closed: gitlabEvents.issues.filter(event => event.action_name.toLowerCase() === "closed").length,
-    count: gitlabEvents.issues.length
+    open: gitlabEvents.issues.filter((event) => event.action_name.toLowerCase() === "opened").length,
+    closed: gitlabEvents.issues.filter((event) => event.action_name.toLowerCase() === "closed").length,
+    count: gitlabEvents.issues.length,
   };
 
   const merges = {
-    open: gitlabEvents.merges.filter(event => event.action_name.toLowerCase() === "opened").length,
-    closed: gitlabEvents.merges.filter(event => event.action_name.toLowerCase() === "closed").length,
-    count: gitlabEvents.merges.length
+    open: gitlabEvents.merges.filter((event) => event.action_name.toLowerCase() === "opened").length,
+    closed: gitlabEvents.merges.filter((event) => event.action_name.toLowerCase() === "closed").length,
+    count: gitlabEvents.merges.length,
   };
 
   return (
     <Container service={service}>
-      <Block label="gitlab.events" value={gitlabEvents.events} />
-      <Block label="gitlab.issues" value={issues.count} />
-      <Block label="gitlab.issuesOpen" value={issues.open} />
-      <Block label="gitlab.issuesClosed" value={issues.closed} />
-      <Block label="gitlab.merges" value={merges.count} />
-      <Block label="gitlab.mergesOpen" value={merges.open} />
-      <Block label="gitlab.mergesClosed" value={merges.closed} />
+      <Block label="gitlab.events" value={t("common.number", { value: gitlabEvents.events })} />
+      <Block label="gitlab.issues" value={t("common.number", { value: issues.count })} />
+      <Block label="gitlab.issuesOpen" value={t("common.number", { value: issues.open })} />
+      <Block label="gitlab.issuesClosed" value={t("common.number", { value: issues.closed })} />
+      <Block label="gitlab.merges" value={t("common.number", { value: merges.count })} />
+      <Block label="gitlab.mergesOpen" value={t("common.number", { value: merges.open })} />
+      <Block label="gitlab.mergesClosed" value={t("common.number", { value: merges.closed })} />
     </Container>
   );
 }

--- a/src/widgets/gitlab/component.jsx
+++ b/src/widgets/gitlab/component.jsx
@@ -1,0 +1,51 @@
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { widget } = service;
+
+  const { data: gitlabEvents, error: gitlabEventsError } = useWidgetAPI(widget, "events");
+
+  if (gitlabEventsError) {
+    return <Container service={service} error={gitlabEvents} />;
+  }
+
+  if (!gitlabEvents) {
+    return (
+      <Container service={service}>
+        <Block label="gitlab.events" />
+        <Block label="gitlab.issues" />
+        <Block label="gitlab.issuesOpen" />
+        <Block label="gitlab.issuesClosed" />
+        <Block label="gitlab.merges" />
+        <Block label="gitlab.mergesOpen" />
+        <Block label="gitlab.mergesClosed" />
+      </Container>
+    );
+  }
+
+  const issues = {
+    open: gitlabEvents.issues.filter(event => event.action_name.toLowerCase() === "opened").length,
+    closed: gitlabEvents.issues.filter(event => event.action_name.toLowerCase() === "closed").length,
+    count: gitlabEvents.issues.length
+  };
+
+  const merges = {
+    open: gitlabEvents.merges.filter(event => event.action_name.toLowerCase() === "opened").length,
+    closed: gitlabEvents.merges.filter(event => event.action_name.toLowerCase() === "closed").length,
+    count: gitlabEvents.merges.length
+  };
+
+  return (
+    <Container service={service}>
+      <Block label="gitlab.events" value={gitlabEvents.events} />
+      <Block label="gitlab.issues" value={issues.count} />
+      <Block label="gitlab.issuesOpen" value={issues.open} />
+      <Block label="gitlab.issuesClosed" value={issues.closed} />
+      <Block label="gitlab.merges" value={merges.count} />
+      <Block label="gitlab.mergesOpen" value={merges.open} />
+      <Block label="gitlab.mergesClosed" value={merges.closed} />
+    </Container>
+  );
+}

--- a/src/widgets/gitlab/widget.js
+++ b/src/widgets/gitlab/widget.js
@@ -1,27 +1,11 @@
-import { asJson } from "utils/proxy/api-helpers";
 import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
 
 const widget = {
   api: "{url}/api/v4/{endpoint}",
   proxyHandler: credentialedProxyHandler,
   mappings: {
-    events: {
-      endpoint: "events",
-      map: (data) => ({
-        count: asJson(data).length,
-      }),
-    },
-    issues: {
-      endpoint: "issues?state=opened",
-      map: (data) => ({
-        count: asJson(data).length,
-      }),
-    },
-    merges: {
-      endpoint: "merge_requests?state=opened",
-      map: (data) => ({
-        count: asJson(data).length,
-      }),
+    counts: {
+      endpoint: "users/{user_id}/associations_count",
     },
   },
 };

--- a/src/widgets/gitlab/widget.js
+++ b/src/widgets/gitlab/widget.js
@@ -10,30 +10,30 @@ const widget = {
       map: (data) => ({
         merges: asJson(data).filter((event) => event.target_type?.toLowerCase() === "merge_request"),
         issues: asJson(data).filter((event) => event.target_type?.toLowerCase() === "issue"),
-        events: asJson(data).length
-      })
+        events: asJson(data).length,
+      }),
     },
     issues: {
       endpoint: "issues",
-      params: ["state"]
+      params: ["state"],
     },
     openIssues: {
-      endpoint: "issues?state=opened"
+      endpoint: "issues?state=opened",
     },
     closedIssues: {
-      endpoint: "issues?state=closed"
+      endpoint: "issues?state=closed",
     },
     mergeRequests: {
       endpoint: "merge_requests",
-      params: ["state"]
+      params: ["state"],
     },
     openMergeRequests: {
-      endpoint: "merge_requests?state=opened"
+      endpoint: "merge_requests?state=opened",
     },
     closedMergeRequests: {
-      endpoint: "merge_requests?state=closed"
-    }
-  }
+      endpoint: "merge_requests?state=closed",
+    },
+  },
 };
 
 export default widget;

--- a/src/widgets/gitlab/widget.js
+++ b/src/widgets/gitlab/widget.js
@@ -2,7 +2,7 @@ import { asJson } from "utils/proxy/api-helpers";
 import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
 
 const widget = {
-  api: "{url}/api/v1/{endpoint}",
+  api: "{url}/api/v4/{endpoint}",
   proxyHandler: credentialedProxyHandler,
   mappings: {
     events: {

--- a/src/widgets/gitlab/widget.js
+++ b/src/widgets/gitlab/widget.js
@@ -8,9 +8,19 @@ const widget = {
     events: {
       endpoint: "events",
       map: (data) => ({
-        merges: asJson(data).filter((event) => event.target_type?.toLowerCase() === "merge_request"),
-        issues: asJson(data).filter((event) => event.target_type?.toLowerCase() === "issue"),
-        events: asJson(data).length,
+        count: asJson(data).length,
+      }),
+    },
+    issues: {
+      endpoint: "issues?state=opened",
+      map: (data) => ({
+        count: asJson(data).length,
+      }),
+    },
+    merges: {
+      endpoint: "merge_requests?state=opened",
+      map: (data) => ({
+        count: asJson(data).length,
       }),
     },
   },

--- a/src/widgets/gitlab/widget.js
+++ b/src/widgets/gitlab/widget.js
@@ -13,26 +13,6 @@ const widget = {
         events: asJson(data).length,
       }),
     },
-    issues: {
-      endpoint: "issues",
-      params: ["state"],
-    },
-    openIssues: {
-      endpoint: "issues?state=opened",
-    },
-    closedIssues: {
-      endpoint: "issues?state=closed",
-    },
-    mergeRequests: {
-      endpoint: "merge_requests",
-      params: ["state"],
-    },
-    openMergeRequests: {
-      endpoint: "merge_requests?state=opened",
-    },
-    closedMergeRequests: {
-      endpoint: "merge_requests?state=closed",
-    },
   },
 };
 

--- a/src/widgets/gitlab/widget.js
+++ b/src/widgets/gitlab/widget.js
@@ -1,0 +1,39 @@
+import { asJson } from "utils/proxy/api-helpers";
+import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
+
+const widget = {
+  api: "{url}/api/v1/{endpoint}",
+  proxyHandler: credentialedProxyHandler,
+  mappings: {
+    events: {
+      endpoint: "events",
+      map: (data) => ({
+        merges: asJson(data).filter((event) => event.target_type?.toLowerCase() === "merge_request"),
+        issues: asJson(data).filter((event) => event.target_type?.toLowerCase() === "issue"),
+        events: asJson(data).length
+      })
+    },
+    issues: {
+      endpoint: "issues",
+      params: ["state"]
+    },
+    openIssues: {
+      endpoint: "issues?state=opened"
+    },
+    closedIssues: {
+      endpoint: "issues?state=closed"
+    },
+    mergeRequests: {
+      endpoint: "merge_requests",
+      params: ["state"]
+    },
+    openMergeRequests: {
+      endpoint: "merge_requests?state=opened"
+    },
+    closedMergeRequests: {
+      endpoint: "merge_requests?state=closed"
+    }
+  }
+};
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -31,6 +31,7 @@ import gamedig from "./gamedig/widget";
 import gatus from "./gatus/widget";
 import ghostfolio from "./ghostfolio/widget";
 import gitea from "./gitea/widget";
+import gitlab from "./gitlab/widget";
 import glances from "./glances/widget";
 import gluetun from "./gluetun/widget";
 import gotify from "./gotify/widget";
@@ -161,6 +162,7 @@ const widgets = {
   gatus,
   ghostfolio,
   gitea,
+  gitlab,
   glances,
   gluetun,
   gotify,


### PR DESCRIPTION
## Proposed change

This adds a widget for [Gitlab](https://gitlab.com). It is able to list the amount of `events` as well as the open `issues` and open `merge requests`

![grafik](https://github.com/user-attachments/assets/6488afae-f64a-4fab-af32-20f73bbe6e57)

Closes #3406 

## Type of change

- [x] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
