### PR TITLE
Enhancement: add string replacements to docker auto discovery labels

### DIFF
--- a/docs/configs/docker.md
+++ b/docs/configs/docker.md
@@ -136,6 +136,29 @@ When your Docker instance has been properly configured, this service will be aut
 
 **When using docker swarm use _deploy/labels_**
 
+
+### Replacement strings in labels
+
+Homepage will substitue `${name}` and `${image}` with the container name and image respectively.
+
+```yaml
+services:
+  emby:
+    image: lscr.io/linuxserver/emby:latest
+    container_name: emby
+    ports:
+      - 8096:8096
+    restart: unless-stopped
+    labels:
+      - homepage.group=Media
+      - homepage.name=$${name} # Will be replaced with 'emby'
+      - homepage.icon=emby.png
+      - homepage.href=http://emby.home/
+      - homepage.description=$${image} # Will be replaced with 'lscr.io/linuxserver/emby:latest'
+```
+Note the double `$$` used in YAML. How to enter a `$` character might differ depending on you service configuration language.
+
+
 ## Widgets
 
 You may also configure widgets, along with the standard service entry, again, using dot notation.

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -93,6 +93,12 @@ export async function servicesFromDocker() {
           let constructedService = null;
           const containerLabels = isSwarm ? shvl.get(container, "Spec.Labels") : container.Labels;
           const containerName = isSwarm ? shvl.get(container, "Spec.Name") : container.Names[0];
+          const containerImage = isSwarm ? shvl.get(container, "Spec.Image") : container.Image;
+
+          const replacements = {
+            name: containerName.replace(/^\//, ""),
+            image: containerImage
+          }
 
           Object.keys(containerLabels).forEach((label) => {
             if (label.startsWith("homepage.")) {
@@ -114,6 +120,9 @@ export async function servicesFromDocker() {
               if (value === "widget.version") {
                 substitutedVal = parseInt(substitutedVal, 10);
               }
+              Object.keys(replacements).forEach((replacement) => {
+                substitutedVal = substitutedVal.replace(`\${${replacement}}`, replacements[replacement]);
+              });
               shvl.set(constructedService, value, substitutedVal);
             }
           });


### PR DESCRIPTION
## Proposed change

Adds string replacements to the automatic docker service discovery. `${name}` and `${image}` will be automatically replaced with the container name and image respectively.

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
