### PR TITLE
Fix: correct iconsOnly bookmark group spacing

### DIFF
--- a/src/components/bookmarks/group.jsx
+++ b/src/components/bookmarks/group.jsx
@@ -24,9 +24,9 @@ export default function BookmarksGroup({
     <div
       key={bookmarks.name}
       className={classNames(
-        "bookmark-group",
+        "bookmark-group flex-1 overflow-hidden",
         layout?.style === "row" ? "basis-full" : "basis-full md:basis-1/4 lg:basis-1/5 xl:basis-1/6",
-        layout?.header === false ? "flex-1 px-1 -my-1 overflow-hidden" : "flex-1 p-1 overflow-hidden",
+        layout?.header === false ? "px-1" : "p-1 pb-0",
       )}
     >
       <Disclosure defaultOpen={!(layout?.initiallyCollapsed ?? groupsInitiallyCollapsed) ?? true}>

--- a/src/components/bookmarks/list.jsx
+++ b/src/components/bookmarks/list.jsx
@@ -5,15 +5,14 @@ import { columnMap } from "../../utils/layout/columns";
 import Item from "components/bookmarks/item";
 
 export default function List({ bookmarks, layout, bookmarksStyle }) {
-  let classes =
-    layout?.style === "row" ? `grid ${columnMap[layout?.columns]} gap-x-2` : "flex flex-col mt-3 bookmark-list";
+  let classes = layout?.style === "row" ? `grid ${columnMap[layout?.columns]} gap-x-2` : "flex flex-col bookmark-list";
   const style = {};
   if (layout?.iconsOnly || bookmarksStyle === "icons") {
-    classes = "grid gap-3 mt-3 bookmark-list";
+    classes = "grid gap-2 bookmark-list";
     style.gridTemplateColumns = "repeat(auto-fill, minmax(60px, 1fr))";
   }
   return (
-    <ul className={classNames(classes)} style={style}>
+    <ul className={classNames(classes, "mb-2", layout?.header === false ? "" : "mt-3")} style={style}>
       {bookmarks.map((bookmark) => (
         <Item
           key={`${bookmark.name}-${bookmark.href}`}


### PR DESCRIPTION
<!--
==== STOP ====================
======== STOP ================
============ STOP ============
================ STOP ========
==================== STOP ====

⚠️ Before opening this pull request please review the guidelines in the checklist below.
If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.
-->

## Proposed change

<img width="411" alt="Screenshot 2024-12-27 at 4 00 39 PM" src="https://github.com/user-attachments/assets/79181904-38ef-4905-89c2-03eed6eb5538" />
<img width="375" alt="Screenshot 2024-12-27 at 4 07 58 PM" src="https://github.com/user-attachments/assets/c657d625-8799-43a9-bd65-bab2bf686ae9" />
<img width="418" alt="Screenshot 2024-12-27 at 4 07 43 PM" src="https://github.com/user-attachments/assets/f1cad329-0dbe-4cba-9957-f2638f04c3ce" />
<img width="298" alt="Screenshot 2024-12-27 at 4 11 29 PM" src="https://github.com/user-attachments/assets/db841068-c7e9-44a0-972d-eae9842d2441" />


Closes #4500

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
