### PR TITLE
Enhancement: support for new grafana alerting api

### DIFF
--- a/docs/widgets/services/grafana.md
+++ b/docs/widgets/services/grafana.md
@@ -5,11 +5,18 @@ description: Grafana Widget Configuration
 
 Learn more about [Grafana](https://github.com/grafana/grafana).
 
+| Grafana Version | Homepage Widget Version |
+| -------------- | ----------------------- |
+| <= v10.4       | 1 (default)             |
+| >= v10      | 2                       |
+
 Allowed fields: `["dashboards", "datasources", "totalalerts", "alertstriggered"]`.
 
 ```yaml
 widget:
   type: grafana
+  version: 2 # optional, default is 1
+  alerts: alertmanager # optional, default is grafana
   url: http://grafana.host.or.ip:port
   username: username
   password: password

--- a/docs/widgets/services/grafana.md
+++ b/docs/widgets/services/grafana.md
@@ -8,7 +8,7 @@ Learn more about [Grafana](https://github.com/grafana/grafana).
 | Grafana Version | Homepage Widget Version |
 | --------------- | ----------------------- |
 | <= v10.4        | 1 (default)             |
-| >= v10          | 2                       |
+| > v10.4         | 2                       |
 
 Allowed fields: `["dashboards", "datasources", "totalalerts", "alertstriggered"]`.
 

--- a/docs/widgets/services/grafana.md
+++ b/docs/widgets/services/grafana.md
@@ -6,9 +6,9 @@ description: Grafana Widget Configuration
 Learn more about [Grafana](https://github.com/grafana/grafana).
 
 | Grafana Version | Homepage Widget Version |
-| -------------- | ----------------------- |
-| <= v10.4       | 1 (default)             |
-| >= v10      | 2                       |
+| --------------- | ----------------------- |
+| <= v10.4        | 1 (default)             |
+| >= v10          | 2                       |
 
 Allowed fields: `["dashboards", "datasources", "totalalerts", "alertstriggered"]`.
 

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -407,6 +407,9 @@ export function cleanServiceGroups(groups) {
 
           // spoolman
           spoolIds,
+
+          // grafana
+          alerts,
         } = widgetData;
 
         let fieldsList = fields;
@@ -603,6 +606,9 @@ export function cleanServiceGroups(groups) {
         }
         if (type === "jellystat") {
           if (days !== undefined) widget.days = parseInt(days, 10);
+        }
+        if (type === "grafana") {
+          if (alerts) widget.alerts = alerts;
         }
         return widget;
       });

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -514,7 +514,18 @@ export function cleanServiceGroups(groups) {
           if (snapshotPath) widget.snapshotPath = snapshotPath;
         }
         if (
-          ["beszel", "glances", "immich", "komga", "mealie", "pfsense", "pihole", "speedtest", "wgeasy", "grafana"].includes(type)
+          [
+            "beszel",
+            "glances",
+            "immich",
+            "komga",
+            "mealie",
+            "pfsense",
+            "pihole",
+            "speedtest",
+            "wgeasy",
+            "grafana",
+          ].includes(type)
         ) {
           if (version) widget.version = parseInt(version, 10);
         }

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -514,7 +514,7 @@ export function cleanServiceGroups(groups) {
           if (snapshotPath) widget.snapshotPath = snapshotPath;
         }
         if (
-          ["beszel", "glances", "immich", "komga", "mealie", "pfsense", "pihole", "speedtest", "wgeasy"].includes(type)
+          ["beszel", "glances", "immich", "komga", "mealie", "pfsense", "pihole", "speedtest", "wgeasy", "grafana"].includes(type)
         ) {
           if (version) widget.version = parseInt(version, 10);
         }

--- a/src/widgets/grafana/component.jsx
+++ b/src/widgets/grafana/component.jsx
@@ -11,22 +11,26 @@ export default function Component({ service }) {
   const { data: statsData, error: statsError } = useWidgetAPI(widget, "stats");
   const { data: alertsData, error: alertsError } = useWidgetAPI(widget, "alerts");
   const { data: alertmanagerData, error: alertmanagerError } = useWidgetAPI(widget, "alertmanager");
+  const { data: grafanaData, error: grafanaError } = useWidgetAPI(widget, "grafana");
 
   let alertsInt = 0;
 
   if (alertsError || !alertsData || alertsData.length === 0) {
-    if (alertmanagerData) {
+    if (alertmanagerData.length > 0) {
       alertsInt = alertmanagerData.length;
+    }
+    if (grafanaData.length > 0) {
+      alertsInt = grafanaData.length;
     }
   } else {
     alertsInt = alertsData.filter((a) => a.state === "alerting").length;
   }
 
-  if (statsError || (alertsError && alertmanagerError)) {
+  if (statsError || (alertsError && alertmanagerError && grafanaError)) {
     return <Container service={service} error={statsError ?? alertsError} />;
   }
 
-  if (!statsData || (!alertsData && !alertmanagerData)) {
+  if (!statsData || (!alertsData && !alertmanagerData && !grafanaData)) {
     return (
       <Container service={service}>
         <Block label="grafana.dashboards" />

--- a/src/widgets/grafana/component.jsx
+++ b/src/widgets/grafana/component.jsx
@@ -10,13 +10,12 @@ export default function Component({ service }) {
 
   const { version = 1, alerts = "grafana" } = widget;
 
+  let alertsError = null;
   const allowedEndpoints = ["alertmanager", "grafana"];
   if (!allowedEndpoints.includes(alerts)) {
-    return (
-      <Container
-        service={service}
-        error={new Error(`Invalid alerts endpoint: ${alerts}, allowed endpoints are: ${allowedEndpoints.join(", ")}`)}
-      />
+    alerts = ""; // Reset to empty string if invalid
+    alertsError = new Error(
+      `Invalid alerts endpoint: ${alerts}, allowed endpoints are: ${allowedEndpoints.join(", ")}`,
     );
   }
 
@@ -29,12 +28,10 @@ export default function Component({ service }) {
     secondaryAlertsEndpoint = "";
   }
 
-  let alertsInt = 0;
-
   const { data: primaryAlertsData, error: primaryAlertsError } = useWidgetAPI(widget, primaryAlertsEndpoint);
   const { data: secondaryAlertsData, error: secondaryAlertsError } = useWidgetAPI(widget, secondaryAlertsEndpoint);
 
-  let alertsError = null;
+  let alertsInt = 0;
   if (version === 1) {
     if (primaryAlertsError || !primaryAlertsData || primaryAlertsData.length === 0) {
       if (secondaryAlertsData) {

--- a/src/widgets/grafana/component.jsx
+++ b/src/widgets/grafana/component.jsx
@@ -12,9 +12,12 @@ export default function Component({ service }) {
 
   const allowedEndpoints = ["alertmanager", "grafana"];
   if (!allowedEndpoints.includes(alerts)) {
-    return <Container service={service} error={new Error(
-        `Invalid alerts endpoint: ${alerts}, allowed endpoints are: ${allowedEndpoints.join(", ")}`,
-      )} />;
+    return (
+      <Container
+        service={service}
+        error={new Error(`Invalid alerts endpoint: ${alerts}, allowed endpoints are: ${allowedEndpoints.join(", ")}`)}
+      />
+    );
   }
 
   const { data: statsData, error: statsError } = useWidgetAPI(widget, "stats");

--- a/src/widgets/grafana/component.jsx
+++ b/src/widgets/grafana/component.jsx
@@ -21,7 +21,7 @@ export default function Component({ service }) {
   const { data: alertsData, error: alertsError } = useWidgetAPI(widget, alertsEndpoint);
 
   let alertsInt = 0;
-  if(alertsData) {
+  if (alertsData) {
     if (version === 1) {
       alertsInt = alertsData.filter((a) => a.state === "alerting").length;
     } else {

--- a/src/widgets/grafana/component.jsx
+++ b/src/widgets/grafana/component.jsx
@@ -10,15 +10,6 @@ export default function Component({ service }) {
 
   const { version = 1, alerts = "grafana" } = widget;
 
-  let alertsError = null;
-  const allowedEndpoints = ["alertmanager", "grafana"];
-  if (!allowedEndpoints.includes(alerts)) {
-    alerts = ""; // Reset to empty string if invalid
-    alertsError = new Error(
-      `Invalid alerts endpoint: ${alerts}, allowed endpoints are: ${allowedEndpoints.join(", ")}`,
-    );
-  }
-
   const { data: statsData, error: statsError } = useWidgetAPI(widget, "stats");
 
   let primaryAlertsEndpoint = "alerts";
@@ -32,6 +23,7 @@ export default function Component({ service }) {
   const { data: secondaryAlertsData, error: secondaryAlertsError } = useWidgetAPI(widget, secondaryAlertsEndpoint);
 
   let alertsInt = 0;
+  let alertsError = null;
   if (version === 1) {
     if (primaryAlertsError || !primaryAlertsData || primaryAlertsData.length === 0) {
       if (secondaryAlertsData) {

--- a/src/widgets/grafana/widget.js
+++ b/src/widgets/grafana/widget.js
@@ -9,6 +9,9 @@ const widget = {
       endpoint: "alerts",
     },
     alertmanager: {
+      endpoint: "alertmanager/alertmanager/api/v2/alerts",
+    },
+    grafana: {
       endpoint: "alertmanager/grafana/api/v2/alerts",
     },
     stats: {

--- a/src/widgets/grafana/widget.js
+++ b/src/widgets/grafana/widget.js
@@ -9,7 +9,7 @@ const widget = {
       endpoint: "alerts",
     },
     alertmanager: {
-      endpoint: "alertmanager/alertmanager/api/v2/alerts",
+      endpoint: "alertmanager/alertmanager/api/v2/alerts", 
     },
     grafana: {
       endpoint: "alertmanager/grafana/api/v2/alerts",

--- a/src/widgets/grafana/widget.js
+++ b/src/widgets/grafana/widget.js
@@ -9,7 +9,7 @@ const widget = {
       endpoint: "alerts",
     },
     alertmanager: {
-      endpoint: "alertmanager/alertmanager/api/v2/alerts", 
+      endpoint: "alertmanager/alertmanager/api/v2/alerts",
     },
     grafana: {
       endpoint: "alertmanager/grafana/api/v2/alerts",


### PR DESCRIPTION
## Proposed change

This PR leaves the existing legacy `alerts` API call unchanged and adds support for querying both Grafana's `grafana-alerting` data source and the `alertmanager` data source so that firing alerts from either source will be displayed.

I have opened a discussion here: https://github.com/gethomepage/homepage/discussions/5475

## Type of change

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
