### PR TITLE
Documentation: correct documentation for multiple widgets in docker labels

### DIFF
--- a/docs/configs/docker.md
+++ b/docs/configs/docker.md
@@ -157,12 +157,12 @@ Multiple widgets can be specified by incrementing the index, e.g.
 
 ```yaml
 labels: ...
-  - homepage.widget[0].type=emby
-  - homepage.widget[0].url=http://emby.home
-  - homepage.widget[0].key=yourembyapikeyhere
-  - homepage.widget[1].type=uptimekuma
-  - homepage.widget[1].url=http://uptimekuma.home
-  - homepage.widget[1].slug=youreventslughere
+  - homepage.widgets[0].type=emby
+  - homepage.widgets[0].url=http://emby.home
+  - homepage.widgets[0].key=yourembyapikeyhere
+  - homepage.widgets[1].type=uptimekuma
+  - homepage.widgets[1].url=http://uptimekuma.home
+  - homepage.widgets[1].slug=youreventslughere
 ```
 
 You can add specify fields for e.g. the [CustomAPI](../widgets/services/customapi.md) widget by using array-style dot notation:


### PR DESCRIPTION
<!--
==== STOP ====================
======== STOP ================
============ STOP ============
================ STOP ========
==================== STOP ====

⚠️ Before opening this pull request please review the guidelines in the checklist below.

If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.
-->

## Proposed change

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->
Fix incorrect documentation for using multiple widgets in docker tags. Need to use `widgets` instead of `widget`.

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [x] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
