### PR TITLE
Fix: increase color popover z-index

### DIFF
--- a/src/components/toggles/color.jsx
+++ b/src/components/toggles/color.jsx
@@ -55,7 +55,7 @@ export default function ColorToggle() {
           leaveFrom="opacity-100 translate-y-0"
           leaveTo="opacity-0 translate-y-1"
         >
-          <Popover.Panel className="absolute -top-[75px] left-0">
+          <Popover.Panel className="absolute -top-[75px] left-0 z-10">
             <div className="rounded-md shadow-lg ring-1 ring-black ring-opacity-5 w-[85vw] sm:w-full">
               <div className="relative grid gap-2 p-2 grid-cols-11 bg-white/50 dark:bg-white/10 shadow-black/10 dark:shadow-black/20 rounded-md shadow-md">
                 {colors.map((color) => (


### PR DESCRIPTION
## Proposed change

Fix the color popover

### Before:
![070725_05-48-56-PM_ci0Ixk5EyF](https://github.com/user-attachments/assets/3fb0d810-5446-4a38-ab5d-406b518a7517)

### After:
![070725_05-49-15-PM_Se5e5OyTK5](https://github.com/user-attachments/assets/8569434c-ceb2-45da-8fb2-af061eb27bac)

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

## Type of change

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
