### PR TITLE
Added a new widget for tvheadend

### DIFF
--- a/docs/widgets/services/tvheadend.md
+++ b/docs/widgets/services/tvheadend.md
@@ -1,0 +1,19 @@
+---
+title: Tvheadend
+description: Tvheadend Widget Configuration
+---
+
+Shows the status of the DVR feature (upcoming, finished, failed recordings) as well as a list of active subscriptions.
+
+Learn more about [Tvheadend](https://tvheadend.org/).
+
+Allowed fields: `["upcoming", "finished", "failed"]`.
+
+```yaml
+widget:
+  type: tvheadend
+  url: http://tvheadend.host.or.ip
+  username: user
+  password: pass
+  fields: ["upcoming", "finished", "failed"]
+```

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1007,5 +1007,10 @@
         "issues": "Issues",
         "merges": "Merge Requests",
         "projects": "Projects"
+    },
+    "tvheadend": {
+        "upcoming": "Upcoming",
+        "finished": "Finished",
+        "failed": "Failed"
     }
 }

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -127,6 +127,7 @@ const components = {
   transmission: dynamic(() => import("./transmission/component")),
   tubearchivist: dynamic(() => import("./tubearchivist/component")),
   truenas: dynamic(() => import("./truenas/component")),
+  tvheadend: dynamic(() => import("./tvheadend/component")),
   unifi: dynamic(() => import("./unifi/component")),
   unmanic: dynamic(() => import("./unmanic/component")),
   uptimekuma: dynamic(() => import("./uptimekuma/component")),

--- a/src/widgets/tvheadend/component.jsx
+++ b/src/widgets/tvheadend/component.jsx
@@ -1,0 +1,89 @@
+import { useTranslation } from "next-i18next";
+
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+import Subscription from "widgets/tvheadend/subscription";
+
+function timeAgo(ticks) {
+  const now = Date.now(); // Current time in milliseconds
+  const inputTime = ticks * 1000; // Convert the input ticks from seconds to milliseconds
+  const difference = now - inputTime; // Difference in milliseconds
+
+  const seconds = Math.floor((difference / 1000) % 60);
+  const minutes = Math.floor((difference / (1000 * 60)) % 60);
+  const hours = Math.floor((difference / (1000 * 60 * 60)) % 24);
+  return { hours, minutes, seconds };
+}
+
+function timeAgoToString(ticks) {
+  const { hours, minutes, seconds } = timeAgo(ticks);
+  const parts = [];
+  if (hours > 0) {
+    parts.push(hours);
+  }
+  parts.push(minutes);
+  parts.push(seconds);
+
+  return parts.map((part) => part.toString().padStart(2, "0")).join(":");
+}
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+  const { widget } = service;
+
+  const { data: dvrData, error: dvrError } = useWidgetAPI(widget, "dvr", {
+    refreshInterval: 60000,
+  });
+  const { data: subscriptionsData, error: subscriptionsError } = useWidgetAPI(widget, "subscriptions", {
+    refreshInterval: 5000,
+  });
+
+  if (dvrError || subscriptionsError) {
+    const finalError = dvrError ?? subscriptionsError;
+    return <Container service={service} error={finalError} />;
+  }
+
+  if (!dvrData || !subscriptionsData) {
+    return (
+      <Container service={service}>
+        <Block label="tvheadend.upcoming" />
+        <Block label="tvheadend.finished" />
+        <Block label="tvheadend.failed" />
+      </Container>
+    );
+  }
+
+  const upcomingCount = dvrData.entries.filter((entry) => entry.sched_status === "scheduled").length;
+  const finishedCount = dvrData.entries.filter((entry) => entry.sched_status === "completed").length;
+  const failedCount = dvrData.entries.filter((entry) => entry.sched_status === "failed").length;
+
+  const hasSubscriptions = Array.isArray(subscriptionsData.entries) && subscriptionsData.entries.length > 0;
+
+  return (
+    <>
+      <Container service={service}>
+        <Block label="tvheadend.upcoming" value={t("common.number", { value: upcomingCount })} />
+        <Block label="tvheadend.finished" value={t("common.number", { value: finishedCount })} />
+        <Block label="tvheadend.failed" value={t("common.number", { value: failedCount })} />
+      </Container>
+      {hasSubscriptions &&
+        subscriptionsData.entries
+          .filter(
+            (entry) =>
+              entry.channel && 
+              entry.id &&
+              entry.start && // Only include valid entries
+              entry.state === "Running", // and being watched (Idle=downloading)
+          )
+          .sort((a, b) => a.channel.localeCompare(b.channel))
+          .map((subscription) => (
+            <Subscription
+              key={subscription.id}
+              channel={subscription.channel}
+              sinceStart={timeAgoToString(subscription.start)}
+            />
+          ))}
+    </>
+  );
+}

