### PR TITLE
Fix extra backslash in qBittorrent widget API call

### DIFF
--- a/src/widgets/qbittorrent/proxy.js
+++ b/src/widgets/qbittorrent/proxy.js
@@ -7,7 +7,7 @@ const logger = createLogger("qbittorrentProxyHandler");
 
 async function login(widget) {
   logger.debug("qBittorrent is rejecting the request, logging in.");
-  const loginUrl = new URL(`${widget.url}/api/v2/auth/login`).toString();
+  const loginUrl = new URL(`${widget.url}api/v2/auth/login`).toString();
   const loginBody = `username=${encodeURIComponent(widget.username)}&password=${encodeURIComponent(widget.password)}`;
   const loginParams = {
     method: "POST",


### PR DESCRIPTION
## Proposed change

This fixes an issue where the qBittorrent widget was making API calls with an unintended extra backslash.
![image](https://github.com/user-attachments/assets/c105c0cd-3887-482e-a12c-69ab99341f32)

## Type of change

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
