### PR TITLE
fix: changing strict equals to just equals to allow string value in widget.version

### DIFF
--- a/src/widgets/beszel/proxy.js
+++ b/src/widgets/beszel/proxy.js
@@ -46,7 +46,7 @@ export default async function beszelProxyHandler(req, res) {
     if (widget) {
       const url = new URL(formatApiCall(widgets[widget.type].api, { endpoint, ...widget }));
       let authEndpointVersion = "authv1";
-      if (widget.version === 2) authEndpointVersion = "authv2";
+      if (widget.version == 2) authEndpointVersion = "authv2";
       const loginUrl = formatApiCall(widgets[widget.type].api, {
         endpoint: widgets[widget.type].mappings[authEndpointVersion].endpoint,
         ...widget,


### PR DESCRIPTION


The strict equality is failing here for me because I'm using docker labels in the docker-compose.yaml for the version and I think the values get interpreted as strings.

    labels:
      - homepage.widget.username=xxxxx@email.com
      - homepage.widget.password=xxxxxxx
      - homepage.widget.systemId=rrsa25j8p920ukn
      - homepage.widget.version=2

## Type of change

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
