### PR TITLE
New service widget: OpenStack widget

### DIFF
--- a/docs/widgets/services/openstack.md
+++ b/docs/widgets/services/openstack.md
@@ -7,20 +7,21 @@ Learn more about [OpenStack](https://docs.openstack.org/).
 
 ```yaml
 widget:
-    type: openstack
-    version: v2.1
-    identityUrl: http://keystone.host.or.ip:port
-    url: http://openstack.host.or.ip:port
-    appCredId: app_credential_id
-    appCredName: app_credential_name
-    appCredSecret: app_credential_secret
-    server: server_id # optional, will display cluster stats if omitted
-    enableDiagnostics: false # optional, only applicable for server widget
-    enableNetwork: true # optional, only applicable for server widget
+  type: openstack
+  version: v2.1
+  identityUrl: http://keystone.host.or.ip:port
+  url: http://openstack.host.or.ip:port
+  appCredId: app_credential_id
+  appCredName: app_credential_name
+  appCredSecret: app_credential_secret
+  server: server_id # optional, will display cluster stats if omitted
+  enableDiagnostics: false # optional, only applicable for server widget
+  enableNetwork: true # optional, only applicable for server widget
 ```
 
-In order to use the widget, an application credential must be obtained via the web interface (Identity > Application Credentials) or via CLI as described in the [documentation](https://docs.openstack.org/keystone/2024.2/admin/oauth2-usage-guide.html). Said credential must be assigned role *reader* or *admin* if diagnostics data should be displayed.
+In order to use the widget, an application credential must be obtained via the web interface (Identity > Application Credentials) or via CLI as described in the [documentation](https://docs.openstack.org/keystone/2024.2/admin/oauth2-usage-guide.html). Said credential must be assigned role _reader_ or _admin_ if diagnostics data should be displayed.
 
 Limitations:
+
 - Widget currently only supports Identity API v3 and Compute API v2.1
 - Diagnostics data can only be retrieved for libvirt based instances

--- a/docs/widgets/services/openstack.md
+++ b/docs/widgets/services/openstack.md
@@ -19,7 +19,7 @@ widget:
     enableNetwork: true # optional, only applicable for server widget
 ```
 
-In order to use the widget, an application credential with role *reader* must be obtained via the web interface (Identity > Application Credentials) or via CLI as described in the [documentation](https://docs.openstack.org/keystone/2024.2/admin/oauth2-usage-guide.html).
+In order to use the widget, an application credential must be obtained via the web interface (Identity > Application Credentials) or via CLI as described in the [documentation](https://docs.openstack.org/keystone/2024.2/admin/oauth2-usage-guide.html). Said credential must be assigned role *reader* or *admin* if diagnostics data should be displayed.
 
 Limitations:
 - Widget currently only supports Identity API v3 and Compute API v2.1

--- a/docs/widgets/services/openstack.md
+++ b/docs/widgets/services/openstack.md
@@ -9,7 +9,7 @@ Learn more about [OpenStack](https://docs.openstack.org/).
 widget:
     type: openstack
     version: v2.1
-    idpUrl: http://keystone.host.or.ip:port
+    identityUrl: http://keystone.host.or.ip:port
     url: http://openstack.host.or.ip:port
     appCredId: app_credential_id
     appCredName: app_credential_name
@@ -19,16 +19,8 @@ widget:
     enableNetwork: true # optional, only applicable for server widget
 ```
 
-In order to use the widget, you will need to obtain an application credential via the web interface (Identity > Application Credentials) or via CLI as described in the [documentation](https://docs.openstack.org/keystone/2024.2/admin/oauth2-usage-guide.html). Said credential should be assigned the role *reader* and have the following acces rules:
+In order to use the widget, an application credential with role *reader* must be obtained via the web interface (Identity > Application Credentials) or via CLI as described in the [documentation](https://docs.openstack.org/keystone/2024.2/admin/oauth2-usage-guide.html).
 
-```json
-[
-    {
-        "path": "/v2.1/servers/**",
-        "method": "GET",
-        "service": "compute"
-    }
-]
-```
-
-Limitations: Advanced diagnostics data (RAM, CPU time) can currently only be retrieved for libvirt based instances.
+Limitations:
+- Widget currently only supports Identity API v3 and Compute API v2.1
+- Diagnostics data can only be retrieved for libvirt based instances

--- a/docs/widgets/services/openstack.md
+++ b/docs/widgets/services/openstack.md
@@ -1,0 +1,34 @@
+---
+title: OpenStack
+description: OpenStack Widget Configuration
+---
+
+Learn more about [OpenStack](https://docs.openstack.org/).
+
+```yaml
+widget:
+    type: openstack
+    version: v2.1
+    idpUrl: http://keystone.host.or.ip:port
+    url: http://openstack.host.or.ip:port
+    appCredId: app_credential_id
+    appCredName: app_credential_name
+    appCredSecret: app_credential_secret
+    server: server_id # optional, will display cluster stats if omitted
+    enableDiagnostics: false # optional, only applicable for server widget
+    enableNetwork: true # optional, only applicable for server widget
+```
+
+In order to use the widget, you will need to obtain an application credential via the web interface (Identity > Application Credentials) or via CLI as described in the [documentation](https://docs.openstack.org/keystone/2024.2/admin/oauth2-usage-guide.html). Said credential should be assigned the role *reader* and have the following acces rules:
+
+```json
+[
+    {
+        "path": "/v2.1/servers/**",
+        "method": "GET",
+        "service": "compute"
+    }
+]
+```
+
+Limitations: Advanced diagnostics data (RAM, CPU time) can currently only be retrieved for libvirt based instances.

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,8 @@
         "minecraft-ping-js": "^1.0.2",
         "next": "^15.0.3",
         "next-i18next": "^12.1.0",
+        "node-cache": "^5.1.2",
+        "node-fetch": "^3.3.2",
         "ping": "^0.4.4",
         "pretty-bytes": "^6.1.1",
         "raw-body": "^3.0.0",
@@ -802,6 +804,26 @@
         "ws": "^8.18.0"
       }
     },
+    "node_modules/@kubernetes/client-node/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@next/env": {
       "version": "15.1.6",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-15.1.6.tgz",
@@ -1094,18 +1116,6 @@
       "integrity": "sha512-kkKUDVlII2DQiKy7UstOR1ErJP8kUKAQ4oa+SQtM0K+lPdmmjj0YnnxBgtTVYH7mUKtbsxeFC9y0AmK7Yb78/A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@sindresorhus/is": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
-      "integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/is?sponsor=1"
-      }
     },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
@@ -2178,24 +2188,6 @@
         "node": ">=14.16"
       }
     },
-    "node_modules/cacheable-request": {
-      "version": "10.2.14",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.14.tgz",
-      "integrity": "sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/http-cache-semantics": "^4.0.2",
-        "get-stream": "^6.0.1",
-        "http-cache-semantics": "^4.1.1",
-        "keyv": "^4.5.3",
-        "mimic-response": "^4.0.0",
-        "normalize-url": "^8.0.0",
-        "responselike": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      }
-    },
     "node_modules/cal-parser": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cal-parser/-/cal-parser-1.0.2.tgz",
@@ -2459,6 +2451,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/clsx": {
@@ -2807,6 +2808,15 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -3996,6 +4006,29 @@
       "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
       "license": "MIT"
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -4145,13 +4178,16 @@
         "node": ">= 6"
       }
     },
