### PR TITLE
Fix: support shvl on customapi dynamic list target

### DIFF
--- a/src/widgets/customapi/component.jsx
+++ b/src/widgets/customapi/component.jsx
@@ -246,10 +246,14 @@ export default function Component({ service }) {
                 const itemName = shvl.get(item, name, "");
                 const itemLabel = shvl.get(item, label, "");
 
-                const itemUrl = target ? [...target.matchAll(/\{(.*?)\}/g)].map((match) => match[1]).targetReplaces.reduce((url, targetTemplate) => {
-                  const value = shvl.get(item, targetTemplate, "");
-                  return url.replaceAll(`{${targetTemplate}}`, value);
-                }, target) : null;
+                const itemUrl = target
+                  ? [...target.matchAll(/\{(.*?)\}/g)]
+                      .map((match) => match[1])
+                      .reduce((url, targetTemplate) => {
+                        const value = shvl.get(item, targetTemplate, item[targetTemplate]) ?? "";
+                        return url.replaceAll(`{${targetTemplate}}`, value);
+                      }, target)
+                  : null;
                 const className =
                   "bg-theme-200/50 dark:bg-theme-900/20 rounded-sm m-1 flex-1 flex flex-row items-center justify-between p-1 text-xs";
 

--- a/src/widgets/customapi/component.jsx
+++ b/src/widgets/customapi/component.jsx
@@ -245,7 +245,11 @@ export default function Component({ service }) {
               listItems.map((item, index) => {
                 const itemName = shvl.get(item, name, "");
                 const itemLabel = shvl.get(item, label, "");
-                const itemUrl = target ? target.replace(/\{([^}]+)\}/g, (_, key) => item[key] || "") : null;
+
+                const itemUrl = target ? [...target.matchAll(/\{(.*?)\}/g)].map((match) => match[1]).targetReplaces.reduce((url, targetTemplate) => {
+                  const value = shvl.get(item, targetTemplate, "");
+                  return url.replaceAll(`{${targetTemplate}}`, value);
+                }, target) : null;
                 const className =
                   "bg-theme-200/50 dark:bg-theme-900/20 rounded-sm m-1 flex-1 flex flex-row items-center justify-between p-1 text-xs";
 


### PR DESCRIPTION
## Proposed change

Support SHVL syntax on dynamic list target templating
There is no way to access nested fields on dynamic lists `target` field

```
  target: https://example.com/{subject.id}
```
Closes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
