### PR TITLE
Enhancement: add duration format to customapi widget

### DIFF
--- a/docs/widgets/services/customapi.md
+++ b/docs/widgets/services/customapi.md
@@ -67,7 +67,7 @@ Supported formats for the values are `text`, `number`, `float`, `percent`, `dura
 The `dateStyle` and `timeStyle` options of the `date` format are passed directly to [Intl.DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat) and the `style` and `numeric` options of `relativeDate` are passed to [Intl.RelativeTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/RelativeTimeFormat).
 
 The `duration` format expects the duration to be specified in seconds. The `scale` transformation tool can be used if a conversion is required.
- 
+
 The `size` format will return the length of the array or string, or the number of keys in an object. This is then formatted as `number`.
 
 ## Example

--- a/docs/widgets/services/customapi.md
+++ b/docs/widgets/services/customapi.md
@@ -62,10 +62,12 @@ widget:
       format: size
 ```
 
-Supported formats for the values are `text`, `number`, `float`, `percent`, `bytes`, `bitrate`, `size`, `date` and `relativeDate`.
+Supported formats for the values are `text`, `number`, `float`, `percent`, `duration`, `bytes`, `bitrate`, `size`, `date` and `relativeDate`.
 
 The `dateStyle` and `timeStyle` options of the `date` format are passed directly to [Intl.DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat) and the `style` and `numeric` options of `relativeDate` are passed to [Intl.RelativeTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/RelativeTimeFormat).
 
+The `duration` format expects the duration to be specified in seconds. The `scale` transformation tool can be used if a conversion is required.
+ 
 The `size` format will return the length of the array or string, or the number of keys in an object. This is then formatted as `number`.
 
 ## Example

--- a/src/widgets/customapi/component.jsx
+++ b/src/widgets/customapi/component.jsx
@@ -78,6 +78,9 @@ function formatValue(t, mapping, rawValue) {
     case "percent":
       value = t("common.percent", { value });
       break;
+    case "duration":
+      value = t("common.duration", { value });
+      break;
     case "bytes":
       value = t("common.bytes", { value });
       break;


### PR DESCRIPTION
<!--
==== STOP ====================
======== STOP ================
============ STOP ============
================ STOP ========
==================== STOP ====

⚠️ Before opening this pull request please review the guidelines in the checklist below.
If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.
-->

## Proposed change

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

*** Please see the development guidelines for new widgets: https://gethomepage.dev/more/development/#service-widget-guidelines
*** If you do not follow these guidelines your PR will likely be closed without review.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

This PR adds a `duration` format to the customapi widget. This allows formatting durations (in seconds) in to a more human-readable format, e.g. `1h20m` instead of `4,850`.


## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