-    "node_modules/form-data-encoder": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
-      "integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
       "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
       "engines": {
-        "node": ">= 14.17"
+        "node": ">=12.20.0"
       }
     },
     "node_modules/fraction.js": {
@@ -4259,11 +4295,96 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/gamedig/node_modules/@sindresorhus/is": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
+      "integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/gamedig/node_modules/cacheable-request": {
+      "version": "10.2.14",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.14.tgz",
+      "integrity": "sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "^4.0.2",
+        "get-stream": "^6.0.1",
+        "http-cache-semantics": "^4.1.1",
+        "keyv": "^4.5.3",
+        "mimic-response": "^4.0.0",
+        "normalize-url": "^8.0.0",
+        "responselike": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/gamedig/node_modules/form-data-encoder": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
+      "integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.17"
+      }
+    },
+    "node_modules/gamedig/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gamedig/node_modules/got": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-13.0.0.tgz",
+      "integrity": "sha512-XfBk1CxOOScDcMr9O1yKkNaQyy865NbYs+F7dr4H0LZMVgCj2Le59k6PqbNHoL5ToeaEQUYh6c6yMfVcc6SJxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^5.2.0",
+        "@szmarczak/http-timer": "^5.0.1",
+        "cacheable-lookup": "^7.0.0",
+        "cacheable-request": "^10.2.8",
+        "decompress-response": "^6.0.0",
+        "form-data-encoder": "^2.1.2",
+        "get-stream": "^6.0.1",
+        "http2-wrapper": "^2.1.10",
+        "lowercase-keys": "^3.0.0",
+        "p-cancelable": "^3.0.0",
+        "responselike": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
     "node_modules/gamedig/node_modules/long": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
       "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
       "license": "Apache-2.0"
+    },
+    "node_modules/gamedig/node_modules/p-cancelable": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
+      "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
     },
     "node_modules/gbxremote": {
       "version": "0.2.1",
@@ -4326,18 +4447,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-symbol-description": {
@@ -4474,31 +4583,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/got": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/got/-/got-13.0.0.tgz",
-      "integrity": "sha512-XfBk1CxOOScDcMr9O1yKkNaQyy865NbYs+F7dr4H0LZMVgCj2Le59k6PqbNHoL5ToeaEQUYh6c6yMfVcc6SJxA==",
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/is": "^5.2.0",
-        "@szmarczak/http-timer": "^5.0.1",
-        "cacheable-lookup": "^7.0.0",
-        "cacheable-request": "^10.2.8",
-        "decompress-response": "^6.0.0",
-        "form-data-encoder": "^2.1.2",
-        "get-stream": "^6.0.1",
-        "http2-wrapper": "^2.1.10",
-        "lowercase-keys": "^3.0.0",
-        "p-cancelable": "^3.0.0",
-        "responselike": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/got?sponsor=1"
       }
     },
     "node_modules/graceful-fs": {
@@ -5957,24 +6041,53 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+    "node_modules/node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
       "license": "MIT",
       "dependencies": {
-        "whatwg-url": "^5.0.0"
+        "clone": "2.x"
       },
       "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
         }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-int64": {
@@ -6243,15 +6356,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/p-cancelable": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
-      "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20"
       }
     },
     "node_modules/p-limit": {
@@ -8463,6 +8567,26 @@
         "node-fetch": "^2.6.1"
       }
     },
+    "node_modules/urbackup-server-api/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -8537,6 +8661,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "react-icons": "^5.4.0",
         "recharts": "^2.12.7",
         "rrule": "^2.8.1",
+        "semver": "^7.7.1",
         "swr": "^1.3.0",
         "systeminformation": "^5.24.3",
         "tough-cookie": "^4.1.4",
@@ -1509,19 +1510,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@typescript-eslint/utils": {
@@ -3494,6 +3482,16 @@
         "eslint-plugin-import": "^2.25.2"
       }
     },
+    "node_modules/eslint-config-airbnb-base/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/eslint-config-next": {
       "version": "14.2.23",
       "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-14.2.23.tgz",
@@ -3678,6 +3676,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eslint-plugin-import/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/eslint-plugin-jsx-a11y": {
       "version": "6.10.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
@@ -3814,6 +3822,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/eslint-scope": {
@@ -5009,19 +5027,6 @@
       "license": "MIT",
       "dependencies": {
         "semver": "^7.6.3"
-      }
-    },
-    "node_modules/is-bun-module/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/is-callable": {
@@ -7374,13 +7379,15 @@
       }
     },
     "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/set-function-length": {
@@ -7476,19 +7483,6 @@
         "@img/sharp-wasm32": "0.33.5",
         "@img/sharp-win32-ia32": "0.33.5",
         "@img/sharp-win32-x64": "0.33.5"
-      }
-    },
-    "node_modules/sharp/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "license": "ISC",
-      "optional": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/shebang-command": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "react-icons": "^5.4.0",
     "recharts": "^2.12.7",
     "rrule": "^2.8.1",
+    "semver": "^7.7.1",
     "swr": "^1.3.0",
     "systeminformation": "^5.24.3",
     "tough-cookie": "^4.1.4",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "minecraft-ping-js": "^1.0.2",
     "next": "^15.0.3",
     "next-i18next": "^12.1.0",
+    "node-cache": "^5.1.2",
+    "node-fetch": "^3.3.2",
     "ping": "^0.4.4",
     "pretty-bytes": "^6.1.1",
     "raw-body": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,12 @@ importers:
       next-i18next:
         specifier: ^12.1.0
         version: 12.1.0(next@15.1.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      node-cache:
+        specifier: ^5.1.2
+        version: 5.1.2
+      node-fetch:
+        specifier: ^3.3.2
+        version: 3.3.2
       ping:
         specifier: ^0.4.4
         version: 0.4.4
@@ -83,6 +89,9 @@ importers:
       rrule:
         specifier: ^2.8.1
         version: 2.8.1
+      semver:
+        specifier: ^7.7.1
+        version: 7.7.1
       swr:
         specifier: ^1.3.0
         version: 1.3.0(react@18.3.1)
@@ -101,10 +110,6 @@ importers:
       xml-js:
         specifier: ^1.6.11
         version: 1.6.11
-    optionalDependencies:
-      osx-temperature-sensor:
-        specifier: ^1.0.8
-        version: 1.0.8
     devDependencies:
       '@tailwindcss/forms':
         specifier: ^0.5.8
@@ -117,7 +122,7 @@ importers:
         version: 8.57.1
       eslint-config-airbnb:
         specifier: ^19.0.4
-        version: 19.0.4(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1))(eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1))(eslint-plugin-react-hooks@4.6.2(eslint@8.57.1))(eslint-plugin-react@7.37.4(eslint@8.57.1))(eslint@8.57.1)
+        version: 19.0.4(eslint-plugin-import@2.31.0)(eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1))(eslint-plugin-react-hooks@4.6.2(eslint@8.57.1))(eslint-plugin-react@7.37.4(eslint@8.57.1))(eslint@8.57.1)
       eslint-config-next:
         specifier: ^14.2.4
         version: 14.2.23(eslint@8.57.1)(typescript@5.7.3)
@@ -126,7 +131,7 @@ importers:
         version: 9.1.0(eslint@8.57.1)
       eslint-plugin-import:
         specifier: ^2.31.0
-        version: 2.31.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+        version: 2.31.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
       eslint-plugin-jsx-a11y:
         specifier: ^6.9.0
         version: 6.10.2(eslint@8.57.1)
@@ -154,6 +159,10 @@ importers:
       typescript:
         specifier: ^5.6.3
         version: 5.7.3
+    optionalDependencies:
+      osx-temperature-sensor:
+        specifier: ^1.0.8
+        version: 1.0.8
 
 packages:
 
@@ -860,6 +869,10 @@ packages:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
 
