### PR TITLE
Add other statuses to Healthchecks widget

### DIFF
--- a/docs/widgets/services/healthchecks.md
+++ b/docs/widgets/services/healthchecks.md
@@ -5,7 +5,7 @@ description: Health checks Widget Configuration
 
 Learn more about [Health Checks](https://github.com/healthchecks/healthchecks).
 
-Specify a single check by including the `uuid` field or show the total 'up' and 'down' for all
+Specify a single check by including the `uuid` field or show the toal 'up', total 'down', total 'other' (new, paused & grace) and overall total for all
 checks by leaving off the `uuid` field.
 
 To use the Health Checks widget, you first need to generate an API key.
@@ -14,7 +14,7 @@ To use the Health Checks widget, you first need to generate an API key.
 2. Click on API key (read-only) and then click _Create_.
 3. Copy the API key that is generated for you.
 
-Allowed fields: `["status", "last_ping"]` for single checks, `["up", "down"]` for total stats.
+Allowed fields: `["status", "last_ping"]` for single checks, `["up", "down", "other", "total"]` for total stats.
 
 ```yaml
 widget:

--- a/docs/widgets/services/healthchecks.md
+++ b/docs/widgets/services/healthchecks.md
@@ -5,7 +5,7 @@ description: Health checks Widget Configuration
 
 Learn more about [Health Checks](https://github.com/healthchecks/healthchecks).
 
-Specify a single check by including the `uuid` field or show the toal 'up', total 'down', total 'other' (new, paused & grace) and overall total for all
+Specify a single check by including the `uuid` field or show the total 'up', total 'down', total 'other' (new, paused & grace) and overall total for all
 checks by leaving off the `uuid` field.
 
 To use the Health Checks widget, you first need to generate an API key.

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -531,6 +531,8 @@
         "grace": "In Grace Period",
         "down": "Down",
         "paused": "Paused",
+        "other": "Other",
+        "total": "Total",
         "status": "Status",
         "last_ping": "Last Ping",
         "never": "No pings yet"

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -531,6 +531,8 @@
         "grace": "In de respijt periode",
         "down": "Offline",
         "paused": "Gepauzeerd",
+        "other": "Overig",
+        "total": "Totaal",
         "status": "Status",
         "last_ping": "Laatste Ping",
         "never": "Nog geen pings"

--- a/src/skeleton/services.yaml
+++ b/src/skeleton/services.yaml
@@ -2,17 +2,14 @@
 # For configuration options and examples, please see:
 # https://gethomepage.dev/configs/services/
 
-- My First Group:
-    - My First Service:
-        href: http://localhost/
-        description: Homepage is awesome
-
-- My Second Group:
-    - My Second Service:
-        href: http://localhost/
-        description: Homepage is the best
-
 - My Third Group:
     - My Third Service:
         href: http://localhost/
         description: Homepage is 😎
+    - Healthchecks - General (6):
+        icon: healthchecks.png
+        href: http://healthchecks.home
+        widget:
+          type: healthchecks
+          url: http://healthchecks.home
+          key: HoRf-AQOVvXaMjtB4b5tB91FP6qMbgxq

--- a/src/skeleton/services.yaml
+++ b/src/skeleton/services.yaml
@@ -2,14 +2,17 @@
 # For configuration options and examples, please see:
 # https://gethomepage.dev/configs/services/
 
+- My First Group:
+    - My First Service:
+        href: http://localhost/
+        description: Homepage is awesome
+
+- My Second Group:
+    - My Second Service:
+        href: http://localhost/
+        description: Homepage is the best
+
 - My Third Group:
     - My Third Service:
         href: http://localhost/
         description: Homepage is 😎
-    - Healthchecks - General (6):
-        icon: healthchecks.png
-        href: http://healthchecks.home
-        widget:
-          type: healthchecks
-          url: http://healthchecks.home
-          key: HoRf-AQOVvXaMjtB4b5tB91FP6qMbgxq

--- a/src/widgets/healthchecks/component.jsx
+++ b/src/widgets/healthchecks/component.jsx
@@ -30,18 +30,23 @@ function formatDate(dateString) {
 function countStatus(data) {
   let upCount = 0;
   let downCount = 0;
+  let otherCount = 0;
+  let totalCount = 0;
 
   if (data.checks) {
     data.checks.forEach((check) => {
+      totalCount += 1;
       if (check.status === "up") {
         upCount += 1;
       } else if (check.status === "down") {
         downCount += 1;
+      } else {
+        otherCount += 1;
       }
     });
   }
 
-  return { upCount, downCount };
+  return { upCount, downCount, otherCount, totalCount };
 }
 
 export default function Component({ service }) {
@@ -65,7 +70,7 @@ export default function Component({ service }) {
 
   const hasUuid = !!widget?.uuid;
 
-  const { upCount, downCount } = countStatus(data);
+  const { upCount, downCount, otherCount, totalCount } = countStatus(data);
 
   return hasUuid ? (
     <Container service={service}>
@@ -79,6 +84,8 @@ export default function Component({ service }) {
     <Container service={service}>
       <Block label="healthchecks.up" value={upCount} />
       <Block label="healthchecks.down" value={downCount} />
+      <Block label="healthchecks.other" value={otherCount} />
+      <Block label="healthchecks.total" value={totalCount} />
     </Container>
   );
 }


### PR DESCRIPTION
## Proposed change
This change contains changes to the Healthchecks.io widget. It's a fairly small change that adds 2 blocks (bringing the total to the maximum of 4).

Currently the widget supports "up" and "down", based on the [documentation](https://healthchecks.io/docs/api/#list-checks) "The possible values for the status field are: new, up, grace, down, and paused.". In short, the "new", "paused" and "grace" statuses would not show up on the dashboard.

I've grouped them in a block "other" and added the total number of checks as well, so you always have the complete picture.

Also, it's my first ever PR on GitHub, please be understandig of this, I tried to check all the guidelines to make the process as smooth as possible :).

Closes #4706 

## Type of change
- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
