### PR TITLE
Documentation: add HOMEPAGE_ALLOWED_HOSTS to k8s docs

### DIFF
--- a/docs/installation/k8s.md
+++ b/docs/installation/k8s.md
@@ -302,6 +302,9 @@ spec:
         - name: homepage
           image: "ghcr.io/gethomepage/homepage:latest"
           imagePullPolicy: Always
+          env:
+            - name: HOMEPAGE_ALLOWED_HOSTS
+              value: gethomepage.dev # required, may need port
           ports:
             - name: http
               containerPort: 3000


### PR DESCRIPTION
<!--
==== STOP ====================
======== STOP ================
============ STOP ============
================ STOP ========
==================== STOP ====

⚠️ Before opening this pull request please review the guidelines in the checklist below.

If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.
-->

## Minor Update To K8s Installation Example


The goal of this PR is to add the newly required `HOMEPAGE_ALLOWED_HOSTS` environment variable to the kubernetes installation page. Specifically, the deployment manifest example.

![CleanShot 2025-03-15 at 10 34 30](https://github.com/user-attachments/assets/b3ea2c6d-ebc2-4cea-98e6-c6273294d969)


## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [x] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
