### PR TITLE
Fix: correct units for speedtest tracker API v2

### DIFF
--- a/docs/widgets/services/komga.md
+++ b/docs/widgets/services/komga.md
@@ -20,4 +20,5 @@ widget:
   url: http://komga.host.or.ip:port
   username: username
   password: password
+  key: komgaapikey # optional
 ```

--- a/docs/widgets/services/komga.md
+++ b/docs/widgets/services/komga.md
@@ -20,5 +20,4 @@ widget:
   url: http://komga.host.or.ip:port
   username: username
   password: password
-  key: komgaapikey # optional
 ```

--- a/src/widgets/speedtest/component.jsx
+++ b/src/widgets/speedtest/component.jsx
@@ -36,14 +36,14 @@ export default function Component({ service }) {
       <Block
         label="speedtest.download"
         value={t("common.bitrate", {
-          value: speedtestData.data.download * 1000 * 1000,
+          value: widget.version === 2 ? speedtestData.data.download * 8 : speedtestData.data.download * 1000 * 1000,
           decimals: bitratePrecision,
         })}
       />
       <Block
         label="speedtest.upload"
         value={t("common.bitrate", {
-          value: speedtestData.data.upload * 1000 * 1000,
+          value: widget.version === 2 ? speedtestData.data.upload * 8 : speedtestData.data.upload * 1000 * 1000,
           decimals: bitratePrecision,
         })}
       />


### PR DESCRIPTION
<!--
==== STOP ====================
======== STOP ================
============ STOP ============
================ STOP ========
==================== STOP ====

⚠️ Before opening this pull request please review the guidelines in the checklist below.

If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.
-->

## Proposed change

<!--
Speed test tracker interface v2 download and upload are in bits
-->

Closes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
