### PR TITLE
More precise information in kubernetes.md

### DIFF
--- a/docs/configs/kubernetes.md
+++ b/docs/configs/kubernetes.md
@@ -20,12 +20,12 @@ The Kubernetes connection is configured in the `kubernetes.yaml` file. There are
 mode: default
 ```
 
-To configure Kubernetes gateway-api, ingress or ingressRoute service discovery, add one or multiple of the following settings.
+To configure Kubernetes gateway-api, ingress or ingressRoute service discovery, add one or multiple of the following settings. At least one setting must be set for service discovery via annotation to work.
 
 Example settings:
 
 ```yaml
-ingress: true # default, enable ingress only
+ingress: true # enable ingress only
 ```
 
 or


### PR DESCRIPTION


## Proposed change

More precise information in kubernetes.md about the configuration. The current information about ingress being optional is misleading. It suggests that you won't have to set ingress, because it is the default. This is not true. If not set, no annotation will be evaluated and the elements won't appear on the homepage.

Closes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [x] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
