### PR TITLE
Enhancement: downloading torrents list for qbittorrent 

### DIFF
--- a/docs/widgets/services/qbittorrent.md
+++ b/docs/widgets/services/qbittorrent.md
@@ -15,4 +15,5 @@ widget:
   url: http://qbittorrent.host.or.ip
   username: username
   password: password
+  enableLeechProgress: true # optional, defaults to false
 ```

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -479,6 +479,9 @@ export function cleanServiceGroups(groups) {
           // proxmox
           node,
 
+          // qbittorrent
+          enableLeechProgress,
+
           // speedtest
           bitratePrecision,
 
@@ -670,6 +673,9 @@ export function cleanServiceGroups(groups) {
         }
         if (type === "spoolman") {
           if (spoolIds !== undefined) widget.spoolIds = spoolIds;
+        }
+        if (type === "qbittorrent") {
+          if (enableLeechProgress !== undefined) widget.enableLeechProgress = JSON.parse(enableLeechProgress);
         }
         return widget;
       });

--- a/src/widgets/qbittorrent/component.jsx
+++ b/src/widgets/qbittorrent/component.jsx
@@ -1,12 +1,38 @@
 import { useTranslation } from "next-i18next";
 
+import QueueEntry from "../../components/widgets/queue/queueEntry";
+
 import Container from "components/services/widget/container";
 import Block from "components/services/widget/block";
 import useWidgetAPI from "utils/proxy/use-widget-api";
 
+function formatTimeLeft(inputSeconds) {
+  let seconds = inputSeconds;
+  const years = Math.floor(seconds / (365 * 24 * 60 * 60));
+  seconds %= 365 * 24 * 60 * 60;  // Remaining seconds after subtracting years
+
+  const days = Math.floor(seconds / (24 * 60 * 60));
+  seconds %= 24 * 60 * 60;  // Remaining seconds after subtracting days
+
+  const hours = Math.floor(seconds / 3600);
+  seconds %= 3600;  // Remaining seconds after subtracting hours
+
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+
+  let result = '';
+  if (years > 0) result += `${years}y `;
+  if (days > 0) result += `${days}d `;
+  if (hours > 0) result += `${hours}h `;
+  if (minutes > 0) result += `${minutes}m `;
+  result += `${remainingSeconds}s`;
+
+  return result.trim();
+}
+
+
 export default function Component({ service }) {
   const { t } = useTranslation();
-
   const { widget } = service;
 
   const { data: torrentData, error: torrentError } = useWidgetAPI(widget, "torrents");
@@ -29,6 +55,7 @@ export default function Component({ service }) {
   let rateDl = 0;
   let rateUl = 0;
   let completed = 0;
+  const leechTorrents = [];
 
   for (let i = 0; i < torrentData.length; i += 1) {
     const torrent = torrentData[i];
@@ -37,16 +64,32 @@ export default function Component({ service }) {
     if (torrent.progress === 1) {
       completed += 1;
     }
+    if (torrent.state.includes("DL") || torrent.state === "downloading") {
+      leechTorrents.push(torrent);
+    }
   }
 
   const leech = torrentData.length - completed;
+  const enableLeechProgress = widget?.enableLeechProgress && Array.isArray(leechTorrents) && leechTorrents.length > 0;
 
   return (
-    <Container service={service}>
-      <Block label="qbittorrent.leech" value={t("common.number", { value: leech })} />
-      <Block label="qbittorrent.download" value={t("common.bibyterate", { value: rateDl, decimals: 1 })} />
-      <Block label="qbittorrent.seed" value={t("common.number", { value: completed })} />
-      <Block label="qbittorrent.upload" value={t("common.bibyterate", { value: rateUl, decimals: 1 })} />
-    </Container>
+    <>
+      <Container service={service}>
+        <Block label="qbittorrent.leech" value={t("common.number", { value: leech })} />
+        <Block label="qbittorrent.download" value={t("common.bibyterate", { value: rateDl, decimals: 1 })} />
+        <Block label="qbittorrent.seed" value={t("common.number", { value: completed })} />
+        <Block label="qbittorrent.upload" value={t("common.bibyterate", { value: rateUl, decimals: 1 })} />
+      </Container>
+      {enableLeechProgress &&
+        leechTorrents.map((queueEntry) => (
+          <QueueEntry
+            progress={(queueEntry.progress) * 100}
+            timeLeft={formatTimeLeft(queueEntry.eta)}
+            title={queueEntry.name}
+            activity={queueEntry.state}
+            key={`${queueEntry.name}-${queueEntry.amount_left}`}
+          />
+        ))}
+    </>
   );
 }

--- a/src/widgets/qbittorrent/component.jsx
+++ b/src/widgets/qbittorrent/component.jsx
@@ -45,7 +45,6 @@ export default function Component({ service }) {
   }
 
   const leech = torrentData.length - completed;
-  const enableLeechProgress = widget?.enableLeechProgress && Array.isArray(leechTorrents) && leechTorrents.length > 0;
 
   return (
     <>
@@ -55,7 +54,7 @@ export default function Component({ service }) {
         <Block label="qbittorrent.seed" value={t("common.number", { value: completed })} />
         <Block label="qbittorrent.upload" value={t("common.bibyterate", { value: rateUl, decimals: 1 })} />
       </Container>
-      {enableLeechProgress &&
+      {widget?.enableLeechProgress &&
         leechTorrents.map((queueEntry) => (
           <QueueEntry
             progress={queueEntry.progress * 100}

--- a/src/widgets/qbittorrent/component.jsx
+++ b/src/widgets/qbittorrent/component.jsx
@@ -21,11 +21,11 @@ function formatTimeLeft(inputSeconds) {
   const remainingSeconds = seconds % 60;
 
   let result = '';
-  if (years > 0) result += `${years}y `;
-  if (days > 0) result += `${days}d `;
-  if (hours > 0) result += `${hours}h `;
-  if (minutes > 0) result += `${minutes}m `;
-  result += `${remainingSeconds}s`;
+  if (years > 0) result = `over ${years}y`;
+  else if (days > 0) result = `over ${days}d`;
+  else if (hours > 0) result = `${hours}h ${minutes}m`;
+  else if (minutes > 0) result = `${minutes}m ${remainingSeconds}s`;
+  else result = `${remainingSeconds}s`;
 
   return result.trim();
 }

--- a/src/widgets/qbittorrent/component.jsx
+++ b/src/widgets/qbittorrent/component.jsx
@@ -9,18 +9,18 @@ import useWidgetAPI from "utils/proxy/use-widget-api";
 function formatTimeLeft(inputSeconds) {
   let seconds = inputSeconds;
   const years = Math.floor(seconds / (365 * 24 * 60 * 60));
-  seconds %= 365 * 24 * 60 * 60;  // Remaining seconds after subtracting years
+  seconds %= 365 * 24 * 60 * 60; // Remaining seconds after subtracting years
 
   const days = Math.floor(seconds / (24 * 60 * 60));
-  seconds %= 24 * 60 * 60;  // Remaining seconds after subtracting days
+  seconds %= 24 * 60 * 60; // Remaining seconds after subtracting days
 
   const hours = Math.floor(seconds / 3600);
-  seconds %= 3600;  // Remaining seconds after subtracting hours
+  seconds %= 3600; // Remaining seconds after subtracting hours
 
   const minutes = Math.floor(seconds / 60);
   const remainingSeconds = seconds % 60;
 
-  let result = '';
+  let result = "";
   if (years > 0) result = `over ${years}y`;
   else if (days > 0) result = `over ${days}d`;
   else if (hours > 0) result = `${hours}h ${minutes}m`;
@@ -29,7 +29,6 @@ function formatTimeLeft(inputSeconds) {
 
   return result.trim();
 }
-
 
 export default function Component({ service }) {
   const { t } = useTranslation();
@@ -83,7 +82,7 @@ export default function Component({ service }) {
       {enableLeechProgress &&
         leechTorrents.map((queueEntry) => (
           <QueueEntry
-            progress={(queueEntry.progress) * 100}
+            progress={queueEntry.progress * 100}
             timeLeft={formatTimeLeft(queueEntry.eta)}
             title={queueEntry.name}
             activity={queueEntry.state}

--- a/src/widgets/qbittorrent/component.jsx
+++ b/src/widgets/qbittorrent/component.jsx
@@ -6,30 +6,6 @@ import Container from "components/services/widget/container";
 import Block from "components/services/widget/block";
 import useWidgetAPI from "utils/proxy/use-widget-api";
 
-function formatTimeLeft(inputSeconds) {
-  let seconds = inputSeconds;
-  const years = Math.floor(seconds / (365 * 24 * 60 * 60));
-  seconds %= 365 * 24 * 60 * 60; // Remaining seconds after subtracting years
-
-  const days = Math.floor(seconds / (24 * 60 * 60));
-  seconds %= 24 * 60 * 60; // Remaining seconds after subtracting days
-
-  const hours = Math.floor(seconds / 3600);
-  seconds %= 3600; // Remaining seconds after subtracting hours
-
-  const minutes = Math.floor(seconds / 60);
-  const remainingSeconds = seconds % 60;
-
-  let result = "";
-  if (years > 0) result = `over ${years}y`;
-  else if (days > 0) result = `over ${days}d`;
-  else if (hours > 0) result = `${hours}h ${minutes}m`;
-  else if (minutes > 0) result = `${minutes}m ${remainingSeconds}s`;
-  else result = `${remainingSeconds}s`;
-
-  return result.trim();
-}
-
 export default function Component({ service }) {
   const { t } = useTranslation();
   const { widget } = service;
@@ -83,7 +59,7 @@ export default function Component({ service }) {
         leechTorrents.map((queueEntry) => (
           <QueueEntry
             progress={queueEntry.progress * 100}
-            timeLeft={formatTimeLeft(queueEntry.eta)}
+            timeLeft={t("common.duration", { value: queueEntry.eta })}
             title={queueEntry.name}
             activity={queueEntry.state}
             key={`${queueEntry.name}-${queueEntry.amount_left}`}


### PR DESCRIPTION
## Proposed change
This change adds a flag `enableLeechProgress` to the qbittorrent widget. It will show the progress of leech/s as shown in the screenshot. It also shows the status/state of the leech as well as the ETA. 
<img width="497" alt="Screenshot 2024-12-12 at 3 04 25 PM" src="https://github.com/user-attachments/assets/c49cc821-7ca3-4c7d-addb-e0541dcb0708" />


Closes #4374

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
