### PR TITLE
Documentation: Added missing admonition type

### DIFF
--- a/docs/widgets/info/unifi_controller.md
+++ b/docs/widgets/info/unifi_controller.md
@@ -7,7 +7,7 @@ _(Find the Unifi Controller service widget [here](../services/unifi-controller.m
 
 You can display general connectivity status from your Unifi (Network) Controller.
 
-!!!
+!!! warning
 
     When authenticating you will want to use a local account that has at least read privileges.
 

--- a/docs/widgets/services/unifi-controller.md
+++ b/docs/widgets/services/unifi-controller.md
@@ -9,7 +9,7 @@ _(Find the Unifi Controller information widget [here](../info/unifi_controller.m
 
 You can display general connectivity status from your Unifi (Network) Controller.
 
-!!!
+!!! warning
 
     When authenticating you will want to use a local account that has at least read privileges.
 


### PR DESCRIPTION
## Proposed change

Found missing admonition types in both of the UDM docs, set them to type: _warning_

Closes # none

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
