### PR TITLE
ignore local icon folder in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ site*/
 
 # venv
 .venv/
+
+# local icons
+/public/icons


### PR DESCRIPTION
## Proposed change
Add the /public/icons folder to the .gotignore so any local icons added are excluded from being tracked.

## Type of change
- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [x] Other (please explain)
Add local icon folder to .gitignore

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
