### PR TITLE
Fix: kubernetes statistics not respecting selector

### DIFF
--- a/src/pages/api/kubernetes/stats/[...service].js
+++ b/src/pages/api/kubernetes/stats/[...service].js
@@ -53,9 +53,11 @@ export default async function handler(req, res) {
       return;
     }
 
+    const podNames = new Set();
     let cpuLimit = 0;
     let memLimit = 0;
     pods.forEach((pod) => {
+      podNames.add(pod.metadata.name);
       pod.spec.containers.forEach((container) => {
         if (container?.resources?.limits?.cpu) {
           cpuLimit += parseCpu(container?.resources?.limits?.cpu);
@@ -66,42 +68,32 @@ export default async function handler(req, res) {
       });
     });
 
-    const podStatsList = await Promise.all(
-      pods.map(async (pod) => {
-        let depMem = 0;
-        let depCpu = 0;
-        const podMetrics = await metricsApi
-          .getPodMetrics(namespace, pod.items)
-          .then((response) => response.items)
-          .catch((err) => {
-            // 404 generally means that the metrics have not been populated yet
-            if (err.statusCode !== 404) {
-              logger.error("Error getting pod metrics: %d %s %s", err.statusCode, err.body, err.response);
-            }
-            return null;
-          });
-        if (podMetrics) {
-          podMetrics.forEach((metrics) => {
-            metrics.containers.forEach((container) => {
-              depMem += parseMemory(container.usage.memory);
-              depCpu += parseCpu(container.usage.cpu);
-            });
-          });
+    const namespaceMetrics = await metricsApi
+      .getPodMetrics(namespace)
+      .then((response) => response.items)
+      .catch((err) => {
+        // 404 generally means that the metrics have not been populated yet
+        if (err.statusCode !== 404) {
+          logger.error("Error getting pod metrics: %d %s %s", err.statusCode, err.body, err.response);
         }
-        return {
-          mem: depMem,
-          cpu: depCpu,
-        };
-      }),
-    );
+        return null;
+      });
+
     const stats = {
       mem: 0,
       cpu: 0,
     };
-    podStatsList.forEach((podStat) => {
-      stats.mem += podStat.mem;
-      stats.cpu += podStat.cpu;
-    });
+
+    if (namespaceMetrics) {
+      const podMetrics = namespaceMetrics.filter((item) => podNames.has(item.metadata.name));
+      podMetrics.forEach((metrics) => {
+        metrics.containers.forEach((container) => {
+          stats.mem += parseMemory(container.usage.memory);
+          stats.cpu += parseCpu(container.usage.cpu);
+        });
+      });
+    }
+
     stats.cpuLimit = cpuLimit;
     stats.memLimit = memLimit;
     stats.cpuUsage = cpuLimit ? 100 * (stats.cpu / cpuLimit) : 0;


### PR DESCRIPTION
<!--
==== STOP ====================
======== STOP ================
============ STOP ============
================ STOP ========
==================== STOP ====

⚠️ Before opening this pull request please review the guidelines in the checklist below.

If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.
-->

## Proposed change

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

After upgrading to v1, I noticed that my Kubernetes widgets were reporting invalid statistics:

![image](https://github.com/user-attachments/assets/6bca9f05-c0dd-483c-9939-4200515e462a)

This clearly can't be correct, since `kubectl top` reports that it only uses about 1.5gb of memory:

```
NAME                                                     CPU(cores)   MEMORY(bytes)
...
prometheus-grafana-0                                     19m          384Mi
prometheus-kube-prometheus-operator-796b68b4c-qjswh      1m           35Mi
prometheus-kube-state-metrics-c44f8f948-r7mvd            4m           58Mi
prometheus-prometheus-kube-prometheus-prometheus-0       290m         1294Mi
prometheus-prometheus-node-exporter-bnzs7                1m           17Mi
prometheus-prometheus-node-exporter-gr6h6                1m           15Mi
prometheus-prometheus-node-exporter-wsss6                1m           27Mi
...
```

This issue can be reproduced with the following configuration:
```yaml
- My First Group:
    - My First Service:
        href: http://localhost/
        description: Homepage is awesome
        app: homepage
        namespace: services # any namespace with multiple pods
        podSelector: app=homepage # restrict this to a single pod
```

Instead of showing the statistics of the pods in `podSelector`, homepage will show the statistics of the entire namespace *multiplied* by the amount of pods found in the podSelector. This is because `.getPodMetrics(namespace, pod.items)` is returning the metrics for the entire namespace, as it does not accept a second argument.

This pull requests fixes the issue by filtering the metrics by the pods found in the namespace. Since `.getPodMetrics` can only filter by namespace, I also pull the fetch outside to reduce the number of calls from the amount of matched pods to just one. I considered using a simple filter per pod for a minimal diff, but I believe using a Set is the better choice here, in case there are a lot of selected pods, to avoid a `O(n^2)` time complexity.

Here is the same entry, with the fixes applied:

![image](https://github.com/user-attachments/assets/dff244c0-3774-410b-a0fd-c788ecfe7661)


<!-- Closes # (issue) -->

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
