### PR TITLE
Change: re-enable k8s ingress by default

### DIFF
--- a/docs/configs/kubernetes.md
+++ b/docs/configs/kubernetes.md
@@ -25,13 +25,13 @@ To configure Kubernetes gateway-api, ingress or ingressRoute service discovery, 
 Example settings:
 
 ```yaml
-ingress: true # enable ingress only
+ingress: true # default, enable ingress only
 ```
 
 or
 
 ```yaml
-ingress: true # enable ingress
+ingress: true # default, enable ingress
 traefik: true # enable traefik ingressRoute
 gateway: true # enable gateway-api
 ```

--- a/k3d/k3d-helm-values.yaml
+++ b/k3d/k3d-helm-values.yaml
@@ -43,7 +43,6 @@ config:
         target: _blank
   kubernetes:
     mode: cluster
-    ingress: true
   docker:
   settings:
 

--- a/src/utils/kubernetes/ingress-list.js
+++ b/src/utils/kubernetes/ingress-list.js
@@ -8,7 +8,7 @@ const kc = getKubeConfig();
 
 export default async function listIngress() {
   const networking = kc.makeApiClient(NetworkingV1Api);
-  const { ingress } = getKubernetes();
+  const { ingress = true } = getKubernetes();
   let ingressList = [];
 
   if (ingress) {


### PR DESCRIPTION
<!--
==== STOP ====================
======== STOP ================
============ STOP ============
================ STOP ========
==================== STOP ====

⚠️ Before opening this pull request please review the guidelines in the checklist below.

If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.
-->

## Proposed change

@djeinstine @dudo sorry to keep bothering you guys, but now that I can run a little k3d cluster I was able to look at this, I was considering making `ingress: true` the default (aka not make 1.0 changes breaking). I believe this change will do it but the question is whether this will have other effects?

Thanks again for all your help

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [x] Other (please explain)