### PR TITLE
Fix: Longhorn still showing Total despite `total: false`

### DIFF
--- a/src/components/widgets/longhorn/longhorn.jsx
+++ b/src/components/widgets/longhorn/longhorn.jsx
@@ -32,8 +32,8 @@ export default function Longhorn({ options }) {
         <div className="flex flex-row self-center flex-wrap justify-between">
           {data.nodes
             .filter((node) => {
-              if (node.id === "total" && total) {
-                return true;
+              if (node.id === "total") {
+                return total;
               }
               if (!nodes) {
                 return false;


### PR DESCRIPTION
The logic was falling to the final `return true` rather than breaking the logic chain when the node.id was matched to `"total"` and return false.

<!--
==== STOP ====================
======== STOP ================
============ STOP ============
================ STOP ========
==================== STOP ====

⚠️ Before opening this pull request please review the guidelines in the checklist below.

If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.
-->

## Proposed change

Fixes where the `widgets.yaml` configuration includes:
```
- longhorn:
    total: false
    nodes: true
```

Still shows a `total` node.

## Type of change

Bug-fix

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [X] If applicable, I have added corresponding documentation changes.
- [X] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [X] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [X] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
