### PR TITLE
Enhancement: Improve gamedig player number estimate

### DIFF
--- a/src/widgets/gamedig/proxy.js
+++ b/src/widgets/gamedig/proxy.js
@@ -24,7 +24,7 @@ export default async function gamedigProxyHandler(req, res) {
       online: true,
       name: serverData.name,
       map: serverData.map,
-      players: serverData.players?.length ?? serverData.numplayers,
+      players: serverData.numplayers ?? serverData.players?.length,
       maxplayers: serverData.maxplayers,
       bots: serverData.bots.length,
       ping: serverData.ping,


### PR DESCRIPTION
## Proposed change

Ensure gamedig's priority is for `numplayers` rather than `players.length` (See code change).

For some games, `players` returns `[]`, even when `numplayers` returns 5, for example.
```
you@yourmachine:~$ npx gamedig@5.2.0 --type mumble <mumbleserverhost> --debug | tail
  },
  "version": "1.5.255",
  "maxplayers": 25,
  "numplayers": 2,
  "players": [],
  "bots": [],
  "queryPort": 64738,
  "connect": "<mumbleserverhost>:64738",
  "ping": 13
}
```
Because `players` is checked first, this returns `0`, rather than the correct `2`.

Previously `numplayers` worked when I had tested in my original PR https://github.com/gethomepage/homepage/pull/4760, but as you suggested, including the older `players?.length` is better. I did not test then - mea culpa - having assumed `players` would be null rather than an empty list.

Based on above, the order should be reversed. I've tested this.

## Type of change

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.

tested via:
In `services.yaml`,
```yaml
- Mumble Group:
    - Mumble:
        href: https://whatever
        widgets:
            - type: gamedig
              serverType: mumble
              url: udp://mumbleserver:64738
```

```
pnpm install
pnpm build
HOMEPAGE_ALLOWED_HOSTS=localhost:3000 pnpm start
```
![image](https://github.com/user-attachments/assets/848c2a5f-7464-4fa3-b063-28036b8977aa)
