### PR TITLE
Enhancement: support gamedig numplayers

### DIFF
--- a/src/widgets/gamedig/proxy.js
+++ b/src/widgets/gamedig/proxy.js
@@ -24,7 +24,7 @@ export default async function gamedigProxyHandler(req, res) {
       online: true,
       name: serverData.name,
       map: serverData.map,
-      players: serverData.numplayers,
+      players: serverData.players?.length ?? serverData.numplayers,
       maxplayers: serverData.maxplayers,
       bots: serverData.bots.length,
       ping: serverData.ping,

--- a/src/widgets/gamedig/proxy.js
+++ b/src/widgets/gamedig/proxy.js
@@ -24,7 +24,7 @@ export default async function gamedigProxyHandler(req, res) {
       online: true,
       name: serverData.name,
       map: serverData.map,
-      players: serverData.players.length,
+      players: serverData.numplayers,
       maxplayers: serverData.maxplayers,
       bots: serverData.bots.length,
       ping: serverData.ping,


### PR DESCRIPTION
## Proposed change

gamedig's default value to get the number of players in a game **has changed to be** `numplayers`. No longer `players` - which is not always present, and which homepage currently uses. Initially, I thought it was an issue with gamedig, but it was a conscious choice. See: https://github.com/gamedig/node-gamedig/pull/676

>players is only present if gamedig knows details (like names) about specific players, and numplayers is always present.

This change breaks current instances of homepage gamedig widgets, one example being mumble (mumbleping protocol, the one without using a murmur plugin). Another being Minecraft Bedrock edition.

Further information:
* https://github.com/search?q=repo%3Agamedig%2Fnode-gamedig%20numplayers&type=code
* ![image](https://github.com/user-attachments/assets/4c9c808e-25e8-4507-86c5-9270c05e6a1f)

I imagine the issue may've been present since:
* https://github.com/gethomepage/homepage/commit/2aa7a3898b31bbf4263614d8722571c3dfc0c892 
* https://github.com/gamedig/node-gamedig/blob/master/CHANGELOG.md#games-1

See two discussions:
1. https://github.com/gethomepage/homepage/discussions/4628
2. https://github.com/gethomepage/homepage/discussions/4759

## Type of change

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
   - Not applicable. Users will not have to change anything in their configs.
- [ ] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
   - Not applicable. I read service widget, but this is a bug fix, not a new service.
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.