### PR TITLE
Fix: return all http routes of a namespace (k8s)

### DIFF
--- a/src/utils/kubernetes/httproute-list.js
+++ b/src/utils/kubernetes/httproute-list.js
@@ -48,7 +48,7 @@ export default async function listHttpRoute() {
         }),
       );
 
-      httpRouteList = httpRouteListUnfiltered.flat().filter((httpRoute) => httpRoute !== undefined);
+      httpRouteList = httpRouteListUnfiltered.flat().filter((httpRoute) => httpRoute);
     }
   }
   return httpRouteList;

--- a/src/utils/kubernetes/httproute-list.js
+++ b/src/utils/kubernetes/httproute-list.js
@@ -1,6 +1,6 @@
-import { CustomObjectsApi, CoreV1Api } from "@kubernetes/client-node";
+import { CoreV1Api, CustomObjectsApi } from "@kubernetes/client-node";
 
-import { getKubernetes, getKubeConfig, HTTPROUTE_API_GROUP, HTTPROUTE_API_VERSION } from "utils/config/kubernetes";
+import { getKubeConfig, getKubernetes, HTTPROUTE_API_GROUP, HTTPROUTE_API_VERSION } from "utils/config/kubernetes";
 import createLogger from "utils/logger";
 
 const logger = createLogger("httproute-list");
@@ -14,7 +14,7 @@ export default async function listHttpRoute() {
 
   if (gateway) {
     // httproutes
-    const getHttpRoute = async (namespace) =>
+    const getHttpRoutes = async (namespace) =>
       crd
         .listNamespacedCustomObject({
           group: HTTPROUTE_API_GROUP,
@@ -23,8 +23,7 @@ export default async function listHttpRoute() {
           plural: "httproutes",
         })
         .then((response) => {
-          const [httpRoute] = response.items;
-          return httpRoute;
+          return response.items;
         })
         .catch((error) => {
           logger.error("Error getting httproutes: %d %s %s", error.statusCode, error.body, error.response);
@@ -44,12 +43,14 @@ export default async function listHttpRoute() {
     if (namespaces) {
       const httpRouteListUnfiltered = await Promise.all(
         namespaces.map(async (namespace) => {
-          const httpRoute = await getHttpRoute(namespace);
-          return httpRoute;
+          const httpRoutes = await getHttpRoutes(namespace);
+          return httpRoutes;
         }),
       );
 
-      httpRouteList = httpRouteListUnfiltered.filter((httpRoute) => httpRoute !== undefined);
+      httpRouteList = httpRouteListUnfiltered
+        .flat()
+        .filter((httpRoute) => httpRoute !== undefined);
     }
   }
   return httpRouteList;

--- a/src/utils/kubernetes/httproute-list.js
+++ b/src/utils/kubernetes/httproute-list.js
@@ -48,9 +48,7 @@ export default async function listHttpRoute() {
         }),
       );
 
-      httpRouteList = httpRouteListUnfiltered
-        .flat()
-        .filter((httpRoute) => httpRoute !== undefined);
+      httpRouteList = httpRouteListUnfiltered.flat().filter((httpRoute) => httpRoute !== undefined);
     }
   }
   return httpRouteList;


### PR DESCRIPTION
<!--
==== STOP ====================
======== STOP ================
============ STOP ============
================ STOP ========
==================== STOP ====

⚠️ Before opening this pull request please review the guidelines in the checklist below.

If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.
-->

## Proposed change

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

The Kubernetes integration was only returning a single `HTTPRoute` per namespace due to array destructuring in the `listHttpRoute` function. This limited the service discovery capabilities for users with multiple HTTPRoutes in the same namespace.

I don't quite understand why it was limited to one `HTTPRoute` per namespace, as it's certainly interesting to have multiple `HTTPRoute` in the same namespace, on one or more `Gateway`, and thus exposing multiple services on the Homepage. As a result, I have flagged this as a bug.

Closes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
