### PR TITLE
Add XML-RPC support for ruTorrent widget

### DIFF
--- a/docs/widgets/services/rutorrent.md
+++ b/docs/widgets/services/rutorrent.md
@@ -16,3 +16,14 @@ widget:
   username: username # optional, false if not used
   password: password # optional, false if not used
 ```
+
+Some seedboxes may use an alternate XMLRPC endpoint, if that's the case the below configuration may work
+```yaml
+widget:
+  type: rutorrent
+  xmlrpc: true
+  host: http://rutorrent.host.or.ip
+  endpoint: /xmlrpc
+  username: username # optional, false if not used
+  password: password # optional, false if not used
+```

--- a/docs/widgets/services/rutorrent.md
+++ b/docs/widgets/services/rutorrent.md
@@ -18,6 +18,7 @@ widget:
 ```
 
 Some seedboxes may use an alternate XMLRPC endpoint, if that's the case the below configuration may work
+
 ```yaml
 widget:
   type: rutorrent

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "tough-cookie": "^5.1.2",
     "urbackup-server-api": "^0.8.9",
     "winston": "^3.17.0",
-    "xml-js": "^1.6.11"
+    "xml-js": "^1.6.11",
+    "xmlrpc": "^1.3.2"
   },
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,10 +101,9 @@ importers:
       xml-js:
         specifier: ^1.6.11
         version: 1.6.11
-    optionalDependencies:
-      osx-temperature-sensor:
-        specifier: ^1.0.8
-        version: 1.0.8
+      xmlrpc:
+        specifier: ^1.3.2
+        version: 1.3.2
     devDependencies:
       '@tailwindcss/forms':
         specifier: ^0.5.10
@@ -151,6 +150,10 @@ importers:
       typescript:
         specifier: ^5.7.3
         version: 5.7.3
+    optionalDependencies:
+      osx-temperature-sensor:
+        specifier: ^1.0.8
+        version: 1.0.8
 
 packages:
 
@@ -3918,7 +3921,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.2(eslint-plugin-import@2.31.0)(eslint@9.21.0(jiti@2.4.2)))(eslint@9.21.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.2)(eslint@9.21.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -3940,7 +3943,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.21.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.2(eslint-plugin-import@2.31.0)(eslint@9.21.0(jiti@2.4.2)))(eslint@9.21.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.24.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.2)(eslint@9.21.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/src/widgets/rutorrent/proxy.js
+++ b/src/widgets/rutorrent/proxy.js
@@ -68,25 +68,18 @@ export default async function rutorrentProxyHandler(req, res) {
         let options = {
           strictSSL: false,
           rejectUnauthorized: false,
-          url: url.toString()
-        }
+          url: url.toString(),
+        };
 
         if (widget.username) {
           options.basic_auth = {
             user: widget.username,
             pass: widget.password,
-          }
+          };
         }
 
         const client = xmlrpc.createSecureClient(options);
-        const multicallParams = [
-          "",
-          "main",
-          "d.hash=",
-          "d.down.rate=",
-          "d.up.rate=",
-          "d.state="
-        ];
+        const multicallParams = ["", "main", "d.hash=", "d.down.rate=", "d.up.rate=", "d.state="];
 
         let result;
         try {
@@ -116,7 +109,7 @@ export default async function rutorrentProxyHandler(req, res) {
               hash: hashString,
               "d.get_down_rate": downRate,
               "d.get_up_rate": upRate,
-              "d.get_state": state
+              "d.get_state": state,
             };
           });
 
@@ -149,7 +142,9 @@ export default async function rutorrentProxyHandler(req, res) {
 
           return res.status(200).send(parsedData);
         } catch (e) {
-          return res.status(500).json({ error: { message: e?.toString() ?? "Error parsing rutorrent data", url, data } });
+          return res
+            .status(500)
+            .json({ error: { message: e?.toString() ?? "Error parsing rutorrent data", url, data } });
         }
       }
     }


### PR DESCRIPTION
## Proposed change
Adds support for XMLRPC endpoints in ruTorrent.

Closes/Relates To:
#1166
#682 


## Type of change

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
