### PR TITLE
Features: Add searching by URL in quick launch

### DIFF
--- a/docs/configs/settings.md
+++ b/docs/configs/settings.md
@@ -378,6 +378,7 @@ You can use the 'Quick Launch' feature to search services, perform a web search 
 There are a few optional settings for the Quick Launch feature:
 
 - `searchDescriptions`: which lets you control whether item descriptions are included in searches. This is false by default. When enabled, results that match the item name will be placed above those that only match the description.
+- `searchUrls`: which lets you control whether item URLs are included in searches. This is false by default. When enabled, results that match the item name will be placed above those that only match URLs. When used with `searchDescriptions`, items which match descriptions will show higher than those that match only URLs.
 - `hideInternetSearch`: disable automatically including the currently-selected web search (e.g. from the widget) as a Quick Launch option. This is false by default, enabling the feature.
 - `showSearchSuggestions`: show search suggestions for the internet search. If this is not specified then the setting will be inherited from the search widget. If it is not specified there either, it will default to false. For custom providers the `suggestionUrl` needs to be set in order for this to work.
 - `provider`: search engine provider. If none is specified it will try to use the provider set for the Search Widget, if neither are present then internet search will be disabled.
@@ -386,6 +387,7 @@ There are a few optional settings for the Quick Launch feature:
 ```yaml
 quicklaunch:
   searchDescriptions: true
+  searchUrls: true
   hideInternetSearch: true
   showSearchSuggestions: true
   hideVisitURL: true

--- a/src/components/quicklaunch.jsx
+++ b/src/components/quicklaunch.jsx
@@ -12,7 +12,7 @@ export default function QuickLaunch({ servicesAndBookmarks, searchString, setSea
   const { t } = useTranslation();
 
   const { settings } = useContext(SettingsContext);
-  const { searchDescriptions = false, hideVisitURL = false } = settings?.quicklaunch ?? {};
+  const { searchDescriptions = false, searchUrls = false, hideVisitURL = false } = settings?.quicklaunch ?? {};
 
   const searchField = useRef();
 
@@ -138,10 +138,15 @@ export default function QuickLaunch({ servicesAndBookmarks, searchString, setSea
           descriptionMatch = r.description?.toLowerCase().includes(searchString);
           r.priority = nameMatch ? 2 * +nameMatch : +descriptionMatch; // eslint-disable-line no-param-reassign
         }
-        return nameMatch || descriptionMatch;
+        let urlMatch;
+        if (searchUrls) {
+          urlMatch = r.href?.toLowerCase().includes(searchString);
+          r.priority = nameMatch ? 3 * +nameMatch : descriptionMatch ? 2 * +descriptionMatch : +urlMatch;
+        }
+        return nameMatch || descriptionMatch || urlMatch;
       });
 
-      if (searchDescriptions) {
+      if (searchDescriptions || searchUrls) {
         newResults = newResults.sort((a, b) => b.priority - a.priority);
       }
 
@@ -205,7 +210,7 @@ export default function QuickLaunch({ servicesAndBookmarks, searchString, setSea
     return () => {
       abortController.abort();
     };
-  }, [searchString, servicesAndBookmarks, searchDescriptions, hideVisitURL, searchSuggestions, searchProvider, url, t]);
+  }, [searchString, servicesAndBookmarks, searchDescriptions, searchUrls, hideVisitURL, searchSuggestions, searchProvider, url, t]);
 
   const [hidden, setHidden] = useState(true);
   useEffect(() => {


### PR DESCRIPTION
## Proposed change

Adds the ability to search with URLs alongside searching with name and description in quick launch. Disabled by default, can be enabled with option searchUrls.

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

Closes #4319 

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
