### PR TITLE
Fix: quick launch not showing  nested services

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -168,11 +168,10 @@ const headerStyles = {
 
 function getAllServices(services) {
   function get(sg) {
-    let nestedServices = [];
+    let nestedServices = [...sg.services];
     if (sg.groups.length > 0) {
       nestedServices = [...nestedServices, ...sg.groups.map(get).flat()];
     }
-    nestedServices = [...nestedServices, ...sg.services.flat()];
     return nestedServices;
   }
 

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -166,6 +166,22 @@ const headerStyles = {
   boxedWidgets: "m-5 mb-0 sm:m-9 sm:mb-0 sm:mt-1",
 };
 
+function getAllServices(services) {
+  function get(sg){
+    let nestedServices = [];
+    if (sg.groups.length > 0) {
+      nestedServices = [...nestedServices, ...sg.groups.map(get).flat()]
+    }
+    nestedServices = [...nestedServices, ...sg.services.flat()]
+    return nestedServices;
+  }
+
+  return [
+    ...services.map(get).flat()
+  ];
+
+}
+
 function Home({ initialSettings }) {
   const { i18n } = useTranslation();
   const { theme, setTheme } = useContext(ThemeContext);
@@ -183,8 +199,8 @@ function Home({ initialSettings }) {
   const { data: widgets } = useSWR("/api/widgets");
 
   const servicesAndBookmarks = [
-    ...services.map((sg) => sg.services).flat(),
     ...bookmarks.map((bg) => bg.bookmarks).flat(),
+    ...getAllServices(services)
   ].filter((i) => i?.href);
 
   useEffect(() => {

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -167,19 +167,16 @@ const headerStyles = {
 };
 
 function getAllServices(services) {
-  function get(sg){
+  function get(sg) {
     let nestedServices = [];
     if (sg.groups.length > 0) {
-      nestedServices = [...nestedServices, ...sg.groups.map(get).flat()]
+      nestedServices = [...nestedServices, ...sg.groups.map(get).flat()];
     }
-    nestedServices = [...nestedServices, ...sg.services.flat()]
+    nestedServices = [...nestedServices, ...sg.services.flat()];
     return nestedServices;
   }
 
-  return [
-    ...services.map(get).flat()
-  ];
-
+  return [...services.map(get).flat()];
 }
 
 function Home({ initialSettings }) {
@@ -198,10 +195,9 @@ function Home({ initialSettings }) {
   const { data: bookmarks } = useSWR("/api/bookmarks");
   const { data: widgets } = useSWR("/api/widgets");
 
-  const servicesAndBookmarks = [
-    ...bookmarks.map((bg) => bg.bookmarks).flat(),
-    ...getAllServices(services)
-  ].filter((i) => i?.href);
+  const servicesAndBookmarks = [...bookmarks.map((bg) => bg.bookmarks).flat(), ...getAllServices(services)].filter(
+    (i) => i?.href,
+  );
 
   useEffect(() => {
     if (settings.language) {


### PR DESCRIPTION
## Proposed change

Fix for quick launch not showing nested services.

The issue can be reproduced with the following `services.yaml`, and then searching for "c" only shows `NonNestedCalendar`.

```yaml

- NonNested:
  - NonNestedCalendar:
      href: http://google.com
      widget:
        type: calendar

- NestedParent:
  - Nested:
    - NestedCalendar:
        href: http://google.com
        widget:
          type: calendar

- NestedNestedParent:
  - Nested1:
    - Nested2:
      - DoubleyNestedCalendar:
          href: http://google.com
          widget:
            type: calendar

- NestedNestedNestedParent:
  - NestedNestedParent:
    - Nested1:
      - Nested2:
        - FullyNestedCalendar:
            href: http://google.com
            widget:
              type: calendar
```

![image](https://github.com/user-attachments/assets/8056a25e-f24f-4f8b-9cc7-c884db82dcd5)


After this fix, searching for "c" finds both the non nested and all the nested services:

![fixed](https://github.com/user-attachments/assets/f42a8e9d-710d-474e-8120-906a648b89b5)

## Type of change

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
