### PR TITLE
Documentation: Inform about url encoded values in synology widgets

### DIFF
--- a/docs/widgets/services/diskstation.md
+++ b/docs/widgets/services/diskstation.md
@@ -11,6 +11,8 @@ An optional 'volume' parameter can be supplied to specify which volume's free sp
 
 Allowed fields: `["uptime", "volumeAvailable", "resources.cpu", "resources.mem"]`.
 
+Username & password will be part of the url. You should use URL encoded value!
+
 To access these system metrics you need to connect to the DiskStation (`DSM`) with an account that is a member of the default `Administrators` group. That is because these metrics are requested from the API's `SYNO.Core.System` part that is only available to admin users. In order to keep the security impact as small as possible we can set the account in DSM up to limit the user's permissions inside the Synology system. In DSM 7.x, for instance, follow these steps:
 
 1. Create a new user, i.e. `remote_stats`.

--- a/docs/widgets/services/downloadstation.md
+++ b/docs/widgets/services/downloadstation.md
@@ -9,6 +9,8 @@ Note: the widget is not compatible with 2FA.
 
 Allowed fields: `["leech", "download", "seed", "upload"]`.
 
+Username & password will be part of the url. You should use URL encoded value!
+
 ```yaml
 widget:
   type: downloadstation


### PR DESCRIPTION
## Proposed change

- Improve documentation for synology widgets
- Mention that username & password should be url encoded as these data will be used in url query parameter

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
