### PR TITLE
Enhancement: set css color-scheme

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -26,12 +26,14 @@ body {
 }
 
 .light {
+  color-scheme: light;
   --bg-color: var(--color-50);
   --scrollbar-thumb: rgb(var(--color-300));
   --scrollbar-track: rgb(var(--color-200));
 }
 
 .dark {
+  color-scheme: dark;
   --bg-color: var(--color-800);
   --scrollbar-thumb: rgb(var(--color-600));
   --scrollbar-track: rgb(var(--color-700));


### PR DESCRIPTION
## Proposed change

Add `color-scheme` so that iframes or other embedded components can follow the color-scheme of the main page.

Closes #4329 

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
