### PR TITLE
Fix: formatting of CPU value for Proxmox VM and LXC stats

### DIFF
--- a/src/widgets/proxmoxvm/component.jsx
+++ b/src/widgets/proxmoxvm/component.jsx
@@ -25,7 +25,7 @@ export default function ProxmoxVM({ service }) {
 
   return (
     <Container service={service}>
-      <Block label="resources.cpu" value={t("common.percent", { value: data.cpu })} />
+      <Block label="resources.cpu" value={t("common.percent", { value: data.cpu * 100 })} />
       <Block label="resources.mem" value={t("common.bytes", { value: data.mem })} />
     </Container>
   );


### PR DESCRIPTION
## Proposed change

- Adds a fix to properly display the CPU percentage for Proxmox VMs and LXCs in the Proxmox stats integration

I noticed that all my LXCs and VMs had CPU usage of 0% even under load. I tested by running `stress` on an LXC and a VM to create 100% CPU load, and the widgets only displayed 1%.

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
