### PR TITLE
Enhancement: sort qBittorrent leechProgress

### DIFF
--- a/src/widgets/qbittorrent/component.jsx
+++ b/src/widgets/qbittorrent/component.jsx
@@ -53,7 +53,7 @@ export default function Component({ service }) {
     "checkingDL",
     "stalledDL",
     "queuedDL",
-    "pausedDL"
+    "pausedDL",
   ];
 
   leechTorrents.sort((firstTorrent, secondTorrent) => {

--- a/src/widgets/qbittorrent/component.jsx
+++ b/src/widgets/qbittorrent/component.jsx
@@ -45,6 +45,25 @@ export default function Component({ service }) {
   }
 
   const leech = torrentData.length - completed;
+  const statePriority = [
+    "downloading",
+    "forcedDL",
+    "metaDL",
+    "forcedMetaDL",
+    "checkingDL",
+    "stalledDL",
+    "queuedDL",
+    "pausedDL"
+  ];
+
+  leechTorrents.sort((firstTorrent, secondTorrent) => {
+    const firstStateIndex = statePriority.indexOf(firstTorrent.state);
+    const secondStateIndex = statePriority.indexOf(secondTorrent.state);
+    if (firstStateIndex !== secondStateIndex) {
+      return firstStateIndex - secondStateIndex;
+    }
+    return secondTorrent.progress - firstTorrent.progress;
+  });
 
   return (
     <>


### PR DESCRIPTION
<!--
==== STOP ====================
======== STOP ================
============ STOP ============
================ STOP ========
==================== STOP ====

⚠️ Before opening this pull request please review the guidelines in the checklist below.

If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.
-->

## Proposed change
The qBittorrent widget's leech progress list is a very nice feature, but its disordered nature makes it difficult to quickly parse (for me at least). This change sorts the list in the following order:

1. downloading
2. forcedDL
3. metaDL
4. forcedMetaDL
5. checkingDL
6. stalledDL
7. queuedDL
8. pausedDL

when any entry has the same status, e.g multiple torrents actively downloading, they will be sorted by progress (highest % done first).

### Before
![image](https://github.com/user-attachments/assets/ce225397-d490-4579-876c-99b5bbfb889d)

### After
![image](https://github.com/user-attachments/assets/93752f84-b31d-4673-aa9b-44e88b4f7275)

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

Closes # (issue)
https://github.com/gethomepage/homepage/discussions/5222
## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [X] If applicable, I have added corresponding documentation changes.
- [X] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [X] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [X] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
