### PR TITLE
Enhancement: downloading torrents list for deluge

### DIFF
--- a/docs/widgets/services/deluge.md
+++ b/docs/widgets/services/deluge.md
@@ -14,4 +14,5 @@ widget:
   type: deluge
   url: http://deluge.host.or.ip
   password: password # webui password
+  enableLeechProgress: true # optional, defaults to false
 ```

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -402,6 +402,9 @@ export function cleanServiceGroups(groups) {
           mappings,
           display,
 
+          // deluge, qbittorrent
+          enableLeechProgress,
+
           // diskstation
           volume,
 
@@ -478,9 +481,6 @@ export function cleanServiceGroups(groups) {
 
           // proxmox
           node,
-
-          // qbittorrent
-          enableLeechProgress,
 
           // speedtest
           bitratePrecision,
@@ -571,6 +571,9 @@ export function cleanServiceGroups(groups) {
           if (loadingStrategy) widget.loadingStrategy = loadingStrategy;
           if (allowScrolling) widget.allowScrolling = allowScrolling;
           if (refreshInterval) widget.refreshInterval = refreshInterval;
+        }
+        if (["deluge", "qbittorrent"].includes(type)) {
+          if (enableLeechProgress !== undefined) widget.enableLeechProgress = JSON.parse(enableLeechProgress);
         }
         if (["opnsense", "pfsense"].includes(type)) {
           if (wan) widget.wan = wan;
@@ -673,9 +676,6 @@ export function cleanServiceGroups(groups) {
         }
         if (type === "spoolman") {
           if (spoolIds !== undefined) widget.spoolIds = spoolIds;
-        }
-        if (type === "qbittorrent") {
-          if (enableLeechProgress !== undefined) widget.enableLeechProgress = JSON.parse(enableLeechProgress);
         }
         return widget;
       });

--- a/src/widgets/deluge/component.jsx
+++ b/src/widgets/deluge/component.jsx
@@ -1,5 +1,7 @@
 import { useTranslation } from "next-i18next";
 
+import QueueEntry from "../../components/widgets/queue/queueEntry";
+
 import Container from "components/services/widget/container";
 import Block from "components/services/widget/block";
 import useWidgetAPI from "utils/proxy/use-widget-api";
@@ -32,21 +34,38 @@ export default function Component({ service }) {
   let rateDl = 0;
   let rateUl = 0;
   let completed = 0;
+  const leechTorrents = [];
+
   for (let i = 0; i < keys.length; i += 1) {
     const torrent = torrents[keys[i]];
     rateDl += torrent.download_payload_rate;
     rateUl += torrent.upload_payload_rate;
     completed += torrent.total_remaining === 0 ? 1 : 0;
+    if (torrent.state === "Downloading") {
+      leechTorrents.push(torrent);
+    }
   }
 
   const leech = keys.length - completed || 0;
 
   return (
-    <Container service={service}>
-      <Block label="deluge.leech" value={t("common.number", { value: leech })} />
-      <Block label="deluge.download" value={t("common.byterate", { value: rateDl })} />
-      <Block label="deluge.seed" value={t("common.number", { value: completed })} />
-      <Block label="deluge.upload" value={t("common.byterate", { value: rateUl })} />
-    </Container>
+    <>
+      <Container service={service}>
+        <Block label="deluge.leech" value={t("common.number", { value: leech })} />
+        <Block label="deluge.download" value={t("common.byterate", { value: rateDl })} />
+        <Block label="deluge.seed" value={t("common.number", { value: completed })} />
+        <Block label="deluge.upload" value={t("common.byterate", { value: rateUl })} />
+      </Container>
+      {widget?.enableLeechProgress &&
+        leechTorrents.map((queueEntry) => (
+          <QueueEntry
+            progress={queueEntry.progress}
+            timeLeft={t("common.duration", { value: queueEntry.eta })}
+            title={queueEntry.name}
+            activity={queueEntry.state}
+            key={`${queueEntry.name}-${queueEntry.total_remaining}`}
+          />
+        ))}
+    </>
   );
 }

--- a/src/widgets/deluge/proxy.js
+++ b/src/widgets/deluge/proxy.js
@@ -17,6 +17,7 @@ const dataParams = [
     "download_payload_rate",
     "upload_payload_rate",
     "total_remaining",
+    "eta",
   ],
   {},
 ];


### PR DESCRIPTION
## Proposed change

This change adds a flag enableLeechProgress to the deluge widget. It will show the progress of leech/s as shown in the screenshot. It also shows the status/state of the leech as well as the ETA.
<img width="493" alt="Screenshot 2024-12-17 at 2 01 20 PM" src="https://github.com/user-attachments/assets/9b45a9bc-73c9-482c-9195-cf8542bf6f42" />


## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
