### PR TITLE
Fixhancement: add an option to fritzbox widget to display IPv6

### DIFF
--- a/docs/widgets/services/fritzbox.md
+++ b/docs/widgets/services/fritzbox.md
@@ -13,7 +13,7 @@ Home Network > Network > Network Settings > Access Settings in the Home Network
 
 Credentials are not needed and, as such, you may want to consider using `http` instead of `https` as those requests are significantly faster.
 
-Allowed fields (limited to a max of 4): `["connectionStatus", "uptime", "maxDown", "maxUp", "down", "up", "received", "sent", "externalIPAddress"]`.
+Allowed fields (limited to a max of 4): `["connectionStatus", "uptime", "maxDown", "maxUp", "down", "up", "received", "sent", "externalIPAddress", "externalIPv6Address", "externalIPv6Prefix"]`.
 
 ```yaml
 widget:

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -148,7 +148,9 @@
         "up": "Up",
         "received": "Received",
         "sent": "Sent",
-        "externalIPAddress": "Ext. IP"
+        "externalIPAddress": "Ext. IP",
+        "externalIPv6Address": "Ext. IPv6",
+        "externalIPv6Prefix": "Ext. IPv6-Prefix"
     },
     "caddy": {
         "upstreams": "Upstreams",

--- a/src/widgets/fritzbox/component.jsx
+++ b/src/widgets/fritzbox/component.jsx
@@ -37,6 +37,8 @@ export default function Component({ service }) {
         <Block label="fritzbox.received" />
         <Block label="fritzbox.sent" />
         <Block label="fritzbox.externalIPAddress" />
+        <Block label="fritzbox.externalIPv6Address" />
+        <Block label="fritzbox.externalIPv6Prefix" />
       </Container>
     );
   }
@@ -52,6 +54,8 @@ export default function Component({ service }) {
       <Block label="fritzbox.received" value={t("common.bytes", { value: fritzboxData.received })} />
       <Block label="fritzbox.sent" value={t("common.bytes", { value: fritzboxData.sent })} />
       <Block label="fritzbox.externalIPAddress" value={fritzboxData.externalIPAddress} />
+      <Block label="fritzbox.externalIPv6Address" value={fritzboxData.externalIPv6Address} />
+      <Block label="fritzbox.externalIPv6Prefix" value={fritzboxData.externalIPv6Prefix} />
     </Container>
   );
 }

--- a/src/widgets/fritzbox/proxy.js
+++ b/src/widgets/fritzbox/proxy.js
@@ -79,7 +79,9 @@ export default async function fritzboxProxyHandler(req, res) {
     requestLinkProperties ? requestEndpoint(apiBaseUrl, "WANCommonInterfaceConfig", "GetCommonLinkProperties") : null,
     requestAddonInfos ? requestEndpoint(apiBaseUrl, "WANCommonInterfaceConfig", "GetAddonInfos") : null,
     requestExternalIPAddress ? requestEndpoint(apiBaseUrl, "WANIPConnection", "GetExternalIPAddress") : null,
-    requestExternalIPv6Address ? requestEndpoint(apiBaseUrl, "WANIPConnection", "X_AVM_DE_GetExternalIPv6Address") : null,
+    requestExternalIPv6Address
+      ? requestEndpoint(apiBaseUrl, "WANIPConnection", "X_AVM_DE_GetExternalIPv6Address")
+      : null,
     requestExternalIPv6Prefix ? requestEndpoint(apiBaseUrl, "WANIPConnection", "X_AVM_DE_GetIPv6Prefix") : null,
   ])
     .then(([statusInfo, linkProperties, addonInfos, externalIPAddress, externalIPv6Address, externalIPv6Prefix]) => {

--- a/src/widgets/fritzbox/proxy.js
+++ b/src/widgets/fritzbox/proxy.js
@@ -70,14 +70,19 @@ export default async function fritzboxProxyHandler(req, res) {
   const requestLinkProperties = ["maxDown", "maxUp"].some((field) => serviceWidget.fields.includes(field));
   const requestAddonInfos = ["down", "up", "received", "sent"].some((field) => serviceWidget.fields.includes(field));
   const requestExternalIPAddress = ["externalIPAddress"].some((field) => serviceWidget.fields.includes(field));
+  const requestExternalIPv6Address = ["externalIPv6Address"].some((field) => serviceWidget.fields.includes(field));
+  const requestExternalIPv6Prefix = ["externalIPv6Prefix"].some((field) => serviceWidget.fields.includes(field));
 
   await Promise.all([
+    // as per http://fritz.box:49000/igddesc.xml specifications (fritz.box is a hostname of your router)
     requestStatusInfo ? requestEndpoint(apiBaseUrl, "WANIPConnection", "GetStatusInfo") : null,
     requestLinkProperties ? requestEndpoint(apiBaseUrl, "WANCommonInterfaceConfig", "GetCommonLinkProperties") : null,
     requestAddonInfos ? requestEndpoint(apiBaseUrl, "WANCommonInterfaceConfig", "GetAddonInfos") : null,
     requestExternalIPAddress ? requestEndpoint(apiBaseUrl, "WANIPConnection", "GetExternalIPAddress") : null,
+    requestExternalIPv6Address ? requestEndpoint(apiBaseUrl, "WANIPConnection", "X_AVM_DE_GetExternalIPv6Address") : null,
+    requestExternalIPv6Prefix ? requestEndpoint(apiBaseUrl, "WANIPConnection", "X_AVM_DE_GetIPv6Prefix") : null,
   ])
-    .then(([statusInfo, linkProperties, addonInfos, externalIPAddress]) => {
+    .then(([statusInfo, linkProperties, addonInfos, externalIPAddress, externalIPv6Address, externalIPv6Prefix]) => {
       res.status(200).json({
         connectionStatus: statusInfo?.NewConnectionStatus || "Unconfigured",
         uptime: statusInfo?.NewUptime || 0,
@@ -88,6 +93,8 @@ export default async function fritzboxProxyHandler(req, res) {
         received: addonInfos?.NewX_AVM_DE_TotalBytesReceived64 || 0,
         sent: addonInfos?.NewX_AVM_DE_TotalBytesSent64 || 0,
         externalIPAddress: externalIPAddress?.NewExternalIPAddress || null,
+        externalIPv6Address: externalIPv6Address?.NewExternalIPv6Address || null,
+        externalIPv6Prefix: externalIPv6Prefix?.NewIPv6Prefix || null,
       });
     })
     .catch((error) => {


### PR DESCRIPTION
<!--
==== STOP ====================
======== STOP ================
============ STOP ============
================ STOP ========
==================== STOP ====

⚠️ Before opening this pull request please review the guidelines in the checklist below.

If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.
-->

## Proposed change

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

This PR adds an ability to display external IPv6 address and/or IPv6-Prefix in the FritzBox widget.

Currently, the widget returns an empty IP address, because there is no IPv4 address assigned by my internet provider. Instead they provide me with an IPv6 subnet.

Unfortunately, the UPnP action is prefixed with `X_AVM_DE_` which might seem like an unstable option. However, there are already values prefixed with `NewX_AVM_DE_` used in the file (as per https://github.com/gethomepage/homepage/discussions/1213) and it seems to be even older, yet still present in my router.

I added an option for both, address and prefix, however, IMHO prefix is sufficient, because `::1` has only the router itself and all the clients (NAS, Raspberry Pi, Home server, etc.) will have a different IP address with a common prefix.

Tested with FRITZ!Box 7590 AX router (FRITZ!OS: 8.02), I would say it's the most popular one in Germany.

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
