### PR TITLE
Chore: migrate dashboard-icons to homarr-labs

### DIFF
--- a/docs/configs/services.md
+++ b/docs/configs/services.md
@@ -134,7 +134,7 @@ Services may have descriptions,
 
 ## Icons
 
-Services may have an icon attached to them, you can use icons from [Dashboard Icons](https://github.com/walkxcode/dashboard-icons) automatically, by passing the name of the icon, with, or without `.png` or with `.svg` to use the svg version.
+Services may have an icon attached to them, you can use icons from [Dashboard Icons](https://github.com/homarr-labs/dashboard-icons) automatically, by passing the name of the icon, with, or without `.png` or with `.svg` to use the svg version.
 
 You can also specify prefixed icons from:
 

--- a/docs/configs/services.md
+++ b/docs/configs/services.md
@@ -134,7 +134,7 @@ Services may have descriptions,
 
 ## Icons
 
-Services may have an icon attached to them, you can use icons from [Dashboard Icons](https://github.com/homarr-labs/dashboard-icons) automatically, by passing the name of the icon, with, or without `.png` or with `.svg` to use the svg version.
+Services may have an icon attached to them, you can use icons from [Dashboard Icons](https://github.com/homarr-labs/dashboard-icons) automatically, by passing the name of the icon, with, or without `.png`, `.webp` or `.svg` to specify the desired version.
 
 You can also specify prefixed icons from:
 

--- a/src/components/resolvedicon.jsx
+++ b/src/components/resolvedicon.jsx
@@ -116,27 +116,29 @@ export default function ResolvedIcon({ icon, width = 32, height = 32, alt = "log
     );
   }
 
+  if (icon.endsWith(".webp")) {
+    const iconName = icon.replace(".webp", "");
+    return (
+      <Image
+        src={`https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/${iconName}.webp`}
+        width={width}
+        height={height}
+        style={{
+          width,
+          height,
+          objectFit: "contain",
+          maxHeight: "100%",
+          maxWidth: "100%",
+        }}
+        alt={alt}
+      />
+    );
+  }
+
   const iconName = icon.replace(".png", "");
   return (
     <Image
       src={`https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/${iconName}.png`}
-      width={width}
-      height={height}
-      style={{
-        width,
-        height,
-        objectFit: "contain",
-        maxHeight: "100%",
-        maxWidth: "100%",
-      }}
-      alt={alt}
-    />
-  );
-
-  const iconName = icon.replace(".webp", "");
-  return (
-    <Image
-      src={`https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/${iconName}.webp`}
       width={width}
       height={height}
       style={{

--- a/src/components/resolvedicon.jsx
+++ b/src/components/resolvedicon.jsx
@@ -101,7 +101,7 @@ export default function ResolvedIcon({ icon, width = 32, height = 32, alt = "log
     const iconName = icon.replace(".svg", "");
     return (
       <Image
-        src={`https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/svg/${iconName}.svg`}
+        src={`https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/${iconName}.svg`}
         width={width}
         height={height}
         style={{
@@ -119,7 +119,24 @@ export default function ResolvedIcon({ icon, width = 32, height = 32, alt = "log
   const iconName = icon.replace(".png", "");
   return (
     <Image
-      src={`https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/${iconName}.png`}
+      src={`https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/${iconName}.png`}
+      width={width}
+      height={height}
+      style={{
+        width,
+        height,
+        objectFit: "contain",
+        maxHeight: "100%",
+        maxWidth: "100%",
+      }}
+      alt={alt}
+    />
+  );
+
+  const iconName = icon.replace(".webp", "");
+  return (
+    <Image
+      src={`https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/webp/${iconName}.webp`}
       width={width}
       height={height}
       style={{


### PR DESCRIPTION
Info: https://github.com/homarr-labs/dashboard-icons/discussions/797#discussioncomment-11736264.

_Note: The walkxcode/dashboard-icons repository will continue to function indefinitely but may no longer receive updates._