### PR TITLE
New Feature: WatchYourLAN Service Widget

### DIFF
--- a/docs/widgets/services/watchyourlan.md
+++ b/docs/widgets/services/watchyourlan.md
@@ -15,4 +15,3 @@ widget:
   type: watchyourlan
   url: http://watchyourlan.host.or.ip:port
 ```
-=

--- a/docs/widgets/services/watchyourlan.md
+++ b/docs/widgets/services/watchyourlan.md
@@ -1,0 +1,18 @@
+---
+title: WatchYourLan
+description: WatchYourLan Widget Configuration
+---
+
+Learn more about [WatchYourLan](https://github.com/aceberg/WatchYourLAN).
+
+---
+
+Only total values are displayed at this time. 
+Total devices, Total Online, Total Offline, Total Known, and Total Unknown. These can be managed in the WatchYourLAN control panel.
+
+```yaml
+widget:
+  type: watchyourlan
+  url: http://watchyourlan.host.or.ip:port
+```
+=

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1071,5 +1071,12 @@
         "servers": "Servers",
         "stacks": "Stacks",
         "containers": "Containers"
+    },
+    "watchyourlan": {
+        "total": "Total",
+        "online": "Online",
+        "offline": "Offline",
+        "known": "Known",
+        "unknown": "Unknown"
     }
 }

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -147,7 +147,7 @@ const components = {
   whatsupdocker: dynamic(() => import("./whatsupdocker/component")),
   xteve: dynamic(() => import("./xteve/component")),
   zabbix: dynamic(() => import("./zabbix/component")),
-  watchyourlan: dynamic(() => import("./watchyourlan/component")),
+  watchyourlan: dynamic(() => import("./watchyourlan/component"))
 };
 
 export default components;

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -147,6 +147,7 @@ const components = {
   whatsupdocker: dynamic(() => import("./whatsupdocker/component")),
   xteve: dynamic(() => import("./xteve/component")),
   zabbix: dynamic(() => import("./zabbix/component")),
+  watchyourlan: dynamic(() => import("./watchyourlan/component")),
 };
 
 export default components;

--- a/src/widgets/watchyourlan/component.jsx
+++ b/src/widgets/watchyourlan/component.jsx
@@ -1,0 +1,36 @@
+import { useTranslation } from "next-i18next";
+import Container from "components/services/widget/container";
+import Block from "components/services/widget/block";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+  const { widget } = service;
+  const { data, error } = useWidgetAPI(widget, "info");
+
+  if (error) {
+    return <Container service={service} error={error} />;
+  }
+
+  if (!data) {
+    return (
+      <Container service={service}>
+        <Block label={t("watchyourlan.total")} />
+        <Block label={t("watchyourlan.online")} />
+        <Block label={t("watchyourlan.offline")} />
+        <Block label={t("watchyourlan.unknown")} />
+        <Block label={t("watchyourlan.known")} />
+      </Container>
+    );
+  }
+
+  return (
+    <Container service={service}>
+      <Block label={t("watchyourlan.total")} value={data.Total} />
+      <Block label={t("watchyourlan.online")} value={data.Online} />
+      <Block label-{t("watchyourlan.offline")} value={data.Offline} />
+      <Block label={t("watchyourlan.unknown")} value={data.Unknown} />
+      <Block label={t("watchyourlan.known")] value={data.Known} />
+    </Container>
+  );
+}

--- a/src/widgets/watchyourlan/widget.js
+++ b/src/widgets/watchyourlan/widget.js
@@ -1,0 +1,13 @@
+import genericProxyHandler from "utils/proxy/handlers/generic";
+
+const widget = {
+  api: "{url}/{endpoint}",
+  proxyHandler: genericProxyHandler,
+  mappings: {
+    info: {
+      endpoint: "api/status/",
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/watchyourlan/widget.js
+++ b/src/widgets/watchyourlan/widget.js
@@ -5,9 +5,9 @@ const widget = {
   proxyHandler: genericProxyHandler,
   mappings: {
     info: {
-      endpoint: "api/status/",
-    },
-  },
+      endpoint: "api/status/"
+    }
+  }
 };
 
 export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -138,6 +138,7 @@ import wgeasy from "./wgeasy/widget";
 import whatsupdocker from "./whatsupdocker/widget";
 import xteve from "./xteve/widget";
 import zabbix from "./zabbix/widget";
+import watchyourlan from "./watchyourlan/widget";
 
 const widgets = {
   adguard,
@@ -284,6 +285,7 @@ const widgets = {
   whatsupdocker,
   xteve,
   zabbix,
+  watchyourlan,
 };
 
 export default widgets;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -285,7 +285,7 @@ const widgets = {
   whatsupdocker,
   xteve,
   zabbix,
-  watchyourlan,
+  watchyourlan
 };
 
 export default widgets;


### PR DESCRIPTION
<!--
==== STOP ====================
======== STOP ================
============ STOP ============
================ STOP ========
==================== STOP ====

⚠️ Before opening this pull request please review the guidelines in the checklist below.

If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.
-->

## Proposed change

This PR adds a new custom service widget for [WatchYourLAN](https://github.com/aceberg/WatchYourLAN), which fetches LAN device status data from the `/api/status/` endpoint and displays total, online, and unknown device counts.

**Features:**
- Pulls data from `/api/status/`
- Displays Total, Online, and Unknown devices
- Supports translations via `common.json`
- Fully responsive using the existing `Block` widget format
[
![IMG_0071](https://github.com/user-attachments/assets/f51426e8-e612-4709-8ea5-14b9ff29fbea)
](url)

## Type of change

- [X] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [X] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [X] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [X] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
