### PR TITLE
Enhancement: Add Repositories field to Gitea

### DIFF
--- a/docs/widgets/services/gitea.md
+++ b/docs/widgets/services/gitea.md
@@ -7,7 +7,7 @@ Learn more about [Gitea](https://gitea.com).
 
 API token requires `notifications`, `repository` and `issue` permissions. See the [gitea documentation](https://docs.gitea.com/development/api-usage#generating-and-listing-api-tokens) for details on generating tokens.
 
-Allowed fields: `["notifications", "issues", "pulls"]`.
+Allowed fields: `["repositories", "notifications", "issues", "pulls"]`.
 
 ```yaml
 widget:

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -883,7 +883,7 @@
         "species": "Species"
     },
     "gitea": {
-        "repositories" : "Repositories",
+        "repositories": "Repositories",
         "notifications": "Notifications",
         "issues": "Issues",
         "pulls": "Pull Requests"

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -883,10 +883,10 @@
         "species": "Species"
     },
     "gitea": {
-        "repositories": "Repositories",
-        "notifications": "Notifications",
-        "issues": "Issues",
-        "pulls": "Pull Requests"
+      "notifications": "Notifications",
+      "issues": "Issues",
+      "pulls": "Pull Requests",
+      "repositories": "Repositories"
     },
     "stash": {
         "scenes": "Scenes",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -883,6 +883,7 @@
         "species": "Species"
     },
     "gitea": {
+        "repositories" : "Repositories",
         "notifications": "Notifications",
         "issues": "Issues",
         "pulls": "Pull Requests"

--- a/src/widgets/gitea/component.jsx
+++ b/src/widgets/gitea/component.jsx
@@ -1,5 +1,6 @@
 import Container from "components/services/widget/container";
 import Block from "components/services/widget/block";
+
 import useWidgetAPI from "utils/proxy/use-widget-api";
 
 export default function Component({ service }) {

--- a/src/widgets/gitea/component.jsx
+++ b/src/widgets/gitea/component.jsx
@@ -1,6 +1,5 @@
 import Container from "components/services/widget/container";
 import Block from "components/services/widget/block";
-
 import useWidgetAPI from "utils/proxy/use-widget-api";
 
 export default function Component({ service }) {
@@ -8,17 +7,19 @@ export default function Component({ service }) {
 
   const { data: giteaNotifications, error: giteaNotificationsError } = useWidgetAPI(widget, "notifications");
   const { data: giteaIssues, error: giteaIssuesError } = useWidgetAPI(widget, "issues");
+  const { data: giteaRepositories, error: giteaRepositoriesError } = useWidgetAPI(widget, "repositories");
 
-  if (giteaNotificationsError || giteaIssuesError) {
-    return <Container service={service} error={giteaNotificationsError ?? giteaIssuesError} />;
+  if (giteaNotificationsError || giteaIssuesError || giteaRepositoriesError) {
+    return <Container service={service} error={giteaNotificationsError ?? giteaIssuesError ?? giteaRepositoriesError} />;
   }
 
-  if (!giteaNotifications || !giteaIssues) {
+  if (!giteaNotifications || !giteaIssues || !giteaRepositories) {
     return (
       <Container service={service}>
         <Block label="gitea.notifications" />
         <Block label="gitea.issues" />
         <Block label="gitea.pulls" />
+        <Block label="gitea.repositories" />
       </Container>
     );
   }
@@ -28,6 +29,7 @@ export default function Component({ service }) {
       <Block label="gitea.notifications" value={giteaNotifications.length} />
       <Block label="gitea.issues" value={giteaIssues.issues.length} />
       <Block label="gitea.pulls" value={giteaIssues.pulls.length} />
+      <Block label="gitea.repositories" value={giteaRepositories} />
     </Container>
   );
 }

--- a/src/widgets/gitea/component.jsx
+++ b/src/widgets/gitea/component.jsx
@@ -1,28 +1,17 @@
 import Container from "components/services/widget/container";
 import Block from "components/services/widget/block";
+
 import useWidgetAPI from "utils/proxy/use-widget-api";
 
 export default function Component({ service }) {
   const { widget } = service;
 
-  const { data: giteaNotifications, error: giteaNotificationsError } =
-    useWidgetAPI(widget, "notifications");
-  const { data: giteaIssues, error: giteaIssuesError } = useWidgetAPI(
-    widget,
-    "issues"
-  );
-  const { data: giteaRepositories, error: giteaRepositoriesError } =
-    useWidgetAPI(widget, "repositories");
+  const { data: giteaNotifications, error: giteaNotificationsError } = useWidgetAPI(widget, "notifications");
+  const { data: giteaIssues, error: giteaIssuesError } = useWidgetAPI(widget, "issues");
+  const { data: giteaRepositories, error: giteaRepositoriesError } = useWidgetAPI(widget, "repositories");
 
   if (giteaNotificationsError || giteaIssuesError || giteaRepositoriesError) {
-    return (
-      <Container
-        service={service}
-        error={
-          giteaNotificationsError ?? giteaIssuesError ?? giteaRepositoriesError
-        }
-      />
-    );
+    return <Container service={service} error={giteaNotificationsError ?? giteaIssuesError ?? giteaRepositoriesError} />;
   }
 
   if (!giteaNotifications || !giteaIssues || !giteaRepositories) {

--- a/src/widgets/gitea/component.jsx
+++ b/src/widgets/gitea/component.jsx
@@ -32,7 +32,7 @@ export default function Component({ service }) {
       <Block label="gitea.notifications" value={giteaNotifications.length} />
       <Block label="gitea.issues" value={giteaIssues.issues.length} />
       <Block label="gitea.pulls" value={giteaIssues.pulls.length} />
-      <Block label="gitea.repositories" value={giteaRepositories} />
+      <Block label="gitea.repositories" value={giteaRepositories.data.length} />
     </Container>
   );
 }

--- a/src/widgets/gitea/component.jsx
+++ b/src/widgets/gitea/component.jsx
@@ -11,7 +11,9 @@ export default function Component({ service }) {
   const { data: giteaRepositories, error: giteaRepositoriesError } = useWidgetAPI(widget, "repositories");
 
   if (giteaNotificationsError || giteaIssuesError || giteaRepositoriesError) {
-    return <Container service={service} error={giteaNotificationsError ?? giteaIssuesError ?? giteaRepositoriesError} />;
+    return (
+      <Container service={service} error={giteaNotificationsError ?? giteaIssuesError ?? giteaRepositoriesError} />
+    );
   }
 
   if (!giteaNotifications || !giteaIssues || !giteaRepositories) {

--- a/src/widgets/gitea/component.jsx
+++ b/src/widgets/gitea/component.jsx
@@ -11,12 +11,7 @@ export default function Component({ service }) {
   const { data: giteaRepositories, error: giteaRepositoriesError } = useWidgetAPI(widget, "repositories");
 
   if (giteaNotificationsError || giteaIssuesError || giteaRepositoriesError) {
-    return (
-      <Container
-        service={service}
-        error={giteaNotificationsError ?? giteaIssuesError ?? giteaRepositoriesError}
-      />
-    );
+    return <Container service={service} error={giteaNotificationsError ?? giteaIssuesError ?? giteaRepositoriesError} />;
   }
 
   if (!giteaNotifications || !giteaIssues || !giteaRepositories) {

--- a/src/widgets/gitea/component.jsx
+++ b/src/widgets/gitea/component.jsx
@@ -11,7 +11,12 @@ export default function Component({ service }) {
   const { data: giteaRepositories, error: giteaRepositoriesError } = useWidgetAPI(widget, "repositories");
 
   if (giteaNotificationsError || giteaIssuesError || giteaRepositoriesError) {
-    return <Container service={service} error={giteaNotificationsError ?? giteaIssuesError ?? giteaRepositoriesError} />;
+    return (
+      <Container
+        service={service}
+        error={giteaNotificationsError ?? giteaIssuesError ?? giteaRepositoriesError}
+      />
+    );
   }
 
   if (!giteaNotifications || !giteaIssues || !giteaRepositories) {

--- a/src/widgets/gitea/component.jsx
+++ b/src/widgets/gitea/component.jsx
@@ -1,17 +1,28 @@
 import Container from "components/services/widget/container";
 import Block from "components/services/widget/block";
-
 import useWidgetAPI from "utils/proxy/use-widget-api";
 
 export default function Component({ service }) {
   const { widget } = service;
 
-  const { data: giteaNotifications, error: giteaNotificationsError } = useWidgetAPI(widget, "notifications");
-  const { data: giteaIssues, error: giteaIssuesError } = useWidgetAPI(widget, "issues");
-  const { data: giteaRepositories, error: giteaRepositoriesError } = useWidgetAPI(widget, "repositories");
+  const { data: giteaNotifications, error: giteaNotificationsError } =
+    useWidgetAPI(widget, "notifications");
+  const { data: giteaIssues, error: giteaIssuesError } = useWidgetAPI(
+    widget,
+    "issues"
+  );
+  const { data: giteaRepositories, error: giteaRepositoriesError } =
+    useWidgetAPI(widget, "repositories");
 
   if (giteaNotificationsError || giteaIssuesError || giteaRepositoriesError) {
-    return <Container service={service} error={giteaNotificationsError ?? giteaIssuesError ?? giteaRepositoriesError} />;
+    return (
+      <Container
+        service={service}
+        error={
+          giteaNotificationsError ?? giteaIssuesError ?? giteaRepositoriesError
+        }
+      />
+    );
   }
 
   if (!giteaNotifications || !giteaIssues || !giteaRepositories) {

--- a/src/widgets/gitea/widget.js
+++ b/src/widgets/gitea/widget.js
@@ -18,7 +18,6 @@ const widget = {
     },
     repositories: {
       endpoint: "repos/search",
-      map: (data) => asJson(data).total_count,
     },
   },
 };

--- a/src/widgets/gitea/widget.js
+++ b/src/widgets/gitea/widget.js
@@ -16,6 +16,10 @@ const widget = {
         issues: asJson(data).filter((issue) => !issue.pull_request),
       }),
     },
+    repositories: {
+      endpoint: "repos/search",
+      map: (data) => asJson(data).total_count,
+    },
   },
 };
 


### PR DESCRIPTION

Hey i know Gitea is already present, but it only tracks notifications, issues & pulls, this PR adds repositories also
![337930412-43c82ce7-2da4-4d36-9281-6d9d4dbd3ec9](https://github.com/user-attachments/assets/7a8eb710-c7d4-43a7-8b1b-4aa57ba3971a)


[(Closed Issue)](https://github.com/gethomepage/homepage/discussions/3614)

There was a prevous PR https://github.com/gethomepage/homepage/pull/3615

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