+  clone@2.1.2:
+    resolution: {integrity: sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==}
+    engines: {node: '>=0.8'}
+
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -986,6 +999,10 @@ packages:
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -1339,6 +1356,10 @@ packages:
   fecha@4.2.3:
     resolution: {integrity: sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==}
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -1385,6 +1406,10 @@ packages:
   form-data@4.0.1:
     resolution: {integrity: sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==}
     engines: {node: '>= 6'}
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
 
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
@@ -1940,6 +1965,14 @@ packages:
       sass:
         optional: true
 
+  node-cache@5.1.2:
+    resolution: {integrity: sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==}
+    engines: {node: '>= 8.0.0'}
+
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
@@ -1948,6 +1981,10 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -2371,8 +2408,8 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
-  semver@7.6.3:
-    resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
+  semver@7.7.1:
+    resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -2716,6 +2753,10 @@ packages:
   void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
+
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -3252,7 +3293,7 @@ snapshots:
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
-      semver: 7.6.3
+      semver: 7.7.1
       ts-api-utils: 2.0.0(typescript@5.7.3)
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -3556,6 +3597,8 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
+  clone@2.1.2: {}
+
   clsx@2.1.1: {}
 
   color-convert@1.9.3:
@@ -3674,6 +3717,8 @@ snapshots:
   d3-timer@3.0.1: {}
 
   damerau-levenshtein@1.0.8: {}
+
+  data-uri-to-buffer@4.0.1: {}
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -3915,20 +3960,20 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-airbnb-base@15.0.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-config-airbnb-base@15.0.0(eslint-plugin-import@2.31.0)(eslint@8.57.1):
     dependencies:
       confusing-browser-globals: 1.0.11
       eslint: 8.57.1
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
       object.assign: 4.1.7
       object.entries: 1.1.8
       semver: 6.3.1
 
