### PR TITLE
Fix: use 'real_usage' for synology diskstation memory stats

### DIFF
--- a/src/widgets/diskstation/component.jsx
+++ b/src/widgets/diskstation/component.jsx
@@ -43,7 +43,9 @@ export default function Component({ service }) {
   // utilization info
   const { cpu, memory } = utilizationData.data;
   const cpuLoad = parseFloat(cpu.user_load) + parseFloat(cpu.system_load);
-  const memoryUsage = parseFloat(memory.real_usage);
+  const memoryUsage = memory.real_usage
+    ? parseFloat(memory.real_usage)
+    : 100 - (100 * (parseFloat(memory.avail_real) + parseFloat(memory.cached))) / parseFloat(memory.total_real);
 
   return (
     <Container service={service}>

--- a/src/widgets/diskstation/component.jsx
+++ b/src/widgets/diskstation/component.jsx
@@ -43,8 +43,7 @@ export default function Component({ service }) {
   // utilization info
   const { cpu, memory } = utilizationData.data;
   const cpuLoad = parseFloat(cpu.user_load) + parseFloat(cpu.system_load);
-  const memoryUsage =
-    100 - (100 * (parseFloat(memory.avail_real) + parseFloat(memory.cached))) / parseFloat(memory.total_real);
+  const memoryUsage = parseFloat(memory.real_usage);
 
   return (
     <Container service={service}>


### PR DESCRIPTION
<!--
==== STOP ====================
======== STOP ================
============ STOP ============
================ STOP ========
==================== STOP ====

⚠️ Before opening this pull request please review the guidelines in the checklist below.

If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.
-->

## Proposed change

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

Closes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
