### PR TITLE
Documentation: add HOMEPAGE_ALLOWED_HOSTS to Unraid docs

### DIFF
--- a/docs/installation/unraid.md
+++ b/docs/installation/unraid.md
@@ -15,6 +15,7 @@ Homepage has an UNRAID community package that you may use to install homepage. T
     - Click `Add another Path, Port, Variable, Label or Device` at the bottom of the page.
     - Click `Variable` and set `HOMEPAGE_ALLOWED_HOSTS` as the key.
     - In the value page enter the same value as the `WebUI` field.
+      - Ex. `192.168.0.1:3000`.  
   - Click on **APPLY**.
 
 ## Run the Container

--- a/docs/installation/unraid.md
+++ b/docs/installation/unraid.md
@@ -15,7 +15,7 @@ Homepage has an UNRAID community package that you may use to install homepage. T
     - Click `Add another Path, Port, Variable, Label or Device` at the bottom of the page.
     - Click `Variable` and set `HOMEPAGE_ALLOWED_HOSTS` as the key.
     - In the value page enter the same value as the `WebUI` field.
-      - Ex. `192.168.0.1:3000`.  
+      - Ex. `192.168.0.1:3000`.
   - Click on **APPLY**.
 
 ## Run the Container

--- a/docs/installation/unraid.md
+++ b/docs/installation/unraid.md
@@ -14,7 +14,7 @@ Homepage has an UNRAID community package that you may use to install homepage. T
   - You may need to add the `HOMEPAGE_ALLOWED_HOSTS` variable to your configuration.
     - Click `Add another Path, Port, Variable, Label or Device` at the bottom of the page.
     - Click `Variable` and set `HOMEPAGE_ALLOWED_HOSTS` as the key.
-    - In the value page enter the same value as the `WebUI` field. 
+    - In the value page enter the same value as the `WebUI` field.
   - Click on **APPLY**.
 
 ## Run the Container

--- a/docs/installation/unraid.md
+++ b/docs/installation/unraid.md
@@ -11,6 +11,10 @@ Homepage has an UNRAID community package that you may use to install homepage. T
 - In the search bar, search for `homepage`.
 - Click on **Install**.
 - Change the parameters to your liking.
+  - You may need to add the `HOMEPAGE_ALLOWED_HOSTS` variable to your configuration.
+    - Click `Add another Path, Port, Variable, Label or Device` at the bottom of the page.
+    - Click `Variable` and set `HOMEPAGE_ALLOWED_HOSTS` as the key.
+    - In the value page enter the same value as the `WebUI` field. 
   - Click on **APPLY**.
 
 ## Run the Container


### PR DESCRIPTION
## Proposed change

I added some language specific to the unraid docs to resolve an issue with the webui not loading on the first contrainer run. 

Closes # (N/A)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [x] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
