### PR TITLE
fix port typo in docker.md

### DIFF
--- a/docs/configs/docker.md
+++ b/docs/configs/docker.md
@@ -20,7 +20,7 @@ Since Docker supports connecting with TLS and client certificate authentication,
 ```yaml
 my-remote-docker:
   host: 192.168.0.101
-  port: 275
+  port: 2375
   tls:
     keyFile: tls/key.pem
     caFile: tls/ca.pem


### PR DESCRIPTION

## Proposed change

Just fixing the port number in the docs to match the one used throughout. It's just a typo.

## Type of change

- [x] Documentation only

## Checklist:

Nothing to check in this case :white_check_mark: 