--- a/src/widgets/tvheadend/subscription.jsx
+++ b/src/widgets/tvheadend/subscription.jsx
@@ -1,0 +1,11 @@
+export default function Subscription({ channel, sinceStart }) {
+  return (
+    <div className="flex flex-col pb-1 mx-1">
+      <div className="text-theme-700 dark:text-theme-200 text-xs relative h-5 w-full rounded-md bg-theme-200/50 dark:bg-theme-900/20 mt-1">
+        <div className="absolute left-2 text-xs mt-[2px]">{channel}</div>
+        <div className="grow " />
+        <div className="self-center text-xs flex justify-end mr-2 mt-[2px]">{sinceStart}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/widgets/tvheadend/widget.js
+++ b/src/widgets/tvheadend/widget.js
@@ -1,0 +1,19 @@
+import genericProxyHandler from "utils/proxy/handlers/generic";
+
+const widget = {
+  api: "{url}/api/{endpoint}",
+  proxyHandler: genericProxyHandler,
+
+  mappings: {
+    dvr: {
+      endpoint: "dvr/entry/grid",
+      validate: ["entries"],
+    },
+    subscriptions: {
+      endpoint: "status/subscriptions",
+      validate: ["entries"],
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -118,6 +118,7 @@ import traefik from "./traefik/widget";
 import transmission from "./transmission/widget";
 import tubearchivist from "./tubearchivist/widget";
 import truenas from "./truenas/widget";
+import tvheadend from "./tvheadend/widget";
 import unifi from "./unifi/widget";
 import unmanic from "./unmanic/widget";
 import uptimekuma from "./uptimekuma/widget";
@@ -255,6 +256,7 @@ const widgets = {
   transmission,
   tubearchivist,
   truenas,
+  tvheadend,
   unifi,
   unifi_console: unifi,
   unmanic,


### PR DESCRIPTION
## Added a new widget for the Tvheadend service.

Added a new widget for the Tvheadend service. It displays the upcoming, finished and failed recordings as well as if any active streams are playing with the duration.

<img width="308" alt="image" src="https://github.com/user-attachments/assets/4d546060-5730-456d-998d-d6dd5ce53e99">

Below is an example of the stats API request it makes. It counts the rows based on the 'sched_status' field which then populates the blocks.
```
{
    "entries": [
        {
            "uuid": "c9a7a0caa299ec3a3545da7b502a4245",
            "enabled": true,
            "create": 1733720760,
            "watched": 0,
            "start": 1734129900,
            "start_extra": 0,
            "start_real": 1734129870,
            "stop": 1734137700,
            "stop_extra": 0,
            "stop_real": 1734137700,
            "duration": 7800,
            "channel": "566396545b2e2bb88a9ba0944b501397",
            "channel_icon": "imagecache/222",
            "channelname": "ITV1 HD",
            "image": "",
            "fanart_image": "",
            "title": {
                "eng": "You Only Live Twice"
            },
            "disp_title": "You Only Live Twice",
            "subtitle": {
                "eng": "Bond film starring Sean Connery and Donald Pleasance, 1967. 007 and the Japanese Secret Service's ninja force unite to find the culprit behind a series of incidents in space. [S,AD,HD]"
            },
            "disp_subtitle": "Bond film starring Sean Connery and Donald Pleasance, 1967. 007 and the Japanese Secret Service's ninja force unite to find the culprit behind a series of incidents in space. [S,AD,HD]",
            "disp_summary": "",
            "disp_description": "",
            "disp_extratext": "Bond film starring Sean Connery and Donald Pleasance, 1967. 007 and the Japanese Secret Service's ninja force unite to find the culprit behind a series of incidents in space. [S,AD,HD]",
            "pri": 6,
            "retention": 0,
            "removal": 0,
            "playposition": 0,
            "playcount": 0,
            "config_name": "8d0f5b7ae354d956d7fe5db25f5d0d24",
            "owner": "admin",
            "creator": "admin",
            "filename": "",
            "errorcode": 0,
            "errors": 0,
            "data_errors": 0,
            "dvb_eid": 19722,
            "noresched": false,
            "norerecord": false,
            "fileremoved": 0,
            "uri": "crid://www.itv.com/261943460",
            "autorec": "255eae47554f75f057a153a120a45408",
            "autorec_caption": " (Bond film - Created from EPG query)",
            "timerec": "",
            "timerec_caption": "",
            "parent": "",
            "child": "",
            "content_type": 1,
            "copyright_year": 0,
            "broadcast": 249773,
            "episode_disp": "",
            "url": "",
            "filesize": 0,
            "status": "Scheduled for recording",
            "sched_status": "scheduled",
            "duplicate": 0,
            "first_aired": 0,
            "comment": "Auto recording: Bond film - Created from EPG query",
            "category": [],
            "credits": {},
            "keyword": [],
            "genre": [
                16
            ],
            "age_rating": 0,
            "rating_label_uuid": "",
            "rating_icon": "",
            "rating_label": ""
        }
    ],
    "total": 6
}
```

Below is an example of the status API request it makes. It pulls out the channel and start keys per row.
```
{
    "entries": [
        {
            "id": 1172,
            "start": 1733722464,
            "errors": 0,
            "state": "Running",
            "hostname": "192.168.1.98",
            "username": "admin",
            "client": "TvhClient/933 LibVLC/3.0.19",
            "title": "HTTP",
            "channel": "BBC TWO HD",
            "service": "Sony CXD2880 #0 : DVB-T #0/DVB-T Network/618MHz/BBC TWO HD",
            "pids": [
                100,
                101,
                102,
                105,
                106
            ],
            "profile": "pass",
            "in": 510232,
            "out": 510232,
            "total_in": 934810824,
            "total_out": 934810824
        }
    ],
    "totalCount": 1
}
```

## Type of change

- [x] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.







