### PR TITLE
Enhancement: Komodo widget

### DIFF
--- a/docs/widgets/services/komodo.md
+++ b/docs/widgets/services/komodo.md
@@ -1,0 +1,18 @@
+---
+title: Komodo
+description: Komodo Widget Configuration
+---
+
+This widget shows the summary of Stacks managed by [Komodo](https://komo.do/).
+
+This widget requires an API Key and Secret, which can be setup at: `http://komodo.hostname.or.ip:port/settings`.
+
+Allowed fields: `["total", "running", "stopped", "down", "unhealthy", "unknown"]`.
+
+```yaml
+widget:
+  type: komodo
+  url: http://komodo.hostname.or.ip:port
+  key: K-xxxxxx...
+  secret: S-xxxxxx...
+```

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1060,5 +1060,13 @@
     "checkmk": {
         "serviceErrors": "Service issues",
         "hostErrors": "Host issues"
+    },
+    "komodo": {
+        "total": "Total",
+        "running": "Running",
+        "stopped": "Stopped",
+        "down": "Down",
+        "unhealthy": "Unhealthy",
+        "unknown": "Unknown"
     }
 }

--- a/src/utils/proxy/handlers/credentialed.js
+++ b/src/utils/proxy/handlers/credentialed.js
@@ -90,6 +90,9 @@ export default async function credentialedProxyHandler(req, res, map) {
         headers.Authorization = `Basic ${Buffer.from(`$:${widget.key}`).toString("base64")}`;
       } else if (widget.type === "glances") {
         headers.Authorization = `Basic ${Buffer.from(`${widget.username}:${widget.password}`).toString("base64")}`;
+      } else if (widget.type === "komodo") {
+        headers["X-API-Key"] = `${widget.key}`;
+        headers["X-API-Secret"] = `${widget.secret}`;
       } else if (widget.type === "plantit") {
         headers.Key = `${widget.key}`;
       } else if (widget.type === "myspeed") {

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -63,6 +63,7 @@ const components = {
   jellystat: dynamic(() => import("./jellystat/component")),
   kavita: dynamic(() => import("./kavita/component")),
   komga: dynamic(() => import("./komga/component")),
+  komodo: dynamic(() => import("./komodo/component")),
   kopia: dynamic(() => import("./kopia/component")),
   lidarr: dynamic(() => import("./lidarr/component")),
   linkwarden: dynamic(() => import("./linkwarden/component")),

--- a/src/widgets/komodo/component.jsx
+++ b/src/widgets/komodo/component.jsx
@@ -1,0 +1,39 @@
+import { useTranslation } from "next-i18next";
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+  const { widget } = service;
+  const { data, error } = useWidgetAPI(widget, "stacks", {
+    columns: "state",
+    query: '{"op": "!=", "left": "state", "right": "0"}',
+  });
+
+  if (error) {
+    return <Container service={service} error={error} />;
+  }
+
+  if (!data) {
+    return (
+      <Container service={service}>
+        <Block label="komodo.total" />
+        <Block label="komodo.running" />
+        <Block label="komodo.down" />
+        <Block label="komodo.unhealthy" />
+      </Container>
+    );
+  }
+
+  return (
+    <Container service={service}>
+      <Block label="komodo.total" value={t("common.number", { value: data.total })} />
+      <Block label="komodo.stopped" value={t("common.number", { value: data.stopped })} />
+      <Block label="komodo.running" value={t("common.number", { value: data.running })} />
+      <Block label="komodo.down" value={t("common.number", { value: data.down })} />
+      <Block label="komodo.unhealthy" value={t("common.number", { value: data.unhealthy })} />
+      <Block label="komodo.unknown" value={t("common.number", { value: data.unknown })} />
+    </Container>
+  );
+}

--- a/src/widgets/komodo/widget.js
+++ b/src/widgets/komodo/widget.js
@@ -1,0 +1,22 @@
+import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
+
+const widget = {
+  api: "{url}/{endpoint}",
+  proxyHandler: credentialedProxyHandler,
+
+  mappings: {
+    stacks: {
+      endpoint: "read",
+      method: "POST",
+      body: {
+        type: "GetStacksSummary",
+        params: {},
+      },
+      headers: {
+        "Content-Type": "application/json",
+      },
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -54,6 +54,7 @@ import jellystat from "./jellystat/widget";
 import karakeep from "./karakeep/widget";
 import kavita from "./kavita/widget";
 import komga from "./komga/widget";
+import komodo from "./komodo/widget";
 import kopia from "./kopia/widget";
 import lidarr from "./lidarr/widget";
 import linkwarden from "./linkwarden/widget";
@@ -197,6 +198,7 @@ const widgets = {
   jellystat,
   kavita,
   komga,
+  komodo,
   kopia,
   lidarr,
   linkwarden,


### PR DESCRIPTION
## Proposed change

Add a service widget for [Komodo](https://komo.do). This widget shows the summary status of all stacks managed by a given Komodo instance.

### Example API request

#### Request

```
curl \
  --header "Content-Type: application/json" \
  --header "X-Api-Key: K-xxxxxx..." \
  --header "X-Api-Secret: S-xxxxxx..." \
  --data '{ "type": "GetStacksSummary", "params": { } }' \
  http://komodo.hostname.or.ip:9120/read
```

#### Response

```json
{
  "total": 21,
  "running": 17,
  "stopped": 0,
  "down": 4,
  "unhealthy": 0,
  "unknown": 0
}
```

### Example Rendering

![image](https://github.com/user-attachments/assets/db939e21-0dd7-4b8a-af74-371cc63db4fc)

## Type of change

- [x] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
