### PR TITLE
Fix: Timezone-aware Date comparison for Calendar integration

### DIFF
--- a/src/widgets/calendar/event.jsx
+++ b/src/widgets/calendar/event.jsx
@@ -39,4 +39,5 @@ export default function Event({ event, colorVariants, showDate = false, showTime
     </div>
   );
 }
-export const compareDateTimezone = (date, event) => date.startOf("day").toISODate() === event.date.startOf("day").toISODate();
+export const compareDateTimezone = (date, event) =>
+  date.startOf("day").toISODate() === event.date.startOf("day").toISODate();

--- a/src/widgets/calendar/event.jsx
+++ b/src/widgets/calendar/event.jsx
@@ -39,4 +39,4 @@ export default function Event({ event, colorVariants, showDate = false, showTime
     </div>
   );
 }
-export const compareDateTimezone = (date, event) => date.startOf("day").ts === event.date.startOf("day").ts;
+export const compareDateTimezone = (date, event) => date.startOf("day").toISODate() === event.date.startOf("day").toISODate();

--- a/src/widgets/calendar/monthly.jsx
+++ b/src/widgets/calendar/monthly.jsx
@@ -12,6 +12,9 @@ export function Day({ weekNumber, weekday, events, colorVariants, showDate, setS
   const cellDate = showDate.set({ weekday, weekNumber, weekYear: showDate.year }).startOf("day");
   const filteredEvents = events?.filter((event) => compareDateTimezone(cellDate, event));
 
+  console.log(`cellDate = ${cellDate.startOf("day").ts}`)
+  console.log(`events = ${events[0].date.startOf("day").ts}`)
+
   const dayStyles = (displayDate) => {
     let style = "h-9 ";
 
@@ -40,7 +43,6 @@ export function Day({ weekNumber, weekday, events, colorVariants, showDate, setS
 
     return style;
   };
-
   return (
     <button
       key={`day${weekday}${weekNumber}}`}
@@ -107,7 +109,6 @@ export default function Monthly({ service, colorVariants, events, showDate, setS
 
   const eventsArray = Object.keys(events).map((eventKey) => events[eventKey]);
   eventsArray.sort((a, b) => a.date - b.date);
-
   return (
     <div className="w-full text-center">
       <div className="flex-col">

--- a/src/widgets/calendar/monthly.jsx
+++ b/src/widgets/calendar/monthly.jsx
@@ -12,9 +12,6 @@ export function Day({ weekNumber, weekday, events, colorVariants, showDate, setS
   const cellDate = showDate.set({ weekday, weekNumber, weekYear: showDate.year }).startOf("day");
   const filteredEvents = events?.filter((event) => compareDateTimezone(cellDate, event));
 
-  console.log(`cellDate = ${cellDate.startOf("day").ts}`)
-  console.log(`events = ${events[0].date.startOf("day").ts}`)
-
   const dayStyles = (displayDate) => {
     let style = "h-9 ";
 
@@ -43,6 +40,7 @@ export function Day({ weekNumber, weekday, events, colorVariants, showDate, setS
 
     return style;
   };
+
   return (
     <button
       key={`day${weekday}${weekNumber}}`}
@@ -109,6 +107,7 @@ export default function Monthly({ service, colorVariants, events, showDate, setS
 
   const eventsArray = Object.keys(events).map((eventKey) => events[eventKey]);
   eventsArray.sort((a, b) => a.date - b.date);
+
   return (
     <div className="w-full text-center">
       <div className="flex-col">


### PR DESCRIPTION
## Proposed change
If Sonarr/Radarr/Lidarr and the Homepage instance are running in separate timezone configurations, then the calendar in Monthly view will show blank due to an error in time comparisons of the two systems.

Current mainline version of this comparison compares the Unix Timestamp of the beginning of the day, which will differ from two same days in different timezones.  This PR changes is to compare the ISO Datestring instead (removing Time).

Closes # (no issue filed)
## Type of change

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
