### PR TITLE
Add iputils to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,8 @@ COPY --link --chmod=755 docker-entrypoint.sh /usr/local/bin/
 COPY --link --from=builder --chown=1000:1000 /app/.next/standalone/ ./
 COPY --link --from=builder --chown=1000:1000 /app/.next/static/ ./.next/static
 
-RUN apk add --no-cache su-exec
+RUN apk add --no-cache su-exec && \
+  apk add --no-cache iputils
 
 ENV NODE_ENV=production
 ENV HOSTNAME=0.0.0.0


### PR DESCRIPTION
## Proposed change

Add the `iputils` package to the Docker image. The `ping:` gadget is not working with the builtin `ping`.
The busybox implementation of `ping` is not compatible with `node-ping`. The suggested fix is to use `iputils`.

Closes # (issue) - not assigned

## Type of change

- [ ] New service widget
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [X] If applicable, I have added corresponding documentation changes.
- [X] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [X] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [X] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
