### PR TITLE
Adding support for RackNerd widget.

### DIFF
--- a/docs/widgets/services/index.md
+++ b/docs/widgets/services/index.md
@@ -108,6 +108,7 @@ You can also find a list of all available service widgets in the sidebar navigat
 - [PyLoad](pyload.md)
 - [qBittorrent](qbittorrent.md)
 - [QNAP](qnap.md)
+- [RackNerd](racknerd.md)
 - [Radarr](radarr.md)
 - [Readarr](readarr.md)
 - [ROMM](romm.md)

--- a/docs/widgets/services/racknerd.md
+++ b/docs/widgets/services/racknerd.md
@@ -1,0 +1,22 @@
+---
+title: RackNerd
+description: RackNerd Widget Configuration
+---
+
+Learn more about [RackNerd](https://racknerd.com).
+
+Use key & hash. Information about the key & hash can be found under the [VPS](https://nerdvm.racknerd.com) control panel in the API section.
+
+Allowed fields: `["ipAddress", "hddtotal", "bandwidthfree", "bandwidthused"]`.
+
+Note `"memoryusage"` is deprecated as v1 of their API result will be always be 0.
+Note `"status"` is not fully implemented.
+
+Note hard drive free/used/percentage isn't functioning in v1 of their API result.
+```yaml
+widget:
+  type: racknerd
+  url: https://nerdvm.racknerd.com
+  key: token
+  hash: token
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -131,6 +131,7 @@ nav:
           - widgets/services/pyload.md
           - widgets/services/qbittorrent.md
           - widgets/services/qnap.md
+          - widgets/services/racknerd.md
           - widgets/services/radarr.md
           - widgets/services/readarr.md
           - widgets/services/romm.md

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -716,6 +716,14 @@
         "numfiles": "Files",
         "numshares": "Shared Items"
     },
+    "racknerd": {
+        "ipAddress": "IP Address",
+        "memoryusage": "Memory Usage",
+        "hddtotal": "Total Space",
+        "bandwidthtotal": "Bandwidth Total",
+        "bandwidthused": "Bandwidth Used",
+        "bandwidthfree": "Bandwidth Free"
+    },
     "kopia": {
         "status": "Status",
         "size": "Size",

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -104,6 +104,7 @@ const components = {
   pyload: dynamic(() => import("./pyload/component")),
   qbittorrent: dynamic(() => import("./qbittorrent/component")),
   qnap: dynamic(() => import("./qnap/component")),
+  racknerd: dynamic(() => import("./racknerd/component")),
   radarr: dynamic(() => import("./radarr/component")),
   readarr: dynamic(() => import("./readarr/component")),
   romm: dynamic(() => import("./romm/component")),

--- a/src/widgets/racknerd/component.jsx
+++ b/src/widgets/racknerd/component.jsx
@@ -1,0 +1,71 @@
+import { useTranslation } from "next-i18next";
+import { useMemo } from "react";
+
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export const racknerdDefaultFields = ["ipAddress", "hddtotal", "bandwidthusage"];
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+
+  const { widget } = service;
+  const params = {
+    key: widget.key,
+    hash: widget.hash,
+  };
+  const { data: racknerdData, error: racknerdError } = useWidgetAPI(widget, "serverinfo", {...params, action: 'info'});
+  // Support for fields (harddriveusage, memoryusage, bandwidthusage)
+  const [showIpAddress, showMemoryUsage, showHardDriveUsage, showBandwidthUsed, showBandwidthFree] = useMemo(() => {
+    // Default values if fields is not set
+    if (!widget.fields) return [true, false, true, true, true];
+
+    const hasIpAddress = widget.fields?.includes("ipAddress") || false;
+    const hasMemoryUsage = widget.fields?.includes("memoryusage") || false;
+    const hasHardDriveUsage = widget.fields?.includes("hddtotal") || false;
+    const hasBandwidthUsed = widget.fields?.includes("bandwidthused") || false;
+    const hasBandwidthFree = widget.fields?.includes("bandwidthfree") || false;
+    return [hasIpAddress, hasMemoryUsage, hasHardDriveUsage, hasBandwidthUsed, hasBandwidthFree];
+  }, [widget.fields]);
+  if (racknerdError) {
+    return <Container service={service} error={racknerdError} />;
+  }
+
+  if (!racknerdData) {
+    return (
+      <Container service={service}>
+        {showIpAddress && <Block label="racknerd.ipAddress" />}
+        {showMemoryUsage && <Block label="racknerd.memoryusage" />}
+        {showHardDriveUsage && <Block label="racknerd.hddtotal" />}
+        {showBandwidthUsed && <Block label="racknerd.bandwidthused" />}
+        {showBandwidthFree && <Block label="racknerd.bandwidthfree" />}
+      </Container>
+    );
+  }
+  const { racknerd: racknerdInfo } = racknerdData;
+  return (
+    <Container service={service}>
+      {showIpAddress && (<Block 
+        label="racknerd.ipAddress" 
+        value={racknerdInfo.ipAddress} 
+      />)}
+      {showMemoryUsage && (<Block 
+        label="racknerd.memoryusage" 
+        value={t("common.bbytes", { value: racknerdInfo.system.memoryused, maximumFractionDigits: 1 })} 
+      />)}
+      {showHardDriveUsage && (<Block
+        label="racknerd.hddtotal"
+        value={t("common.bbytes", { value: racknerdInfo.system.hdd_total, maximumFractionDigits: 1 })}
+      />)}
+      {showBandwidthUsed && (<Block
+        label="racknerd.bandwidthused"
+        value={t("common.bbytes", { value: racknerdInfo.system.bandwidth_used, maximumFractionDigits: 1 })}
+      />)}
+      {showBandwidthFree && (<Block
+        label="racknerd.bandwidthfree"
+        value={t("common.bbytes", { value: racknerdInfo.system.bandwidth_free, maximumFractionDigits: 1 })}
+      />)}
+    </Container>
+  );
+}

--- a/src/widgets/racknerd/proxy.js
+++ b/src/widgets/racknerd/proxy.js
@@ -1,0 +1,100 @@
+import { xml2json } from "xml-js";
+
+import { racknerdDefaultFields } from "./component";
+
+import { httpProxy } from "utils/proxy/http";
+import getServiceWidget from "utils/config/service-helpers";
+import createLogger from "utils/logger";
+
+const logger = createLogger("racknerdProxyHandler");
+
+async function requestEndpoint(apiBaseUrl, action, params) {
+  const request = {
+    method: "POST"
+  };
+  let qs = "";
+  Object.entries(params).forEach(([key, value]) => {
+    qs += `&${key}=${value}`;
+  });
+  const apiUrl = `${apiBaseUrl}?action=${action}${qs}`;
+  const [status, , data] = await httpProxy(apiUrl, request);
+  if (status !== 200) {
+    logger.debug(`HTTP ${status} performing XMLRequest for ${action}`, data);
+    throw new Error(`Failed fetching '${action}'`);
+  }
+  const response = {};
+  try {
+    const jsonData = JSON.parse(xml2json(`<root>${data}</root>`, {compact: true}));
+    const responseElements = jsonData?.root || {};
+    Object.entries(responseElements).forEach(([responseKey, responseValue]) => {
+      /* eslint no-underscore-dangle: ["error", { "allow": ["_text"] }] */
+      response[responseKey] = responseValue?._text || "";
+    });
+  } catch (e) {
+    logger.debug(`Failed parsing ${action} response:`, data);
+    throw new Error(`Failed parsing '${action}' response`);
+  }
+
+  return response;
+}
+
+export default async function racknerdProxyHandler(req, res) {
+  const { group, service, index } = req.query;
+  const serviceWidget = await getServiceWidget(group, service, index);
+
+  if (!serviceWidget) {
+    res.status(500).json({ error: { message: "Service widget not found" } });
+    return;
+  }
+
+  if (!serviceWidget.url) {
+    res.status(500).json({ error: { message: "Service widget url not configured" } });
+    return;
+  }
+
+  const serviceWidgetUrl = new URL(serviceWidget.url);
+  const apiBaseUrl = `${serviceWidgetUrl.protocol}//${serviceWidgetUrl.hostname}/api/client/command.php`;
+
+  if (!serviceWidget.fields?.length > 0) {
+    serviceWidget.fields = racknerdDefaultFields;
+  }
+  const requestStatus = ["status"].some((field) => serviceWidget.fields?.includes(field));
+  const requestInfo = ["bandwidthused", "memoryusage", "hddtotal", "ipAddress"].some((field) => serviceWidget.fields?.includes(field));
+  const params = {
+    bw: serviceWidget.fields?.includes('bandwidthused') || serviceWidget.fields?.includes('bandwidthfree'),
+    hdd: serviceWidget.fields?.includes('hddtotal'),
+    ipAddr: serviceWidget.fields?.includes('ipAddress'),
+    mem: serviceWidget.fields?.includes('memoryusage'),
+    key: serviceWidget.key,
+    hash: serviceWidget.hash,
+  };
+
+  await Promise.all([
+    requestStatus ? requestEndpoint(apiBaseUrl, "status", params) : null,
+    requestInfo ? requestEndpoint(apiBaseUrl, "info", params) : null,
+  ])
+  .then(([statusResponse, infoResponse]) => {
+    const memoryItems = infoResponse.mem?.split(',');
+    const hddItems = infoResponse.hdd?.split(',');
+    const bandwidthItems = infoResponse.bw?.split(',');
+    res.status(200).json({
+      racknerd: {
+        ipAddress: infoResponse.ipaddress || undefined,
+        system: {
+          status: statusResponse ? statusResponse.statusmsg : undefined,
+          memoryused: memoryItems ? parseFloat(memoryItems[1], 10) : undefined,
+          hdd_total: hddItems ? parseFloat(hddItems[0], 10) : undefined,
+          bandwidth_total: bandwidthItems ? parseFloat(bandwidthItems[0], 10) : undefined,
+          bandwidth_used: bandwidthItems ? parseFloat(bandwidthItems[1], 10) : undefined,
+          bandwidth_free: bandwidthItems ? parseFloat(bandwidthItems[2], 10) : undefined,
+          mem_total: memoryItems ? parseFloat(memoryItems[0], 10) : undefined,
+          mem_free: memoryItems ? parseFloat(memoryItems[2], 10) : undefined,
+          mem_percent: memoryItems ? parseFloat(memoryItems[3], 10) : undefined,
+        }
+      }
+    });
+  })
+  .catch((error) => {
+    res.status(500).json({ error: { message: error.message } });
+  });
+}

--- a/src/widgets/racknerd/widget.js
+++ b/src/widgets/racknerd/widget.js
@@ -1,0 +1,16 @@
+import racknerdProxyHandler from "./proxy";
+
+const widget = {
+  api: "{url}/{endpoint}",
+  proxyHandler: racknerdProxyHandler,
+
+  mappings: {
+    serverinfo: {
+      endpoint: "api/client/command.php",
+      params: ["key", "hash"],
+      optionalParams: ["bw", "mem", "hdd", "ipaddr"],
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -96,6 +96,7 @@ import pterodactyl from "./pterodactyl/widget";
 import pyload from "./pyload/widget";
 import qbittorrent from "./qbittorrent/widget";
 import qnap from "./qnap/widget";
+import racknerd from "./racknerd/widget";
 import radarr from "./radarr/widget";
 import readarr from "./readarr/widget";
 import rutorrent from "./rutorrent/widget";
@@ -232,6 +233,7 @@ const widgets = {
   pyload,
   qbittorrent,
   qnap,
+  racknerd,
   radarr,
   readarr,
   romm,


### PR DESCRIPTION
## Proposed change
Idk man, I just did this in my free time cause the VPS was on sale for Black Friday and wanted some visibility for my own VPS. Is it self-hosted? No.. Do I run self-hosted content on my VPS? Yes. Is it any different than stats from something like Glances? Not really. Sending in the PR in case someone magically would enjoy the side thing I built.
<img width="1509" alt="Screenshot 2024-12-04 at 9 13 04 PM" src="https://github.com/user-attachments/assets/cc540dc5-1b08-498c-920b-6e6aef42a063">


Closes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [X] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:
> Please only submit widgets that target a feature request discussion with at least 10 'up-votes'

Whoops

- [X] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [X] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