-  eslint-config-airbnb@19.0.4(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1))(eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1))(eslint-plugin-react-hooks@4.6.2(eslint@8.57.1))(eslint-plugin-react@7.37.4(eslint@8.57.1))(eslint@8.57.1):
+  eslint-config-airbnb@19.0.4(eslint-plugin-import@2.31.0)(eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1))(eslint-plugin-react-hooks@4.6.2(eslint@8.57.1))(eslint-plugin-react@7.37.4(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
-      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.31.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.4(eslint@8.57.1)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1)
@@ -3943,8 +3988,8 @@ snapshots:
       '@typescript-eslint/parser': 8.21.0(eslint@8.57.1)(typescript@5.7.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.4(eslint@8.57.1)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1)
@@ -3967,7 +4012,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.0
@@ -3979,22 +4024,22 @@ snapshots:
       is-glob: 4.0.3
       stable-hash: 0.0.4
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.21.0(eslint@8.57.1)(typescript@5.7.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -4005,7 +4050,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -4175,6 +4220,11 @@ snapshots:
 
   fecha@4.2.3: {}
 
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
   file-entry-cache@6.0.1:
     dependencies:
       flat-cache: 3.2.0
@@ -4216,6 +4266,10 @@ snapshots:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
+
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
 
   fraction.js@4.3.7: {}
 
@@ -4474,7 +4528,7 @@ snapshots:
 
   is-bun-module@1.3.0:
     dependencies:
-      semver: 7.6.3
+      semver: 7.7.1
 
   is-callable@1.2.7: {}
 
@@ -4794,9 +4848,21 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  node-cache@5.1.2:
+    dependencies:
+      clone: 2.1.2
+
+  node-domexception@1.0.0: {}
+
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   node-int64@0.4.0: {}
 
@@ -5239,7 +5305,7 @@ snapshots:
 
   semver@6.3.1: {}
 
-  semver@7.6.3: {}
+  semver@7.7.1: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -5269,7 +5335,7 @@ snapshots:
     dependencies:
       color: 4.2.3
       detect-libc: 2.0.3
-      semver: 7.6.3
+      semver: 7.7.1
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.33.5
       '@img/sharp-darwin-x64': 0.33.5
@@ -5686,6 +5752,8 @@ snapshots:
       d3-timer: 3.0.1
 
   void-elements@3.1.0: {}
+
+  web-streams-polyfill@3.3.3: {}
 
   webidl-conversions@3.0.1: {}
 

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1019,12 +1019,14 @@
         "name": "Name",
         "status": "Status",
         "cputime": "CPU time",
+        "total": "Total",
         "states": {
             "active": "Active",
             "build": "Build",
             "shutoff": "Shut off",
             "error": "Error",
-            "deleted": "Deleted"
+            "deleted": "Deleted",
+            "other": "Other"
         }
     }
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1014,5 +1014,17 @@
         "issues": "Issues",
         "merges": "Merge Requests",
         "projects": "Projects"
+    },
+    "openstack": {
+        "name": "Name",
+        "status": "Status",
+        "cputime": "CPU time",
+        "states": {
+            "active": "Active",
+            "build": "Build",
+            "shutoff": "Shut off",
+            "error": "Error",
+            "deleted": "Deleted"
+        }
     }
 }

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -418,6 +418,8 @@ export function cleanServiceGroups(groups) {
 
           // docker
           container,
+
+          // docker, openstack
           server,
 
           // emby, jellyfin
@@ -591,6 +593,7 @@ export function cleanServiceGroups(groups) {
           if (wan) widget.wan = wan;
         }
         if (type === "openstack") {
+          widget.server = server !== undefined;
           if (enableDiagnostics !== undefined) widget.enableDiagnostics = JSON.parse(enableDiagnostics);
           if (enableNetwork !== undefined) widget.enableNetwork = JSON.parse(enableNetwork);
           if (version !== undefined) widget.version = version;

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -432,7 +432,7 @@ export function cleanServiceGroups(groups) {
           // frigate
           enableRecentEvents,
 
-          // beszel, glances, immich, mealie, pihole, pfsense, speedtest
+          // beszel, glances, immich, mealie, pihole, pfsense, speedtest, openstack
           version,
 
           // glances
@@ -477,6 +477,10 @@ export function cleanServiceGroups(groups) {
 
           // openmediavault
           method,
+
+          // openstack
+          enableDiagnostics,
+          enableNetwork,
 
           // openwrt
           interfaceName,
@@ -585,6 +589,11 @@ export function cleanServiceGroups(groups) {
         }
         if (["opnsense", "pfsense"].includes(type)) {
           if (wan) widget.wan = wan;
+        }
+        if (type === "openstack") {
+          if (enableDiagnostics !== undefined) widget.enableDiagnostics = JSON.parse(enableDiagnostics);
+          if (enableNetwork !== undefined) widget.enableNetwork = JSON.parse(enableNetwork);
+          if (version !== undefined) widget.version = version;
         }
         if (["emby", "jellyfin"].includes(type)) {
           if (enableBlocks !== undefined) widget.enableBlocks = JSON.parse(enableBlocks);

--- a/src/utils/proxy/handlers/openstack.js
+++ b/src/utils/proxy/handlers/openstack.js
@@ -1,216 +1,211 @@
-import getServiceWidget from "utils/config/service-helpers";
-import { httpProxy } from "utils/proxy/http";
-import { formatApiCall, sanitizeErrorURL } from "utils/proxy/api-helpers";
-import validateWidgetData from "utils/proxy/validate-widget-data";
-import createLogger from "utils/logger";
-import widgets from "widgets/widgets";
+import { resolve } from "url";
+
 import fetch from "node-fetch";
 import NodeCache from "node-cache";
 import semver from "semver";
-import { resolve } from "url";
+
+import createLogger from "utils/logger";
+import widgets from "widgets/widgets";
+import getServiceWidget from "utils/config/service-helpers";
+import validateWidgetData from "utils/proxy/validate-widget-data";
+import { httpProxy } from "utils/proxy/http";
+import { formatApiCall, sanitizeErrorURL } from "utils/proxy/api-helpers";
 
 const logger = createLogger("openstackProxyHandler");
 const cache = new NodeCache();
 
-export default async function openstackProxyHandler(req, res, map) {
-    const { group, service, endpoint, index } = req.query;
-    const widget = await getServiceWidget(group, service, index);
-    const url = new URL(formatApiCall(widgets[widget.type].api, { endpoint, ...widget }));
-    
-    let apiVersionSupported;
-    try {
-        logger.debug("Checking for Compute API version support");
-        apiVersionSupported = await isApiVersionSupported(widget)
-    } catch(err) {
-        logger.warn(err.message);
-        return res
-            .status(err?.code || 500)
-            .json({ error: {
-                status: err?.code,
-                message: err.message,
-                url: sanitizeErrorURL(err?.details?.url),
-                data: err?.details?.data
-            }});
-    }
-
-    if (!apiVersionSupported) {
-        const errMsg = `Compute API version ${widget.version} is not supported`;
-        logger.warn(errMsg);
-        return res
-            .status(500)
-            .json({ error: { 
-                message: errMsg,
-                url: sanitizeErrorURL(url)
-            }});
-    }
-    logger.debug(`Compute API version ${widget.version} is supported`);
-
-    let authToken;
-    try {
-        logger.debug("Retrieving authentication token");
-        authToken = await getAuthToken(widget);
-    } catch(err) {
-        logger.warn(err.message);
-        return res
-            .status(err?.code || 500)
-            .json({ error: { 
-                status: err?.code,
-                message: err.message,
-                url: sanitizeErrorURL(err?.details?.url),
-                data: err?.details?.data
-            }});
-    }
-
-    const headers = {
-        "Content-Type": "application/json",
-        "X-Auth-Token": authToken
-    };
-
-    const [status, contentType, data] = await httpProxy(url, {
-        method: req.method,
-        withCredentials: true,
-        credentials: "include",
-        headers,
-    });
-
-    if (data.error?.url) {
-        data.error.url = sanitizeErrorURL(url);
-    }
-
-    if (status !== 200 || !validateWidgetData(widget, endpoint, data)) {
-        const errMsg = `Received invalid response from OpenStack endpoint`;
-        logger.warn(errMsg);
-        return res
-            .status(status)
-            .json({ error: { 
-                status: status,
-                message: errMsg,
-                url: sanitizeErrorURL(url),
-                data: data
-            }});
-    }
-
-    if (map) data = map(data);
-    if (contentType) res.setHeader("Content-Type", contentType);
-    return res.status(status).send(data);
-}
-
 async function isApiVersionSupported(widget) {
-    const { url, version } = widget;
-    const options = {
-        headers: {
-            "Content-Type": "application/json"
-        }
+  const { url, version } = widget;
+  const options = {
+    headers: {
+      "Content-Type": "application/json",
+    },
+  };
+
+  const response = await fetch(url, options);
+  if (!response.ok) {
+    const err = new Error("Could not fetch OpenStack API versions");
+    err.code = response.status;
+    err.details = {
+      url,
+      data: response.json(),
     };
+    throw err;
+  }
 
-    const response = await fetch(url, options);
-    if (!response.ok) {
-        const err = new Error("Could not fetch OpenStack API versions");
-        err.code = response.status;
-        err.details = {
-            url: url,
-            data: response.json()
-        };
-        throw err;
-    }
-
-    const data = await response.json();
-    for (const v of data.versions) {
-        const ver = semver.coerce(version);
-
-        if (semver.satisfies(ver, v.min_version + " - " + v.version)) {
-            return true;
-        }
-    }
-
-    return false;
+  const data = await response.json();
+  return data.versions.some((v) => {
+    const ver = semver.coerce(version);
+    return semver.satisfies(ver, `${v.min_version} - ${v.version}`);
+  });
 }
 
 async function isIdpVersionSupported(identityUrl) {
-    const options = {
-        headers: {
-            "Content-Type": "application/json"
-        }
-    };
-    
-    const response = await fetch(identityUrl, options);
-    if (!response.ok && response.status !== 300) {
-        const err = new Error("Could not fetch OpenStack IDP versions");
-        err.code = response.status;
-        err.details = {
-            url: identityUrl,
-            data: response.json()
-        };
-        throw err;
-    }
-    
-    const data = await response.json();
-    for (const v of data.versions.values) {
-        const ver = semver.coerce(v.id);
-        const majorVer = semver.major(ver);
+  const options = {
+    headers: {
+      "Content-Type": "application/json",
+    },
+  };
 
-        if (majorVer === 3) {
-            return true;
-        }
-    }
+  const response = await fetch(identityUrl, options);
+  if (!response.ok && response.status !== 300) {
+    const err = new Error("Could not fetch OpenStack IDP versions");
+    err.code = response.status;
+    err.details = {
+      url: identityUrl,
+      data: response.json(),
+    };
+    throw err;
+  }
+
+  const data = await response.json();
+  return data.versions.values.some((v) => {
+    const ver = semver.coerce(v.id);
+    const majorVer = semver.major(ver);
+    return majorVer === 3;
+  });
 }
 
 async function getAuthToken(widget) {
-    const { identityUrl, appCredId, appCredName, appCredSecret } = widget;
-    const cacheToken = `openstack-token-${appCredId}`
+  const { identityUrl, appCredId, appCredName, appCredSecret } = widget;
+  const cacheToken = `openstack-token-${appCredId}`;
 
-    if (cache.has(cacheToken)) {
-        logger.debug("Retrieved authentication token from cache");
-        return cache.get(cacheToken);
-    }
+  if (cache.has(cacheToken)) {
+    logger.debug("Retrieved authentication token from cache");
+    return cache.get(cacheToken);
+  }
 
-    logger.debug("Checking for Identity API version support");
-    if (!await isIdpVersionSupported(identityUrl)) {
-        const err = new Error("Currently only OpenStack IDP major version v3 is supported");
-        err.details = { url: identityUrl };
-        throw err;
-    }
+  logger.debug("Checking for Identity API version support");
+  if (!(await isIdpVersionSupported(identityUrl))) {
+    const err = new Error("Currently only OpenStack IDP major version v3 is supported");
+    err.details = { url: identityUrl };
+    throw err;
+  }
 
-    const data = {
-        "auth": {
-            "identity": {
-                "methods": [
-                    "application_credential"
-                ],
-                "application_credential": {
-                    "id": appCredId,
-                    "name": appCredName,
-                    "secret": appCredSecret
-                }
-            }
-        }
+  const data = {
+    auth: {
+      identity: {
+        methods: ["application_credential"],
+        application_credential: {
+          id: appCredId,
+          name: appCredName,
+          secret: appCredSecret,
+        },
+      },
+    },
+  };
+
+  const options = {
+    method: "post",
+    body: JSON.stringify(data),
+    headers: {
+      "Content-Type": "application/json",
+    },
+  };
+
+  const url = resolve(identityUrl, "/v3/auth/tokens");
+  const response = await fetch(url, options);
+  if (!response.ok) {
+    const err = new Error("Could not fetch OpenStack auth token");
+    err.code = response.status;
+    err.details = {
+      url,
+      data: response.json(),
     };
+  }
 
-    const options = {
-        method: "post",
-        body: JSON.stringify(data),
-        headers: {
-            "Content-Type": "application/json"
-        }
-    };
+  const token = response.headers.get("X-Subject-Token");
+  const {
+    token: { expires_at: expiryDate },
+  } = await response.json();
+  const ttlMillis = new Date(expiryDate) - new Date();
+  const ttl = Math.floor(ttlMillis / 1000);
+  cache.set(cacheToken, token, ttl);
 
-    const url = resolve(identityUrl, "/v3/auth/tokens");
-    const response = await fetch(url, options);
-    if (!response.ok) {
-        const err = new Error("Could not fetch OpenStack auth token");
-        err.code = response.status;
-        err.details = {
-            url: url,
-            data: response.json()
-        };
-    }
+  logger.debug("Retrieved and cached authentication token from Identity API");
+  return token;
+}
 
-    const token = response.headers.get("X-Subject-Token");
-    const { token: { expires_at: expiryDate } } = await response.json();
-    const ttlMillis = new Date(expiryDate) - new Date();
-    const ttl = Math.floor(ttlMillis / 1000);
-    cache.set(cacheToken, token, ttl);
+export default async function openstackProxyHandler(req, res, map) {
+  const { group, service, endpoint, index } = req.query;
+  const widget = await getServiceWidget(group, service, index);
+  const url = new URL(formatApiCall(widgets[widget.type].api, { endpoint, ...widget }));
 
-    logger.debug("Retrieved and cached authentication token from Identity API");
-    return token;
+  let apiVersionSupported;
+  try {
+    logger.debug("Checking for Compute API version support");
+    apiVersionSupported = await isApiVersionSupported(widget);
+  } catch (err) {
+    logger.warn(err.message);
+    return res.status(err?.code || 500).json({
+      error: {
+        status: err?.code,
+        message: err.message,
+        url: sanitizeErrorURL(err?.details?.url),
+        data: err?.details?.data,
+      },
+    });
+  }
+
+  if (!apiVersionSupported) {
+    const errMsg = `Compute API version ${widget.version} is not supported`;
+    logger.warn(errMsg);
+    return res.status(500).json({
+      error: {
+        message: errMsg,
+        url: sanitizeErrorURL(url),
+      },
+    });
+  }
+  logger.debug(`Compute API version ${widget.version} is supported`);
+
+  let authToken;
+  try {
+    logger.debug("Retrieving authentication token");
+    authToken = await getAuthToken(widget);
+  } catch (err) {
+    logger.warn(err.message);
+    return res.status(err?.code || 500).json({
+      error: {
+        status: err?.code,
+        message: err.message,
+        url: sanitizeErrorURL(err?.details?.url),
+        data: err?.details?.data,
+      },
+    });
+  }
+
+  const headers = {
+    "Content-Type": "application/json",
+    "X-Auth-Token": authToken,
+  };
+
+  const [status, contentType, _data] = await httpProxy(url, {
+    method: req.method,
+    withCredentials: true,
+    credentials: "include",
+    headers,
+  });
+  let data = _data;
+
+  if (data.error?.url) {
+    data.error.url = sanitizeErrorURL(url);
+  }
+
+  if (status !== 200 || !validateWidgetData(widget, endpoint, data)) {
+    const errMsg = `Received invalid response from OpenStack endpoint`;
+    logger.warn(errMsg);
+    return res.status(status).json({
+      error: {
+        status,
+        message: errMsg,
+        url: sanitizeErrorURL(url),
+        data,
+      },
+    });
+  }
+
+  if (map) data = map(data);
+  if (contentType) res.setHeader("Content-Type", contentType);
+  return res.status(status).send(data);
 }

--- a/src/utils/proxy/handlers/openstack.js
+++ b/src/utils/proxy/handlers/openstack.js
@@ -1,0 +1,99 @@
+import getServiceWidget from "utils/config/service-helpers";
+import { formatApiCall, sanitizeErrorURL } from "utils/proxy/api-helpers";
+import validateWidgetData from "utils/proxy/validate-widget-data";
+import { httpProxy } from "utils/proxy/http";
+import createLogger from "utils/logger";
+import widgets from "widgets/widgets";
+import fetch from 'node-fetch';
+import NodeCache from "node-cache";
+
+const logger = createLogger("openstackProxyHandler");
+const cache = new NodeCache();
+
+export default async function openstackProxyHandler(req, res, map) {
+    const { group, service, endpoint, index } = req.query;
+    const widget = await getServiceWidget(group, service, index);
+
+    if (!widget || widget.type !== 'openstack') {
+        return res.status(400).json({ error: 'openstackProxyHandler can only be used with widget type \'openstack\'' });
+    }
+
+    const authToken = await getAuthToken(widget);
+    
+    const url = new URL(formatApiCall(widgets[widget.type].api, { endpoint, ...widget }));
+
+    const headers = {
+        "Content-Type": "application/json",
+        "X-Auth-Token": authToken
+    };
+
+    const [status, contentType, data] = await httpProxy(url, {
+        method: req.method,
+        withCredentials: true,
+        credentials: "include",
+        headers,
+    });
+
+    if (data.error?.url) {
+        data.error.url = sanitizeErrorURL(url);
+    }
+
+    if (status !== 200) {
+        console.log(status);
+    } else  {
+        if (!validateWidgetData(widget, endpoint, data)) {
+        return res
+            .status(500)
+            .json({ error: { message: "Invalid data", url: sanitizeErrorURL(url), data: data } });
+        }
+        if (map) data = map(data);
+    }
+
+    if (contentType) res.setHeader("Content-Type", contentType);
+    return res.status(status).send(data);
+}
+
+async function getAuthToken(widget) {
+    const { identityUrl, appCredId, appCredName, appCredSecret } = widget;
+
+    if (cache.has('openstack-token-' + identityUrl)) {
+        return cache.get('openstack-token-' + identityUrl);
+    }
+
+    const data = {
+        "auth": {
+            "identity": {
+                "methods": [
+                    "application_credential"
+                ],
+                "application_credential": {
+                    "id": appCredId,
+                    "name": appCredName,
+                    "secret": appCredSecret
+                }
+            }
+        }
+    };
+
+    const options = {
+        method: 'post',
+        body: JSON.stringify(data),
+        headers: {
+            "Content-Type": "application/json"
+        }
+    };
+
+    const url = identityUrl + '/v3/auth/tokens';
+    const response = await fetch(url, options);
+    if (!response.ok) {
+        throw new Error("Error fetching OpenStack auth token: " + response.status + response.statusText)
+    }
+
+    const token = response.headers.get('X-Subject-Token');
+    const { token: { expires_at: expiresAt } } = await response.json();
+    const ttlMillis = new Date(expiresAt) - new Date();
+    const ttl = Math.floor(ttlMillis / 1000);
+
+    cache.set('openstack-token-' + identityUrl, token, ttl);
+    return token;
+}

--- a/src/utils/proxy/handlers/openstack.js
+++ b/src/utils/proxy/handlers/openstack.js
@@ -25,7 +25,8 @@ export default async function openstackProxyHandler(req, res, map) {
         logger.warn(err.message);
         return res
             .status(err?.code || 500)
-            .json({ error: { 
+            .json({ error: {
+                status: err?.code,
                 message: err.message,
                 url: sanitizeErrorURL(err?.details?.url),
                 data: err?.details?.data
@@ -53,6 +54,7 @@ export default async function openstackProxyHandler(req, res, map) {
         return res
             .status(err?.code || 500)
             .json({ error: { 
+                status: err?.code,
                 message: err.message,
                 url: sanitizeErrorURL(err?.details?.url),
                 data: err?.details?.data
@@ -81,6 +83,7 @@ export default async function openstackProxyHandler(req, res, map) {
         return res
             .status(status)
             .json({ error: { 
+                status: status,
                 message: errMsg,
                 url: sanitizeErrorURL(url),
                 data: data

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -87,6 +87,7 @@ const components = {
   opnsense: dynamic(() => import("./opnsense/component")),
   overseerr: dynamic(() => import("./overseerr/component")),
   openmediavault: dynamic(() => import("./openmediavault/component")),
+  openstack: dynamic(() => import("./openstack/component")),
   openwrt: dynamic(() => import("./openwrt/component")),
   paperlessngx: dynamic(() => import("./paperlessngx/component")),
   pfsense: dynamic(() => import("./pfsense/component")),

--- a/src/widgets/openstack/component.jsx
+++ b/src/widgets/openstack/component.jsx
@@ -11,11 +11,9 @@ export default function Component({ service }) {
 
   if (serverError) {
     return <Container service={service} error={serverError} />;
-  } else if (diagnosticsError) {
-    return <Container service={service} error={diagnosticsError} />;
-  }
+  } 
 
-  if (!diagnosticsData || !serverData) {
+  if (!serverData) {
     return (
       <Container service={service}>
           <Block label="openstack.name"/>
@@ -26,23 +24,23 @@ export default function Component({ service }) {
     );
   }
   
-  const { server: { status: serverStatus, name: serverName } } = serverData;
-  const uptime = diagnosticsData.cpu0_time;
-  const memoryUsage = (diagnosticsData["memory-rss"] / diagnosticsData["memory-actual"]) * 100;
+  const { server: { "status": serverStatus, name: serverName } } = serverData;
+  const uptime = diagnosticsData?.cpu0_time;
+  const memoryUsage = (diagnosticsData?.["memory-rss"] / diagnosticsData?.["memory-actual"]) * 100;
 
   return (
     <Container service={service}>
         <Block label="openstack.name" value={serverName} />
         <Block label="openstack.status" value={t("openstack.states." + serverStatus.toLowerCase())} />
 
-        {serverStatus === 'ACTIVE' &&
+        {serverStatus === "ACTIVE" && !diagnosticsError &&
           <>
             <Block label="openstack.cputime" value={t("common.duration", { value: uptime / 1000000000 })} />
             <Block label="resources.mem" value={t("common.percent", { value: memoryUsage.toFixed() })} />
           </>
         }
 
-        {serverStatus !== 'ACTIVE' &&
+        {serverStatus !== "ACTIVE" || diagnosticsError &&
           <>
             <Block label="openstack.cputime"/>
             <Block label="resources.mem"/>

--- a/src/widgets/openstack/component.jsx
+++ b/src/widgets/openstack/component.jsx
@@ -7,21 +7,20 @@ export default function Component({ service }) {
   const { widget: { server: isServerWidget } } = service;
   
   if (isServerWidget) {
-    return ServerComponent(service);
+    return <ServerComponent service={service}/>;
   } else {
-    return ClusterComponent(service);
+    return <ClusterComponent service={service}/>;
   }
 }
 
-function ServerComponent(service) {
+function ServerComponent({ service }) {
   const { t } = useTranslation();
   const { widget } = service;
   const { enableDiagnostics = true, enableNetwork = true } = widget;
   const { data: serverData, error: serverError } = useWidgetAPI(widget, "server");
-  const shouldRenderDiagnostics = enableDiagnostics && serverData?.server?.status === "ACTIVE";
-  
+
   let diagnosticsData, diagnosticsError;
-  if (shouldRenderDiagnostics) {
+  if (enableDiagnostics) {
     const diagnosticsResult = useWidgetAPI(widget, "diagnostics");
     diagnosticsData = diagnosticsResult.data;
     diagnosticsError = diagnosticsResult.error;
@@ -33,7 +32,7 @@ function ServerComponent(service) {
     return <Container service={service} error={diagnosticsError} />;
   }
 
-  if (!serverData || (shouldRenderDiagnostics && !diagnosticsData)) {
+  if (!serverData || (enableDiagnostics && !diagnosticsData)) {
     return (
       <Container service={service}>
           <Block label="openstack.name"/>
@@ -57,7 +56,7 @@ function ServerComponent(service) {
         <Block label="openstack.name" value={serverName} />
         <Block label="openstack.status" value={t("openstack.states." + serverStatus.toLowerCase())} />
 
-        {shouldRenderDiagnostics &&
+        {enableDiagnostics && serverStatus === "ACTIVE" &&
           <>
             <Block label="openstack.cputime" value={t("common.duration", { value: uptime / 1000000000 })} />
             <Block label="resources.mem" value={t("common.percent", { value: memoryUsage.toFixed() })} />
@@ -80,7 +79,7 @@ function ServerComponent(service) {
   );
 }
 
-function ClusterComponent(service) {
+function ClusterComponent({ service }) {
   const { widget } = service;
   const { data, error } = useWidgetAPI(widget, "servers");
 

--- a/src/widgets/openstack/component.jsx
+++ b/src/widgets/openstack/component.jsx
@@ -28,7 +28,7 @@ function ServerComponent({ service }) {
 
   if (serverError) {
     return <Container service={service} error={serverError} />;
-  } else if (diagnosticsError) {
+  } else if (diagnosticsError && diagnosticsError.status !== 409) {
     return <Container service={service} error={diagnosticsError} />;
   }
 

--- a/src/widgets/openstack/component.jsx
+++ b/src/widgets/openstack/component.jsx
@@ -18,9 +18,10 @@ function ServerComponent(service) {
   const { widget } = service;
   const { enableDiagnostics = true, enableNetwork = true } = widget;
   const { data: serverData, error: serverError } = useWidgetAPI(widget, "server");
+  const shouldRenderDiagnostics = enableDiagnostics && serverData?.server?.status === "ACTIVE";
   
   let diagnosticsData, diagnosticsError;
-  if (enableDiagnostics) {
+  if (shouldRenderDiagnostics) {
     const diagnosticsResult = useWidgetAPI(widget, "diagnostics");
     diagnosticsData = diagnosticsResult.data;
     diagnosticsError = diagnosticsResult.error;
@@ -32,7 +33,7 @@ function ServerComponent(service) {
     return <Container service={service} error={diagnosticsError} />;
   }
 
-  if (!serverData || (enableDiagnostics && !diagnosticsData)) {
+  if (!serverData || (shouldRenderDiagnostics && !diagnosticsData)) {
     return (
       <Container service={service}>
           <Block label="openstack.name"/>
@@ -56,7 +57,7 @@ function ServerComponent(service) {
         <Block label="openstack.name" value={serverName} />
         <Block label="openstack.status" value={t("openstack.states." + serverStatus.toLowerCase())} />
 
-        {enableDiagnostics && serverStatus === "ACTIVE" &&
+        {shouldRenderDiagnostics &&
           <>
             <Block label="openstack.cputime" value={t("common.duration", { value: uptime / 1000000000 })} />
             <Block label="resources.mem" value={t("common.percent", { value: memoryUsage.toFixed() })} />

--- a/src/widgets/openstack/component.jsx
+++ b/src/widgets/openstack/component.jsx
@@ -1,16 +1,19 @@
+import { useTranslation } from "next-i18next";
+
 import Container from "components/services/widget/container";
 import Block from "components/services/widget/block";
 import useWidgetAPI from "utils/proxy/use-widget-api";
-import { useTranslation } from "next-i18next";
 
 export default function Component({ service }) {
-  const { widget: { server: isServerWidget } } = service;
-  
+  const {
+    widget: { server: isServerWidget },
+  } = service;
+
   if (isServerWidget) {
-    return <ServerComponent service={service}/>;
-  } else {
-    return <ClusterComponent service={service}/>;
+    return <ServerComponent service={service} />;
   }
+
+  return <ClusterComponent service={service} />;
 }
 
 function ServerComponent({ service }) {
@@ -18,13 +21,7 @@ function ServerComponent({ service }) {
   const { widget } = service;
   const { enableDiagnostics = true, enableNetwork = true } = widget;
   const { data: serverData, error: serverError } = useWidgetAPI(widget, "server");
-
-  let diagnosticsData, diagnosticsError;
-  if (enableDiagnostics) {
-    const diagnosticsResult = useWidgetAPI(widget, "diagnostics");
-    diagnosticsData = diagnosticsResult.data;
-    diagnosticsError = diagnosticsResult.error;
-  }
+  const { data: diagnosticsData, error: diagnosticsError } = useWidgetAPI(widget, "diagnostics");
 
   if (serverError) {
     return <Container service={service} error={serverError} />;
@@ -35,46 +32,50 @@ function ServerComponent({ service }) {
   if (!serverData || (enableDiagnostics && !diagnosticsData)) {
     return (
       <Container service={service}>
-          <Block label="openstack.name"/>
-          <Block label="openstack.status"/>
-          {enableDiagnostics && 
-            <>            
-              <Block label="openstack.cputime"/>
-              <Block label="resources.mem"/>
-            </>
-          }
+        <Block label="openstack.name" />
+        <Block label="openstack.status" />
+        {enableDiagnostics && (
+          <>
+            <Block label="openstack.cputime" />
+            <Block label="resources.mem" />
+          </>
+        )}
       </Container>
     );
   }
-  
-  const { server: { "status": serverStatus, name: serverName } } = serverData;
+
+  const {
+    server: { status: serverStatus, name: serverName },
+  } = serverData;
   const uptime = diagnosticsData?.cpu0_time;
-  const memoryUsage = (diagnosticsData?.["memory-rss"] / diagnosticsData?.["memory-actual"]) * 100;
+  let memoryUsage;
+  if (enableDiagnostics && serverStatus === "ACTIVE") {
+    memoryUsage = (diagnosticsData["memory-rss"] / diagnosticsData["memory-actual"]) * 100;
+  }
 
   return (
     <Container service={service}>
-        <Block label="openstack.name" value={serverName} />
-        <Block label="openstack.status" value={t("openstack.states." + serverStatus.toLowerCase())} />
+      <Block label="openstack.name" value={serverName} />
+      <Block label="openstack.status" value={t(`openstack.states.${serverStatus.toLowerCase()}`)} />
 
-        {enableDiagnostics && serverStatus === "ACTIVE" &&
-          <>
-            <Block label="openstack.cputime" value={t("common.duration", { value: uptime / 1000000000 })} />
-            <Block label="resources.mem" value={t("common.percent", { value: memoryUsage.toFixed() })} />
-          </>
-        }
+      {enableDiagnostics && serverStatus === "ACTIVE" && (
+        <>
+          <Block label="openstack.cputime" value={t("common.duration", { value: uptime / 1000000000 })} />
+          <Block label="resources.mem" value={t("common.percent", { value: memoryUsage.toFixed() })} />
+        </>
+      )}
 
-        {enableDiagnostics && serverStatus !== "ACTIVE" &&
-          <>
-            <Block label="openstack.cputime"/>
-            <Block label="resources.mem"/>
-          </>
-        }
-        
-        {enableNetwork &&
-          Object.entries(serverData.server.addresses).map(([name, network]) => (
-            <Block label={name} value={network[0].addr} />
-          ))
-        }
+      {enableDiagnostics && serverStatus !== "ACTIVE" && (
+        <>
+          <Block label="openstack.cputime" />
+          <Block label="resources.mem" />
+        </>
+      )}
+
+      {enableNetwork &&
+        Object.entries(serverData.server.addresses).map(([name, network]) => (
+          <Block key={name} label={name} value={network[0].addr} />
+        ))}
     </Container>
   );
 }
@@ -90,10 +91,10 @@ function ClusterComponent({ service }) {
   if (!data) {
     return (
       <Container service={service}>
-          <Block label="openstack.total"/>
-          <Block label="openstack.states.active"/>
-          <Block label="openstack.states.shutoff"/>
-          <Block label="openstack.states.other"/>
+        <Block label="openstack.total" />
+        <Block label="openstack.states.active" />
+        <Block label="openstack.states.shutoff" />
+        <Block label="openstack.states.other" />
       </Container>
     );
   }
@@ -102,25 +103,25 @@ function ClusterComponent({ service }) {
   let shutoffCount = 0;
   let othersCount = 0;
 
-  data.servers.forEach(server => {
+  data.servers.forEach((server) => {
     switch (server.status) {
       case "ACTIVE":
-        activeCount++;
+        activeCount += 1;
         break;
       case "SHUTOFF":
-        shutoffCount++;
+        shutoffCount += 1;
         break;
       default:
-        othersCount++;
+        othersCount += 1;
     }
   });
 
   return (
     <Container service={service}>
-        <Block label="openstack.total" value={data.servers.length}/>
-        <Block label="openstack.states.active" value={activeCount}/>
-        <Block label="openstack.states.shutoff" value={shutoffCount}/>
-        <Block label="openstack.states.other" value={othersCount}/>
+      <Block label="openstack.total" value={data.servers.length} />
+      <Block label="openstack.states.active" value={activeCount} />
+      <Block label="openstack.states.shutoff" value={shutoffCount} />
+      <Block label="openstack.states.other" value={othersCount} />
     </Container>
   );
 }

--- a/src/widgets/openstack/component.jsx
+++ b/src/widgets/openstack/component.jsx
@@ -1,0 +1,59 @@
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+import { useTranslation } from "next-i18next";
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+  const { widget } = service;
+  const { data: serverData, error: serverError } = useWidgetAPI(widget, "server");
+  const { data: diagnosticsData, error: diagnosticsError } = useWidgetAPI(widget, "serverDiagnostics");
+
+  if (serverError) {
+    return <Container service={service} error={serverError} />;
+  } else if (diagnosticsError) {
+    return <Container service={service} error={diagnosticsError} />;
+  }
+
+  if (!diagnosticsData || !serverData) {
+    return (
+      <Container service={service}>
+          <Block label="openstack.name"/>
+          <Block label="openstack.status"/>
+          <Block label="openstack.cputime"/>
+          <Block label="resources.mem"/>
+      </Container>
+    );
+  }
+  
+  const { server: { status: serverStatus, name: serverName } } = serverData;
+  const uptime = diagnosticsData.cpu0_time;
+  const memoryUsage = (diagnosticsData["memory-rss"] / diagnosticsData["memory-actual"]) * 100;
+
+  return (
+    <Container service={service}>
+        <Block label="openstack.name" value={serverName} />
+        <Block label="openstack.status" value={t("openstack.states." + serverStatus.toLowerCase())} />
+
+        {serverStatus === 'ACTIVE' &&
+          <>
+            <Block label="openstack.cputime" value={t("common.duration", { value: uptime / 1000000000 })} />
+            <Block label="resources.mem" value={t("common.percent", { value: memoryUsage.toFixed() })} />
+          </>
+        }
+
+        {serverStatus !== 'ACTIVE' &&
+          <>
+            <Block label="openstack.cputime"/>
+            <Block label="resources.mem"/>
+          </>
+        }
+        
+        {
+          Object.entries(serverData.server.addresses).map(([name, network]) => (
+            <Block label={name} value={network[0].addr} />
+          ))
+        }
+    </Container>
+  );
+}

--- a/src/widgets/openstack/component.jsx
+++ b/src/widgets/openstack/component.jsx
@@ -6,20 +6,33 @@ import { useTranslation } from "next-i18next";
 export default function Component({ service }) {
   const { t } = useTranslation();
   const { widget } = service;
+  const { enableDiagnostics = true, enableNetwork = true } = widget;
   const { data: serverData, error: serverError } = useWidgetAPI(widget, "server");
-  const { data: diagnosticsData, error: diagnosticsError } = useWidgetAPI(widget, "serverDiagnostics");
+  
+  let diagnosticsData, diagnosticsError;
+  if (enableDiagnostics) {
+    const diagnosticsResult = useWidgetAPI(widget, "diagnostics");
+    diagnosticsData = diagnosticsResult.data;
+    diagnosticsError = diagnosticsResult.error;
+  }
 
   if (serverError) {
     return <Container service={service} error={serverError} />;
-  } 
+  } else if (diagnosticsError) {
+    return <Container service={service} error={diagnosticsError} />;
+  }
 
-  if (!serverData) {
+  if (!serverData || (enableDiagnostics && !diagnosticsData)) {
     return (
       <Container service={service}>
           <Block label="openstack.name"/>
           <Block label="openstack.status"/>
-          <Block label="openstack.cputime"/>
-          <Block label="resources.mem"/>
+          {enableDiagnostics && 
+            <>            
+              <Block label="openstack.cputime"/>
+              <Block label="resources.mem"/>
+            </>
+          }
       </Container>
     );
   }
@@ -33,21 +46,21 @@ export default function Component({ service }) {
         <Block label="openstack.name" value={serverName} />
         <Block label="openstack.status" value={t("openstack.states." + serverStatus.toLowerCase())} />
 
-        {serverStatus === "ACTIVE" && !diagnosticsError &&
+        {enableDiagnostics && serverStatus === "ACTIVE" &&
           <>
             <Block label="openstack.cputime" value={t("common.duration", { value: uptime / 1000000000 })} />
             <Block label="resources.mem" value={t("common.percent", { value: memoryUsage.toFixed() })} />
           </>
         }
 
-        {serverStatus !== "ACTIVE" || diagnosticsError &&
+        {enableDiagnostics && serverStatus !== "ACTIVE" &&
           <>
             <Block label="openstack.cputime"/>
             <Block label="resources.mem"/>
           </>
         }
         
-        {
+        {enableNetwork &&
           Object.entries(serverData.server.addresses).map(([name, network]) => (
             <Block label={name} value={network[0].addr} />
           ))

--- a/src/widgets/openstack/widget.js
+++ b/src/widgets/openstack/widget.js
@@ -1,20 +1,20 @@
 import openstackProxyHandler from "utils/proxy/handlers/openstack"; 
 
 const widget =  {
-  api: "{url}/{endpoint}" ,
+  api: "{url}/{version}/{endpoint}" ,
   proxyHandler: openstackProxyHandler,
 
   mappings:  {
     servers:  {
-      endpoint: "{version}/servers/detail",
+      endpoint: "servers/detail",
       validate: ["servers"]
     },
     server:  {
-      endpoint: "{version}/servers/{server}",
+      endpoint: "servers/{server}",
       validate: ["server"]
     },
     diagnostics:  {
-      endpoint: "{version}/servers/{server}/diagnostics",
+      endpoint: "servers/{server}/diagnostics",
       validate: ["cpu0_time", "memory-rss", "memory-actual"]
     },
   },

--- a/src/widgets/openstack/widget.js
+++ b/src/widgets/openstack/widget.js
@@ -1,4 +1,3 @@
-import { validate } from "compare-versions";
 import openstackProxyHandler from "utils/proxy/handlers/openstack"; 
 
 const widget =  {
@@ -7,11 +6,11 @@ const widget =  {
 
   mappings:  {
     server:  {
-      endpoint: "v2.1/servers/{server}",
+      endpoint: "{version}/servers/{server}",
       validate: ["server"]
     },
     serverDiagnostics:  {
-      endpoint: "v2.1/servers/{server}/diagnostics",
+      endpoint: "{version}/servers/{server}/diagnostics",
       validate: ["cpu0_time", "memory-rss", "memory-actual"]
     },
   },

--- a/src/widgets/openstack/widget.js
+++ b/src/widgets/openstack/widget.js
@@ -1,0 +1,20 @@
+import { validate } from "compare-versions";
+import openstackProxyHandler from "utils/proxy/handlers/openstack"; 
+
+const widget =  {
+  api: "{url}/{endpoint}" ,
+  proxyHandler: openstackProxyHandler,
+
+  mappings:  {
+    server:  {
+      endpoint: "v2.1/servers/{server}",
+      validate: ["server"]
+    },
+    serverDiagnostics:  {
+      endpoint: "v2.1/servers/{server}/diagnostics",
+      validate: ["cpu0_time", "memory-rss", "memory-actual"]
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/openstack/widget.js
+++ b/src/widgets/openstack/widget.js
@@ -1,21 +1,21 @@
-import openstackProxyHandler from "utils/proxy/handlers/openstack"; 
+import openstackProxyHandler from "utils/proxy/handlers/openstack";
 
-const widget =  {
-  api: "{url}/{version}/{endpoint}" ,
+const widget = {
+  api: "{url}/{version}/{endpoint}",
   proxyHandler: openstackProxyHandler,
 
-  mappings:  {
-    servers:  {
+  mappings: {
+    servers: {
       endpoint: "servers/detail",
-      validate: ["servers"]
+      validate: ["servers"],
     },
-    server:  {
+    server: {
       endpoint: "servers/{server}",
-      validate: ["server"]
+      validate: ["server"],
     },
-    diagnostics:  {
+    diagnostics: {
       endpoint: "servers/{server}/diagnostics",
-      validate: ["cpu0_time", "memory-rss", "memory-actual"]
+      validate: ["cpu0_time", "memory-rss", "memory-actual"],
     },
   },
 };

--- a/src/widgets/openstack/widget.js
+++ b/src/widgets/openstack/widget.js
@@ -9,7 +9,7 @@ const widget =  {
       endpoint: "{version}/servers/{server}",
       validate: ["server"]
     },
-    serverDiagnostics:  {
+    diagnostics:  {
       endpoint: "{version}/servers/{server}/diagnostics",
       validate: ["cpu0_time", "memory-rss", "memory-actual"]
     },

--- a/src/widgets/openstack/widget.js
+++ b/src/widgets/openstack/widget.js
@@ -5,6 +5,10 @@ const widget =  {
   proxyHandler: openstackProxyHandler,
 
   mappings:  {
+    servers:  {
+      endpoint: "{version}/servers/detail",
+      validate: ["servers"]
+    },
     server:  {
       endpoint: "{version}/servers/{server}",
       validate: ["server"]

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -79,6 +79,7 @@ import opendtu from "./opendtu/widget";
 import opnsense from "./opnsense/widget";
 import overseerr from "./overseerr/widget";
 import openmediavault from "./openmediavault/widget";
+import openstack from "./openstack/widget";
 import openwrt from "./openwrt/widget";
 import paperlessngx from "./paperlessngx/widget";
 import peanut from "./peanut/widget";
@@ -215,6 +216,7 @@ const widgets = {
   opnsense,
   overseerr,
   openmediavault,
+  openstack,
   openwrt,
   paperlessngx,
   peanut,


### PR DESCRIPTION
## Proposed change

Adds a widget for displaying information about an OpenStack cluster or server.

![Screenshot_20250311_213453](https://github.com/user-attachments/assets/7556a0b0-af2f-4b63-acb6-a9dc9209495a)

```yaml
widget:
  type: openstack
  version: v2.1
  identityUrl: http://keystone.host.or.ip:port
  url: http://openstack.host.or.ip:port
  appCredId: app_credential_id
  appCredName: app_credential_name
  appCredSecret: app_credential_secret
  server: server_id # optional, will display cluster stats if omitted
  enableDiagnostics: false # optional, only applicable for server widget
  enableNetwork: true # optional, only applicable for server widget
```

Includes a custom proxy handler for fetching an authentication token from Keystone IDP.
Includes a caching mechanism in order to avoid unneccessary API requests to Identity API.
Currently supports Identity API v3 and Compute API v2.1.

## Type of change

- [X] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [X] If applicable, I have added corresponding documentation changes.
- [X] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [X] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [X] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
