### PR TITLE
Fix: refresh beszel token if empty list is returned

### DIFF
--- a/src/widgets/beszel/proxy.js
+++ b/src/widgets/beszel/proxy.js
@@ -72,8 +72,15 @@ export default async function beszelProxyHandler(req, res) {
         },
       });
 
-      if ([400, 403].includes(status)) {
-        logger.debug(`HTTP ${status} retrieving data from Beszel, logging in and trying again.`);
+      const badRequest = [400, 403].includes(status);
+      const isEmpty = data.includes("[]");
+
+      if (badRequest || isEmpty) {
+        if (badRequest) {
+          logger.debug(`HTTP ${status} retrieving data from Beszel, logging in and trying again.`);
+        } else {
+          logger.debug(`Received empty list from Beszel, logging in and trying again.`);
+        }
         cache.del(`${tokenCacheKey}.${service}`);
         [status, token] = await login(loginUrl, widget.username, widget.password, service);
 

--- a/src/widgets/beszel/proxy.js
+++ b/src/widgets/beszel/proxy.js
@@ -73,7 +73,15 @@ export default async function beszelProxyHandler(req, res) {
       });
 
       const badRequest = [400, 403].includes(status);
-      const isEmpty = data.includes("[]");
+      const text = data.toString("utf-8");
+      let isEmpty = false;
+
+      try {
+        const json = JSON.parse(text);
+        isEmpty = Array.isArray(json.items) && json.items.length === 0;
+      } catch (err) {
+        logger.debug("Failed to parse Beszel response JSON:", err);
+      }
 
       if (badRequest || isEmpty) {
         if (badRequest) {


### PR DESCRIPTION
<!--
==== STOP ====================
======== STOP ================
============ STOP ============
================ STOP ========
==================== STOP ====

⚠️ Before opening this pull request please review the guidelines in the checklist below.

If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.
-->

## Proposed change

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

Should fix #5146 and https://github.com/henrygd/beszel/issues/824

Issue is related to https://github.com/pocketbase/pocketbase/discussions/1570 - the API response is always 200 status even after the token expires.

## Replicating

1. Switch on the ability to edit collections in Beszel / PocketBase at `/_/#/settings`
2. In PocketBase, go to Collections > _superusers (expand "system") > Edit collection (cog icon at top)
3. Switch to the Options tab and expand Token Options at the bottom
4. Change "Auth duration" to `30`
5. Start homepage and observe that systems populate
6. Wait 30 seconds for token to expire and refresh, observe that systems do not populate

Let me know if have any questions about this. :+1: 

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
