### PR TITLE
Fix: remove unneeded import from Hoarder widget.js

### DIFF
--- a/src/widgets/hoarder/widget.js
+++ b/src/widgets/hoarder/widget.js
@@ -1,5 +1,4 @@
 import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
-import { asJson } from "utils/proxy/api-helpers";
 
 const widget = {
   api: `{url}/api/v1/{endpoint}`,


### PR DESCRIPTION
## Proposed change

Removes the `asJson` import. It was there because I did use it in an older version of the widget.

Closes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
