### PR TITLE
Documentation: add note about clearing UniFi cache non-docker

### DIFF
--- a/docs/widgets/services/unifi-controller.md
+++ b/docs/widgets/services/unifi-controller.md
@@ -19,7 +19,7 @@ Allowed fields: `["uptime", "wan", "lan", "lan_users", "lan_devices", "wlan", "w
 
 !!! hint
 
-    If you enter e.g. incorrect credentials and receive an "API Error", you may need to recreate the container to clear the cache.
+    If you enter e.g. incorrect credentials and receive an "API Error", you may need to recreate the container or restart the service to clear the cache.
 
 ```yaml
 widget:


### PR DESCRIPTION
## Proposed change

When users who have API errors in Unifi make changes, the cache is not cleared automatically.  This is covered in the documentation for Docker users, but not for non-Docker users.  This is a minor documentation change to add a hint for non-docker users to try restarting the service. 

Closes # N/A 

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [x] Documentation only
- [ ] Other (please explain)

## Checklist:

- [X] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
