### PR TITLE
Feature: Trilium Service widget

### DIFF
--- a/docs/widgets/services/trilium.md
+++ b/docs/widgets/services/trilium.md
@@ -5,6 +5,8 @@ description: Trilium Widget Configuration
 
 Learn more about [Trilium](https://github.com/TriliumNext/Notes).
 
+This widget is compatible with [TriliumNext](https://github.com/TriliumNext/Notes) versions >= [v0.94.0](https://github.com/TriliumNext/Notes/releases/tag/v0.94.0).
+
 Find (or create) your ETAPI key under `Options > ETAPI > Create new ETAPI token`.
 
 ```yaml

--- a/docs/widgets/services/trilium.md
+++ b/docs/widgets/services/trilium.md
@@ -1,0 +1,16 @@
+---
+title: Trilium
+description: Trilium Widget Configuration
+---
+
+Learn more about [Trilium](https://github.com/TriliumNext/Notes).
+
+Find (or create) your ETAPI key under `Options > ETAPI > Create new ETAPI token`.
+
+
+```yaml
+widget:
+  type: trilium
+  url: https://trilium.host.or.ip
+  key: etapi_token
+```

--- a/docs/widgets/services/trilium.md
+++ b/docs/widgets/services/trilium.md
@@ -7,7 +7,6 @@ Learn more about [Trilium](https://github.com/TriliumNext/Notes).
 
 Find (or create) your ETAPI key under `Options > ETAPI > Create new ETAPI token`.
 
-
 ```yaml
 widget:
   type: trilium

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -362,8 +362,8 @@
     "trilium": {
         "version": "Version",
         "notesCount": "Notes",
-        "attachmentsCount": "Attachments",
-        "unknown": "Unknown",
+        "dbSize": "Database Size",
+        "unknown": "Unknown"
     },
     "navidrome": {
         "nothing_streaming": "No Active Streams",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -359,6 +359,13 @@
         "services": "Services",
         "middleware": "Middleware"
     },
+    "trilium": {
+        "version": "Version",
+        "notesCount": "Notes",
+        "attachmentsCount": "Attachments",
+        "unknown": "Unknown",
+        "none": "None"
+    },
     "navidrome": {
         "nothing_streaming": "No Active Streams",
         "please_wait": "Please Wait"

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -364,7 +364,6 @@
         "notesCount": "Notes",
         "attachmentsCount": "Attachments",
         "unknown": "Unknown",
-        "none": "None"
     },
     "navidrome": {
         "nothing_streaming": "No Active Streams",

--- a/src/utils/proxy/handlers/credentialed.js
+++ b/src/utils/proxy/handlers/credentialed.js
@@ -99,6 +99,8 @@ export default async function credentialedProxyHandler(req, res, map) {
         }
       } else if (widget.type === "wgeasy") {
         headers.Authorization = widget.password;
+      } else if (widget.type === "trilium") {
+        headers.Authorization = widget.key;
       } else if (widget.type === "gitlab") {
         headers["PRIVATE-TOKEN"] = widget.key;
       } else if (widget.type === "speedtest") {

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -131,6 +131,7 @@ const components = {
   tdarr: dynamic(() => import("./tdarr/component")),
   traefik: dynamic(() => import("./traefik/component")),
   transmission: dynamic(() => import("./transmission/component")),
+  trilium: dynamic(() => import("./trilium/component")),
   tubearchivist: dynamic(() => import("./tubearchivist/component")),
   truenas: dynamic(() => import("./truenas/component")),
   unifi: dynamic(() => import("./unifi/component")),

--- a/src/widgets/trilium/component.jsx
+++ b/src/widgets/trilium/component.jsx
@@ -36,16 +36,8 @@ export default function Component({ service }) {
 
   return (
     <Container service={service}>
-      <Block
-        icon={RiStackLine}
-        label="trilium.version"
-        value={version ? `v${version}` : t("trilium.unknown")}
-      />
-      <Block
-        icon={FiFileText}
-        label="trilium.notesCount"
-        value={t("common.number", { value: notesCount })}
-      />
+      <Block icon={RiStackLine} label="trilium.version" value={version ? `v${version}` : t("trilium.unknown")} />
+      <Block icon={FiFileText} label="trilium.notesCount" value={t("common.number", { value: notesCount })} />
       <Block
         icon={FiPaperclip}
         label="trilium.attachmentsCount"

--- a/src/widgets/trilium/component.jsx
+++ b/src/widgets/trilium/component.jsx
@@ -1,8 +1,6 @@
 import Block from "components/services/widget/block";
 import Container from "components/services/widget/container";
 import { useTranslation } from "next-i18next";
-import { FiFileText, FiPaperclip } from "react-icons/fi";
-import { RiStackLine } from "react-icons/ri";
 
 import useWidgetAPI from "utils/proxy/use-widget-api";
 
@@ -32,10 +30,9 @@ export default function Component({ service }) {
 
   return (
     <Container service={service}>
-      <Block icon={RiStackLine} label="trilium.version" value={version ? `v${version}` : t("trilium.unknown")} />
-      <Block icon={FiFileText} label="trilium.notesCount" value={t("common.number", { value: notesCount })} />
+      <Block label="trilium.version" value={version ? `v${version}` : t("trilium.unknown")} />
+      <Block label="trilium.notesCount" value={t("common.number", { value: notesCount })} />
       <Block
-        icon={FiPaperclip}
         label="trilium.attachmentsCount"
         value={t("common.number", { value: attachmentsCount })}
       />

--- a/src/widgets/trilium/component.jsx
+++ b/src/widgets/trilium/component.jsx
@@ -10,7 +10,6 @@ export default function Component({ service }) {
   const { t } = useTranslation();
   const { widget } = service;
 
-  // Fetch metrics from Trilium in JSON format
   const { data: metricsData, error: metricsError } = useWidgetAPI(widget, "metrics");
 
   if (metricsError) {

--- a/src/widgets/trilium/component.jsx
+++ b/src/widgets/trilium/component.jsx
@@ -19,20 +19,20 @@ export default function Component({ service }) {
       <Container service={service}>
         <Block label="trilium.version" />
         <Block label="trilium.notesCount" />
-        <Block label="trilium.attachmentsCount" />
+        <Block label="trilium.dbSize" />
       </Container>
     );
   }
 
   const version = metricsData.version?.app;
   const notesCount = metricsData.database?.activeNotes || 0;
-  const attachmentsCount = metricsData.database?.activeAttachments || 0;
+  const databaseSizeBytes = metricsData.statistics?.databaseSizeBytes || 0;
 
   return (
     <Container service={service}>
       <Block label="trilium.version" value={version ? `v${version}` : t("trilium.unknown")} />
       <Block label="trilium.notesCount" value={t("common.number", { value: notesCount })} />
-      <Block label="trilium.attachmentsCount" value={t("common.number", { value: attachmentsCount })} />
+      <Block label="trilium.dbSize" value={t("common.bytes", { value: databaseSizeBytes })} />
     </Container>
   );
 }

--- a/src/widgets/trilium/component.jsx
+++ b/src/widgets/trilium/component.jsx
@@ -11,9 +11,7 @@ export default function Component({ service }) {
   const { widget } = service;
 
   // Fetch metrics from Trilium in JSON format
-  const { data: metricsData, error: metricsError } = useWidgetAPI(widget, "metrics", {
-    refreshInterval: 60000, // refresh every minute
-  });
+  const { data: metricsData, error: metricsError } = useWidgetAPI(widget, "metrics");
 
   if (metricsError) {
     return <Container service={service} error={metricsError} />;

--- a/src/widgets/trilium/component.jsx
+++ b/src/widgets/trilium/component.jsx
@@ -29,10 +29,9 @@ export default function Component({ service }) {
     );
   }
 
-  // Extract values from the clean JSON structure
-  const version = metricsData?.version?.app;
-  const notesCount = metricsData?.database?.activeNotes || 0;
-  const attachmentsCount = metricsData?.database?.activeAttachments || 0;
+  const version = metricsData.version?.app;
+  const notesCount = metricsData.database?.activeNotes || 0;
+  const attachmentsCount = metricsData.database?.activeAttachments || 0;
 
   return (
     <Container service={service}>

--- a/src/widgets/trilium/component.jsx
+++ b/src/widgets/trilium/component.jsx
@@ -1,0 +1,68 @@
+import Block from "components/services/widget/block";
+import Container from "components/services/widget/container";
+import { useTranslation } from "next-i18next";
+import { RiStackLine } from "react-icons/ri";
+import { FiFileText, FiPaperclip } from "react-icons/fi";
+import useSWR from "swr";
+
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+  const { widget } = service;
+
+  // Fetch app info for version and stats
+  const { data: appInfo, error: appInfoError } = useWidgetAPI(widget, "app-info");
+
+  // Fetch all notes using search API
+  const { data: notesData, error: notesError } = useWidgetAPI(
+    widget,
+    "allnotes",
+    {
+      refreshInterval: 60000 // refresh every minute
+    }
+  );
+
+  if (appInfoError || notesError) {
+    const error = appInfoError || notesError;
+    return <Container service={service} error={error} />;
+  }
+
+  if (!appInfo || !notesData) {
+    return (
+      <Container service={service}>
+        <Block label="trilium.version" />
+        <Block label="trilium.notesCount" />
+        <Block label="trilium.attachmentsCount" />
+      </Container>
+    );
+  }
+
+  // Calculate total notes count and attachment count
+  const notesCount = notesData?.results?.length || 0;
+
+  // Count notes that don't have 'text' in the mime type
+  const attachmentsCount = notesData?.results?.filter(note =>
+    note.mime && !note.mime.includes('text')
+  )?.length || 0;
+
+  return (
+    <Container service={service}>
+      <Block
+        icon={RiStackLine}
+        label="trilium.version"
+        value={("v" + appInfo.appVersion) || t("trilium.unknown")}
+      />
+      <Block
+        icon={FiFileText}
+        label="trilium.notesCount"
+        value={t("common.number", { value: notesCount })}
+      />
+      <Block
+        icon={FiPaperclip}
+        label="trilium.attachmentsCount"
+        value={t("common.number", { value: attachmentsCount })}
+      />
+    </Container>
+  );
+}

--- a/src/widgets/trilium/component.jsx
+++ b/src/widgets/trilium/component.jsx
@@ -32,10 +32,7 @@ export default function Component({ service }) {
     <Container service={service}>
       <Block label="trilium.version" value={version ? `v${version}` : t("trilium.unknown")} />
       <Block label="trilium.notesCount" value={t("common.number", { value: notesCount })} />
-      <Block
-        label="trilium.attachmentsCount"
-        value={t("common.number", { value: attachmentsCount })}
-      />
+      <Block label="trilium.attachmentsCount" value={t("common.number", { value: attachmentsCount })} />
     </Container>
   );
 }

--- a/src/widgets/trilium/component.jsx
+++ b/src/widgets/trilium/component.jsx
@@ -1,9 +1,8 @@
 import Block from "components/services/widget/block";
 import Container from "components/services/widget/container";
 import { useTranslation } from "next-i18next";
-import { RiStackLine } from "react-icons/ri";
 import { FiFileText, FiPaperclip } from "react-icons/fi";
-import useSWR from "swr";
+import { RiStackLine } from "react-icons/ri";
 
 import useWidgetAPI from "utils/proxy/use-widget-api";
 
@@ -15,13 +14,9 @@ export default function Component({ service }) {
   const { data: appInfo, error: appInfoError } = useWidgetAPI(widget, "app-info");
 
   // Fetch all notes using search API
-  const { data: notesData, error: notesError } = useWidgetAPI(
-    widget,
-    "allnotes",
-    {
-      refreshInterval: 60000 // refresh every minute
-    }
-  );
+  const { data: notesData, error: notesError } = useWidgetAPI(widget, "allnotes", {
+    refreshInterval: 60000, // refresh every minute
+  });
 
   if (appInfoError || notesError) {
     const error = appInfoError || notesError;
@@ -42,22 +37,12 @@ export default function Component({ service }) {
   const notesCount = notesData?.results?.length || 0;
 
   // Count notes that don't have 'text' in the mime type
-  const attachmentsCount = notesData?.results?.filter(note =>
-    note.mime && !note.mime.includes('text')
-  )?.length || 0;
+  const attachmentsCount = notesData?.results?.filter((note) => note.mime && !note.mime.includes("text"))?.length || 0;
 
   return (
     <Container service={service}>
-      <Block
-        icon={RiStackLine}
-        label="trilium.version"
-        value={("v" + appInfo.appVersion) || t("trilium.unknown")}
-      />
-      <Block
-        icon={FiFileText}
-        label="trilium.notesCount"
-        value={t("common.number", { value: notesCount })}
-      />
+      <Block icon={RiStackLine} label="trilium.version" value={"v" + appInfo.appVersion || t("trilium.unknown")} />
+      <Block icon={FiFileText} label="trilium.notesCount" value={t("common.number", { value: notesCount })} />
       <Block
         icon={FiPaperclip}
         label="trilium.attachmentsCount"

--- a/src/widgets/trilium/widget.js
+++ b/src/widgets/trilium/widget.js
@@ -5,11 +5,8 @@ const widget = {
   proxyHandler: credentialedProxyHandler,
 
   mappings: {
-    "app-info": {
-      endpoint: "app-info",
-    },
-    allnotes: {
-      endpoint: "notes?search=note.id%20%3D%20%22root%22",
+    metrics: {
+      endpoint: "metrics?format=json",
     },
   },
 };

--- a/src/widgets/trilium/widget.js
+++ b/src/widgets/trilium/widget.js
@@ -8,8 +8,8 @@ const widget = {
     "app-info": {
       endpoint: "app-info",
     },
-    "allnotes": {
-      endpoint: "notes?search=note.id%20%3D%20%22root%22"
+    allnotes: {
+      endpoint: "notes?search=note.id%20%3D%20%22root%22",
     },
   },
 };

--- a/src/widgets/trilium/widget.js
+++ b/src/widgets/trilium/widget.js
@@ -7,6 +7,7 @@ const widget = {
   mappings: {
     metrics: {
       endpoint: "metrics?format=json",
+      validate: ["version", "database"],
     },
   },
 };

--- a/src/widgets/trilium/widget.js
+++ b/src/widgets/trilium/widget.js
@@ -1,0 +1,17 @@
+import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
+
+const widget = {
+  api: "{url}/etapi/{endpoint}",
+  proxyHandler: credentialedProxyHandler,
+
+  mappings: {
+    "app-info": {
+      endpoint: "app-info",
+    },
+    "allnotes": {
+      endpoint: "notes?search=note.id%20%3D%20%22root%22"
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -122,6 +122,7 @@ import tdarr from "./tdarr/widget";
 import technitium from "./technitium/widget";
 import traefik from "./traefik/widget";
 import transmission from "./transmission/widget";
+import trilium from "./trilium/widget";
 import truenas from "./truenas/widget";
 import tubearchivist from "./tubearchivist/widget";
 import unifi from "./unifi/widget";
@@ -264,6 +265,7 @@ const widgets = {
   tdarr,
   traefik,
   transmission,
+  trilium,
   tubearchivist,
   truenas,
   unifi,


### PR DESCRIPTION
<!--
==== STOP ====================
======== STOP ================
============ STOP ============
================ STOP ========
==================== STOP ====

⚠️ Before opening this pull request please review the guidelines in the checklist below.

If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.
-->

## Proposed change

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

Relevant discussion: https://github.com/gethomepage/homepage/discussions/2312

This adds the Trilium service widget to Homepage. This will fetch the current Trilium version, number of Notes, and number of Attachments from a user's instance and show them the above information:

![image](https://github.com/user-attachments/assets/c42cce24-1197-4228-aab9-9ec9b1604ae8)

Included in the PR is of course the code, but also the documentation for using it. Please feel free to let me know if you would like me to change anything.

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [x] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
