### PR TITLE
Documentation: add auth documentation to PeaNUT

### DIFF
--- a/docs/widgets/services/peanut.md
+++ b/docs/widgets/services/peanut.md
@@ -20,4 +20,6 @@ widget:
   type: peanut
   url: http://peanut.host.or.ip:port
   key: nameofyourups
+  username: username # only needed if set
+  password: password # only needed if set
 ```


### PR DESCRIPTION
This is a simple documentation change to show users that the homepage PeaNUT widget can accept authentication.

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [x] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
