### PR TITLE
Enhancement: group nesting/subgroups

### DIFF
--- a/docs/configs/services.md
+++ b/docs/configs/services.md
@@ -21,6 +21,25 @@ Groups are defined as top-level array entries.
 
 <img width="1038" alt="Service Groups" src="https://user-images.githubusercontent.com/82196/187040754-28065242-4534-4409-881c-93d1921c6141.png">
 
+## Subgroups
+
+Subgroups are defined as array entries with `type: group` and an array `services: ...`,
+
+```
+- Group A:
+  - Subgroup A:
+      type: group
+      services:
+        - Service A:
+            href: http://localhost/
+  - Service B:
+      href: http://localhost/
+
+- Group B:
+    - Service C:
+        href: http://localhost/
+```
+
 ## Services
 
 Services are defined as array entries on groups,

--- a/src/components/services/group.jsx
+++ b/src/components/services/group.jsx
@@ -8,12 +8,14 @@ import ResolvedIcon from "components/resolvedicon";
 
 export default function ServicesGroup({
   group,
+  subgroups,
   services,
   layout,
   fiveColumns,
   disableCollapse,
   useEqualHeights,
   groupsInitiallyCollapsed,
+  isSubgroup = false,
 }) {
   const panel = useRef();
 
@@ -29,6 +31,7 @@ export default function ServicesGroup({
         layout?.style === "row" ? "basis-full" : "basis-full md:basis-1/2 lg:basis-1/3 xl:basis-1/4",
         layout?.style !== "row" && fiveColumns ? "3xl:basis-1/5" : "",
         layout?.header === false ? "flex-1 px-1 -my-1" : "flex-1 p-1",
+        isSubgroup === false ? "" : "bg-theme-500/20 dark:bg-white/5 rounded-md px-2 py-2",
       )}
     >
       <Disclosure defaultOpen={!(layout?.initiallyCollapsed ?? groupsInitiallyCollapsed) ?? true}>
@@ -74,7 +77,13 @@ export default function ServicesGroup({
               }}
             >
               <Disclosure.Panel className="transition-all overflow-hidden duration-300 ease-out" ref={panel} static>
-                <List group={group} services={services.services} layout={layout} useEqualHeights={useEqualHeights} />
+                <List
+                  group={group}
+                  subgroups={subgroups}
+                  services={services.services}
+                  layout={layout}
+                  useEqualHeights={useEqualHeights}
+                />
               </Disclosure.Panel>
             </Transition>
           </>

--- a/src/components/services/group.jsx
+++ b/src/components/services/group.jsx
@@ -22,7 +22,6 @@ export default function ServicesGroup({
   useEffect(() => {
     if (layout?.initiallyCollapsed ?? groupsInitiallyCollapsed) panel.current.style.height = `0`;
   }, [layout, groupsInitiallyCollapsed]);
-
   return (
     <div
       key={services.name}
@@ -30,8 +29,12 @@ export default function ServicesGroup({
         "services-group",
         layout?.style === "row" ? "basis-full" : "basis-full md:basis-1/2 lg:basis-1/3 xl:basis-1/4",
         layout?.style !== "row" && fiveColumns ? "3xl:basis-1/5" : "",
-        layout?.header === false ? "flex-1 px-1 -my-1" : "flex-1 p-1",
-        isSubgroup === false ? "" : "bg-theme-500/20 dark:bg-white/5 rounded-md px-2 py-2",
+        isSubgroup === false && layout?.header === false ? "flex-1 px-1 -my-1" : "",
+        isSubgroup === false && layout?.header !== false ? "flex-1 p-1" : "",
+        isSubgroup === true && layout?.header !== false
+          ? "bg-theme-500/20 dark:bg-white/5 rounded-md px-2 py-2 mb-2"
+          : "",
+        isSubgroup === true && layout?.header === false ? "-px-2" : "",
       )}
     >
       <Disclosure defaultOpen={!(layout?.initiallyCollapsed ?? groupsInitiallyCollapsed) ?? true}>

--- a/src/components/services/list.jsx
+++ b/src/components/services/list.jsx
@@ -11,7 +11,8 @@ export default function List({ group, subgroups = [], services, layout, useEqual
       <ul
         className={classNames(
           layout?.style === "row" ? `grid ${columnMap[layout?.columns]} gap-x-2` : "flex flex-col",
-          "mt-3 services-list",
+          layout?.header !== false ? "mt-3" : "",
+          "services-list",
         )}
       >
         {services.map((service) => (
@@ -29,7 +30,8 @@ export default function List({ group, subgroups = [], services, layout, useEqual
           <Group
             group={subgroup}
             services={subgroup}
-            layout={layout}
+            subgroups={subgroup.subgroups}
+            layout={subgroup}
             useEqualHeights={useEqualHeights}
             isSubgroup={true}
           />

--- a/src/components/services/list.jsx
+++ b/src/components/services/list.jsx
@@ -3,23 +3,37 @@ import classNames from "classnames";
 import { columnMap } from "../../utils/layout/columns";
 
 import Item from "components/services/item";
+import Group from "components/services/group";
 
-export default function List({ group, services, layout, useEqualHeights }) {
+export default function List({ group, subgroups = [], services, layout, useEqualHeights }) {
   return (
-    <ul
-      className={classNames(
-        layout?.style === "row" ? `grid ${columnMap[layout?.columns]} gap-x-2` : "flex flex-col",
-        "mt-3 services-list",
-      )}
-    >
-      {services.map((service) => (
-        <Item
-          key={[service.container, service.app, service.name].filter((s) => s).join("-")}
-          service={service}
-          group={group}
-          useEqualHeights={layout?.useEqualHeights ?? useEqualHeights}
-        />
-      ))}
-    </ul>
+    <>
+      <ul
+        className={classNames(
+          layout?.style === "row" ? `grid ${columnMap[layout?.columns]} gap-x-2` : "flex flex-col",
+          "mt-3 services-list",
+        )}
+      >
+        {services.map((service) => (
+          <Item
+            key={[service.container, service.app, service.name].filter((s) => s).join("-")}
+            service={service}
+            group={group}
+            useEqualHeights={layout?.useEqualHeights ?? useEqualHeights}
+          />
+        ))}
+      </ul>
+      {subgroups
+        .filter((subgroup) => subgroup != [])
+        .map((subgroup) => (
+          <Group
+            group={subgroup}
+            services={subgroup}
+            layout={layout}
+            useEqualHeights={useEqualHeights}
+            isSubgroup={true}
+          />
+        ))}
+    </>
   );
 }

--- a/src/components/widgets/resources/network.jsx
+++ b/src/components/widgets/resources/network.jsx
@@ -18,7 +18,7 @@ export default function Network({ options, refresh = 1500 }) {
     return <Error />;
   }
 
-  if (!data || !data.network) {
+  if (!data || !data.network || !data.network.rx_sec || !data.network.tx_sec) {
     return (
       <Resource
         icon={FaNetworkWired}

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -264,7 +264,6 @@ function Home({ initialSettings }) {
 
     const serviceGroups = services?.filter(tabGroupFilter).filter(undefinedGroupFilter);
     const bookmarkGroups = bookmarks.filter(tabGroupFilter).filter(undefinedGroupFilter);
-
     return (
       <>
         {tabs.length > 0 && (

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -292,6 +292,7 @@ function Home({ initialSettings }) {
                 <ServicesGroup
                   key={group.name}
                   group={group.name}
+                  subgroups={group.subgroups}
                   services={group}
                   layout={settings.layout?.[group.name]}
                   fiveColumns={settings.fiveColumns}
@@ -317,6 +318,7 @@ function Home({ initialSettings }) {
               <ServicesGroup
                 key={group.name}
                 group={group.name}
+                subgroups={group.subgroups}
                 services={group}
                 layout={settings.layout?.[group.name]}
                 fiveColumns={settings.fiveColumns}

--- a/src/utils/config/api-response.js
+++ b/src/utils/config/api-response.js
@@ -142,9 +142,11 @@ export async function servicesResponse() {
   mergedGroupsNames.forEach((groupName) => {
     const discoveredDockerGroup = discoveredDockerServices.find((group) => group.name === groupName) || {
       services: [],
+      subgroups: [],
     };
     const discoveredKubernetesGroup = discoveredKubernetesServices.find((group) => group.name === groupName) || {
       services: [],
+      subgroups: [],
     };
     const configuredGroup = configuredServices.find((group) => group.name === groupName) || { services: [] };
 
@@ -153,6 +155,11 @@ export async function servicesResponse() {
       services: [...discoveredDockerGroup.services, ...discoveredKubernetesGroup.services, ...configuredGroup.services]
         .filter((service) => service)
         .sort(compareServices),
+      subgroups: [
+        ...discoveredDockerGroup.subgroups,
+        ...discoveredKubernetesGroup.subgroups,
+        ...configuredGroup.subgroups,
+      ].filter((subgroup) => subgroup),
     };
 
     if (definedLayouts) {

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -37,11 +37,16 @@ export async function servicesFromConfig() {
       })),
     subgroups: servicesArr
       .filter((entry) => entry[Object.keys(entry)[0]].type == "group")
-      .map((entries) => mappingFunc(entries, entries[Object.keys(entries)[0]].services)),
+      .map((entries) => ({
+        style: entries[Object.keys(entries)[0]].style,
+        icon: entries[Object.keys(entries)[0]].icon,
+        columns: entries[Object.keys(entries)[0]].columns,
+        header: entries[Object.keys(entries)[0]].header,
+        ...mappingFunc(entries, entries[Object.keys(entries)[0]].services),
+      })),
   });
   // map easy to write YAML objects into easy to consume JS arrays
   const servicesArray = services.map((servicesGroup) => mappingFunc(servicesGroup));
-
   return servicesArray;
 }
 
@@ -664,6 +669,10 @@ export function cleanServiceGroups(groups) {
       return cleanedService;
     }),
     subgroups: serviceGroup.subgroups.map((serviceGroup) => cleanerFunc(serviceGroup)),
+    style: serviceGroup.style ? serviceGroup.style : null,
+    icon: serviceGroup.icon ? serviceGroup.icon : null,
+    columns: serviceGroup.columns ? serviceGroup.columns : null,
+    header: typeof serviceGroup.header != "undefined" ? serviceGroup.header : null,
   });
   return groups.map((serviceGroup) => cleanerFunc(serviceGroup));
 }


### PR DESCRIPTION
## Proposed change

Adds Nested groups and subgroups, with the following formatting

```yaml
- Group A:
  - Subgroup A:
      type: group
      services:
        - Service A:
            href: http://localhost/
  - Service B:
      href: http://localhost/

- Group B:
    - Service C:
        href: http://localhost/
```

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

Closes #2310 

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
