### PR TITLE
feat(jellyfin,emby): add enableMediaControl flag to hide play/pause controls

### DIFF
--- a/docs/widgets/services/emby.md
+++ b/docs/widgets/services/emby.md
@@ -17,6 +17,7 @@ widget:
   enableBlocks: true # optional, defaults to false
   enableNowPlaying: true # optional, defaults to true
   enableUser: true # optional, defaults to false
+  enableMediaControl: false # optional, defaults to true
   showEpisodeNumber: true # optional, defaults to false
   expandOneStreamToTwoRows: false # optional, defaults to true
 ```

--- a/docs/widgets/services/jellyfin.md
+++ b/docs/widgets/services/jellyfin.md
@@ -17,6 +17,7 @@ widget:
   enableBlocks: true # optional, defaults to false
   enableNowPlaying: true # optional, defaults to true
   enableUser: true # optional, defaults to false
+  enableMediaControl: false # optional, defaults to true
   showEpisodeNumber: true # optional, defaults to false
   expandOneStreamToTwoRows: false # optional, defaults to true
 ```

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -295,6 +295,7 @@ export function cleanServiceGroups(groups) {
           // emby, jellyfin
           enableBlocks,
           enableNowPlaying,
+          enableMediaControl,
 
           // emby, jellyfin, tautulli
           enableUser,
@@ -471,6 +472,7 @@ export function cleanServiceGroups(groups) {
           if (wan) widget.wan = wan;
         }
         if (["emby", "jellyfin"].includes(type)) {
+          if (enableMediaControl !== undefined) widget.enableMediaControl = !!JSON.parse(enableMediaControl);
           if (enableBlocks !== undefined) widget.enableBlocks = JSON.parse(enableBlocks);
           if (enableNowPlaying !== undefined) widget.enableNowPlaying = JSON.parse(enableNowPlaying);
         }

--- a/src/widgets/emby/component.jsx
+++ b/src/widgets/emby/component.jsx
@@ -45,7 +45,7 @@ function generateStreamTitle(session, enableUser, showEpisodeNumber) {
   return enableUser ? `${streamTitle} (${UserName})` : streamTitle;
 }
 
-function SingleSessionEntry({ playCommand, session, enableUser, showEpisodeNumber }) {
+function SingleSessionEntry({ playCommand, session, enableUser, showEpisodeNumber, enableMediaControl }) {
   const {
     PlayState: { PositionTicks, IsPaused, IsMuted },
   } = session;
@@ -85,7 +85,7 @@ function SingleSessionEntry({ playCommand, session, enableUser, showEpisodeNumbe
           }}
         />
         <div className="text-xs z-10 self-center ml-1">
-          {IsPaused && (
+          {enableMediaControl && IsPaused && (
             <BsFillPlayFill
               onClick={() => {
                 playCommand(session, "Unpause");
@@ -93,7 +93,7 @@ function SingleSessionEntry({ playCommand, session, enableUser, showEpisodeNumbe
               className="inline-block w-4 h-4 cursor-pointer -mt-[1px] mr-1 opacity-80"
             />
           )}
-          {!IsPaused && (
+          {enableMediaControl && !IsPaused && (
             <BsPauseFill
               onClick={() => {
                 playCommand(session, "Pause");
@@ -114,7 +114,7 @@ function SingleSessionEntry({ playCommand, session, enableUser, showEpisodeNumbe
   );
 }
 
-function SessionEntry({ playCommand, session, enableUser, showEpisodeNumber }) {
+function SessionEntry({ playCommand, session, enableUser, showEpisodeNumber, enableMediaControl }) {
   const {
     PlayState: { PositionTicks, IsPaused, IsMuted },
   } = session;
@@ -139,7 +139,7 @@ function SessionEntry({ playCommand, session, enableUser, showEpisodeNumber }) {
         }}
       />
       <div className="text-xs z-10 self-center ml-1">
-        {IsPaused && (
+        {enableMediaControl && IsPaused && (
           <BsFillPlayFill
             onClick={() => {
               playCommand(session, "Unpause");
@@ -147,7 +147,7 @@ function SessionEntry({ playCommand, session, enableUser, showEpisodeNumber }) {
             className="inline-block w-4 h-4 cursor-pointer -mt-[1px] mr-1 opacity-80"
           />
         )}
-        {!IsPaused && (
+        {enableMediaControl && !IsPaused && (
           <BsPauseFill
             onClick={() => {
               playCommand(session, "Pause");
@@ -238,6 +238,7 @@ export default function Component({ service }) {
 
   const enableBlocks = service.widget?.enableBlocks;
   const enableNowPlaying = service.widget?.enableNowPlaying ?? true;
+  const enableMediaControl = service.widget?.enableMediaControl !== false; // default is true
   const enableUser = !!service.widget?.enableUser; // default is false
   const expandOneStreamToTwoRows = service.widget?.expandOneStreamToTwoRows !== false; // default is true
   const showEpisodeNumber = !!service.widget?.showEpisodeNumber; // default is false
@@ -304,6 +305,7 @@ export default function Component({ service }) {
               session={session}
               enableUser={enableUser}
               showEpisodeNumber={showEpisodeNumber}
+              enableMediaControl={enableMediaControl}
             />
           </div>
         </>
@@ -321,6 +323,7 @@ export default function Component({ service }) {
               session={session}
               enableUser={enableUser}
               showEpisodeNumber={showEpisodeNumber}
+              enableMediaControl={enableMediaControl}
             />
           ))}
         </div>


### PR DESCRIPTION
## Proposed change

Adds a new `enableMediaControl` flag for the Jellyfin & Emby widgets, allowing users to hide the play/pause controls if desired. This feature addresses the original request converted from Issue #945.

Example services.yaml:
```
- Media-Player:
    - Jellyfin:
        icon: jellyfin.png
        href: https://jellyfin.example.org
        description: Filme/Serien streamen
        widget:
          type: jellyfin
          url: https://jellyfin.example.org
          key: xyz
          enableBlocks: true
          enableNowPlaying: true
          enableUser: true
          enableMediaControl: false
          showEpisodeNumber: true
          expandOneStreamToTwoRows: false
```

## Related issues / discussions

- Refs #945  
- Discussion #1282

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.

---

- Documentation: updated [jellyfin.md](docs/widgets/services/jellyfin.md) & [emby.md](docs/widgets/services/emby.md)
- pre-commit run --all-files:
![pre-commit-run](https://github.com/user-attachments/assets/68d50151-54cb-44ea-a386-503dfea0bbc7)
- pnpm lint:
![pnpm-lint](https://github.com/user-attachments/assets/bebb8864-6a9c-4667-812c-2dcd479b2a70)
- enableMediaControl: true (Buttons present)
![enable-media-control-true](https://github.com/user-attachments/assets/9ec64943-0e43-4f45-a6a7-bf183e7c0bd6)
- enableMediaControl: false (Buttons not present)
![enable-media-control-false](https://github.com/user-attachments/assets/f2acdf1a-669e-4b4f-9628-a17735dce9fe)

