### PR TITLE
[Bug fix] Fixed a wrong translation

### DIFF
--- a/public/locales/uk/common.json
+++ b/public/locales/uk/common.json
@@ -291,7 +291,7 @@
         "queries": "Запити",
         "blocked": "Заблоковано",
         "blocked_percent": "Заблоковано %",
-        "gravity": "Гравітація"
+        "gravity": "Доменів в списку"
     },
     "adguard": {
         "queries": "Запити",


### PR DESCRIPTION
The previous translation used the word "gravity," which was incorrect and unrelated to "Domains on Adlists."  
This PR corrects the translation to reflect the intended meaning.