### PR TITLE
feat: dynamic list support additional field

### DIFF
--- a/docs/widgets/services/customapi.md
+++ b/docs/widgets/services/customapi.md
@@ -191,6 +191,10 @@ widget:
     limit: 5 # optional, limit the number of items to display
     format: text # optional - format of the label field
     target: https://example.com/server/{id} # optional, makes items clickable with template support
+    additionalField: # optional
+      field: status
+      color: theme # optional - defaults to "". Allowed values: `["theme", "adaptive", "black", "white"]`.
+      format: text # optional
 ```
 
 This configuration would work with an API that returns a response like:
@@ -198,8 +202,8 @@ This configuration would work with an API that returns a response like:
 ```json
 {
   "data": [
-    { "id": "server1", "name": "Server 1", "ip_address": "192.168.0.1" },
-    { "id": "server2", "name": "Server 2", "ip_address": "192.168.0.2" }
+    { "id": "server1", "name": "Server 1", "ip_address": "192.168.0.1", "status": "active" },
+    { "id": "server2", "name": "Server 2", "ip_address": "192.168.0.2", "status": "inactive" }
   ]
 }
 ```

--- a/src/widgets/customapi/component.jsx
+++ b/src/widgets/customapi/component.jsx
@@ -257,6 +257,19 @@ export default function Component({ service }) {
                 const className =
                   "bg-theme-200/50 dark:bg-theme-900/20 rounded-sm m-1 flex-1 flex flex-row items-center justify-between p-1 text-xs";
 
+                const content = (
+                  <>
+                    <div className="font-thin pl-2">{itemName}</div>
+                    <div className="flex flex-row text-right">
+                      <div className="font-bold mr-2">{formatValue(t, mappings, itemLabel)}</div>
+                      {mappings.additionalField && (
+                        <div className={`font-bold mr-2 ${getColor(mappings, item)}`}>
+                          {formatValue(t, mappings.additionalField, getValue(mappings.additionalField.field, item))}
+                        </div>
+                      )}
+                    </div>
+                  </>
+                );
                 return itemUrl ? (
                   <a
                     key={`${itemName}-${index}`}
@@ -265,17 +278,11 @@ export default function Component({ service }) {
                     target="_blank"
                     rel="noopener noreferrer"
                   >
-                    <div className="font-thin pl-2">{itemName}</div>
-                    <div className="flex flex-row text-right">
-                      <div className="font-bold mr-2">{formatValue(t, mappings, itemLabel)}</div>
-                    </div>
+                    {content}
                   </a>
                 ) : (
                   <div key={`${itemName}-${index}`} className={className}>
-                    <div className="font-thin pl-2">{itemName}</div>
-                    <div className="flex flex-row text-right">
-                      <div className="font-bold mr-2">{formatValue(t, mappings, itemLabel)}</div>
-                    </div>
+                    {content}
                   </div>
                 );
               })


### PR DESCRIPTION
<!--
==== STOP ====================
======== STOP ================
============ STOP ============
================ STOP ========
==================== STOP ====

⚠️ Before opening this pull request please review the guidelines in the checklist below.

If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.
-->

## Proposed change

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

This pull request make custom api widget's dynamic list view supports additional field, just as list view.

For example, for this api response:
```
[
    { "name": "Bitcoin", "price": "102,881.93", "weight": "77.94%" },
    { "name": "Ethereum", "price": "2,337.26", "weight": "9.40%" },
    ...
]
```
with this config:
```
    - Nasdaq Crypto Index:
        widget:
          type: customapi
          url: http://SERVER:3001/nasdaq-crypto-index
          display: dynamic-list
          mappings:
            name: name
            label: price
            additionalField:
              field: weight
```
The dynamic list view now able to render the additional `weight` via `additionalField`
![螢幕擷取畫面 2025-05-09 205614](https://github.com/user-attachments/assets/e877fe69-3a81-4f54-b48d-fb801a17d598)

Closes https://github.com/gethomepage/homepage/discussions/5223

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
