### PR TITLE
Fix inaccurate Chinese translations for wanStatus field in pfSense widget

### DIFF
--- a/docs/widgets/services/headscale.md
+++ b/docs/widgets/services/headscale.md
@@ -14,6 +14,7 @@ Allowed fields: `["name", "address", "last_seen", "status"]`.
 ```yaml
 widget:
   type: headscale
+  url: http://headscale.host.or.ip:port
   nodeId: nodeid
   key: headscaleapiaccesstoken
 ```

--- a/public/locales/zh-CN/common.json
+++ b/public/locales/zh-CN/common.json
@@ -630,8 +630,8 @@
         "load": "平均负载",
         "memory": "内存",
         "wanStatus": "WAN 状态",
-        "up": "上传",
-        "down": "下载",
+        "up": "连接",
+        "down": "断开",
         "temp": "温度",
         "disk": "磁盘",
         "wanIP": "WAN IP"


### PR DESCRIPTION

## Proposed change

In the pfSense widget, the Chinese translations for the wanStatus field values up and down are inaccurate.

The current translations are '上传' (which means upload) and '下载' (which means download).
I have replaced them with '连接' (which means Connected) and '断开' (which means Disconnected) respectively.

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [x] Other (please explain)

This change only involves I18n modifications and does not affect functionality.

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
