### PR TITLE
Feature: Filebrowser service widget

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,4 +16,7 @@
     "[python]": {
         "editor.defaultFormatter": "ms-python.autopep8"
     },
+    "i18n-ally.localesPaths": [
+      "public/locales"
+    ],
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,7 +16,4 @@
     "[python]": {
         "editor.defaultFormatter": "ms-python.autopep8"
     },
-    "i18n-ally.localesPaths": [
-      "public/locales"
-    ],
 }

--- a/docs/widgets/services/filebrowser.md
+++ b/docs/widgets/services/filebrowser.md
@@ -1,0 +1,19 @@
+---
+title: Filebrowser
+description: Filebrowser Widget Configuration
+---
+
+Learn more about [Filebrowser](https://filebrowser.org).
+
+If you are using [Proxy header authentication](https://filebrowser.org/configuration/authentication-method#proxy-header) you have to set `authHeader` and `username`.
+
+Allowed fields: `["available", "used", "total"]`.
+
+```yaml
+widget:
+  type: filebrowser
+  url: http://filebrowserhostorip:port
+  username: username
+  password: password
+  authHeader: X-My-Header # If using Proxy header authentication
+```

--- a/docs/widgets/services/index.md
+++ b/docs/widgets/services/index.md
@@ -33,6 +33,7 @@ You can also find a list of all available service widgets in the sidebar navigat
 - [Emby](emby.md)
 - [ESPHome](esphome.md)
 - [EVCC](evcc.md)
+- [Filebrowser](filebrowser.md)
 - [Fileflows](fileflows.md)
 - [Firefly III](firefly.md)
 - [Flood](flood.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
           - widgets/services/emby.md
           - widgets/services/esphome.md
           - widgets/services/evcc.md
+          - widgets/services/filebrowser.md
           - widgets/services/fileflows.md
           - widgets/services/firefly.md
           - widgets/services/flood.md

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1071,5 +1071,10 @@
         "servers": "Servers",
         "stacks": "Stacks",
         "containers": "Containers"
+    },
+    "filebrowser": {
+        "available": "Available",
+        "used": "Used",
+        "total": "Total"
     }
 }

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -31,6 +31,7 @@ const components = {
   emby: dynamic(() => import("./emby/component")),
   esphome: dynamic(() => import("./esphome/component")),
   evcc: dynamic(() => import("./evcc/component")),
+  filebrowser: dynamic(() => import("./filebrowser/component")),
   fileflows: dynamic(() => import("./fileflows/component")),
   firefly: dynamic(() => import("./firefly/component")),
   flood: dynamic(() => import("./flood/component")),

--- a/src/widgets/filebrowser/component.jsx
+++ b/src/widgets/filebrowser/component.jsx
@@ -27,7 +27,10 @@ export default function Component({ service }) {
 
   return (
     <Container service={service}>
-      <Block label="filebrowser.available" value={t("common.bytes", { value: (usage?.total ?? 0) - (usage?.used ?? 0) })} />
+      <Block
+        label="filebrowser.available"
+        value={t("common.bytes", { value: (usage?.total ?? 0) - (usage?.used ?? 0) })}
+      />
       <Block label="filebrowser.used" value={t("common.bytes", { value: usage?.used ?? 0 })} />
       <Block label="filebrowser.total" value={t("common.bytes", { value: usage?.total ?? 0 })} />
     </Container>

--- a/src/widgets/filebrowser/component.jsx
+++ b/src/widgets/filebrowser/component.jsx
@@ -1,0 +1,35 @@
+import Block from "components/services/widget/block";
+import Container from "components/services/widget/container";
+import { useTranslation } from "next-i18next";
+
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+
+  const { widget } = service;
+
+  const { data: usage, error: usageError } = useWidgetAPI(widget, "usage");
+
+  if (usageError) {
+    return <Container service={service} error={usageError} />;
+  }
+
+  if (!usage) {
+    return (
+      <Container service={service}>
+        <Block label="filebrowser.available" />
+        <Block label="filebrowser.used" />
+        <Block label="filebrowser.total" />
+      </Container>
+    );
+  }
+
+  return (
+    <Container service={service}>
+      <Block label="filebrowser.available" value={t("common.bytes", { value: (usage?.total ?? 0) - (usage?.used ?? 0) })} />
+      <Block label="filebrowser.used" value={t("common.bytes", { value: usage?.used ?? 0 })} />
+      <Block label="filebrowser.total" value={t("common.bytes", { value: usage?.total ?? 0 })} />
+    </Container>
+  );
+}

--- a/src/widgets/filebrowser/proxy.js
+++ b/src/widgets/filebrowser/proxy.js
@@ -8,7 +8,7 @@ const proxyName = "filebrowserProxyHandler";
 const logger = createLogger(proxyName);
 
 async function login(widget, service) {
-  const url = formatApiCall(widgets[widget.type].loginURL, widget);
+  const url = formatApiCall(widgets[widget.type].api, { ...widget, endpoint: "login" });
   const headers = {};
   if (widget.authHeader) {
     headers[widget.authHeader] = widget.username;

--- a/src/widgets/filebrowser/proxy.js
+++ b/src/widgets/filebrowser/proxy.js
@@ -1,0 +1,82 @@
+import cache from "memory-cache";
+
+import getServiceWidget from "utils/config/service-helpers";
+import createLogger from "utils/logger";
+import { formatApiCall } from "utils/proxy/api-helpers";
+import { httpProxy } from "utils/proxy/http";
+import widgets from "widgets/widgets";
+
+const proxyName = "filebrowserProxyHandler";
+const logger = createLogger(proxyName);
+
+async function login(widget, service) {
+  const url = formatApiCall(widgets[widget.type].loginURL, widget);
+  const [status, , data] = await httpProxy(url, {
+    method: "POST",
+    headers: {
+      ...(widget.authHeader ? {
+        [widget.authHeader]: widget.username,
+      } : {}),
+    },
+    body: JSON.stringify({
+      username: widget.username,
+      password: widget.password,
+    }),
+  });
+
+  switch (status) {
+    case 200:
+      return data;
+    case 401:
+      logger.error("Unauthorized access to Filebrowser API for service '%s'. Check credentials.", service);
+      break;
+    default:
+      logger.error("Unexpected status code %d when logging in to Filebrowser API for service '%s'", status, service);
+      break;
+  }
+}
+
+export default async function filebrowserProxyHandler(req, res) {
+  const { group, service, endpoint, index } = req.query;
+
+  if (!group || !service) {
+    logger.error("Invalid or missing service '%s' or group '%s'", service, group);
+    return res.status(400).json({ error: "Invalid proxy service type" });
+  }
+
+  const widget = await getServiceWidget(group, service, index);
+  if (!widget || !widgets[widget.type].api) {
+    logger.error("Invalid or missing widget for service '%s' in group '%s'", service, group);
+    return res.status(400).json({ error: "Invalid widget configuration" });
+  }
+
+  const token = await login(widget, service);
+  if (!token) {
+    return res.status(500).json({ error: "Failed to authenticate with Filebrowser" });
+  }
+
+  const url = new URL(formatApiCall(widgets[widget.type].api, { endpoint, ...widget }));
+
+  try {
+    const params = {
+      method: "GET",
+      headers: {
+        "X-AUTH": token
+      },
+    };
+
+    logger.debug("Calling Filebrowser API endpoint: %s", endpoint);
+
+    const [status,, data] = await httpProxy(url, params);
+
+    if (status !== 200) {
+      logger.error("Error calling Filebrowser API: %d. Data: %s", status, data);
+      return res.status(status).json({ error: "Filebrowser API Error", data });
+    }
+
+    return res.status(status).send(data);
+  } catch (error) {
+    logger.error("Exception calling Filebrowser API: %s", error.message);
+    return res.status(500).json({ error: "Filebrowser API Error", message: error.message });
+  }
+}

--- a/src/widgets/filebrowser/proxy.js
+++ b/src/widgets/filebrowser/proxy.js
@@ -9,15 +9,13 @@ const logger = createLogger(proxyName);
 
 async function login(widget, service) {
   const url = formatApiCall(widgets[widget.type].loginURL, widget);
+  const headers = {};
+  if (widget.authHeader) {
+    headers[widget.authHeader] = widget.username;
+  }
   const [status, , data] = await httpProxy(url, {
     method: "POST",
-    headers: {
-      ...(widget.authHeader
-        ? {
-            [widget.authHeader]: widget.username,
-          }
-        : {}),
-    },
+    headers,
     body: JSON.stringify({
       username: widget.username,
       password: widget.password,

--- a/src/widgets/filebrowser/proxy.js
+++ b/src/widgets/filebrowser/proxy.js
@@ -1,5 +1,3 @@
-import cache from "memory-cache";
-
 import getServiceWidget from "utils/config/service-helpers";
 import createLogger from "utils/logger";
 import { formatApiCall } from "utils/proxy/api-helpers";

--- a/src/widgets/filebrowser/proxy.js
+++ b/src/widgets/filebrowser/proxy.js
@@ -14,9 +14,11 @@ async function login(widget, service) {
   const [status, , data] = await httpProxy(url, {
     method: "POST",
     headers: {
-      ...(widget.authHeader ? {
-        [widget.authHeader]: widget.username,
-      } : {}),
+      ...(widget.authHeader
+        ? {
+            [widget.authHeader]: widget.username,
+          }
+        : {}),
     },
     body: JSON.stringify({
       username: widget.username,
@@ -61,13 +63,13 @@ export default async function filebrowserProxyHandler(req, res) {
     const params = {
       method: "GET",
       headers: {
-        "X-AUTH": token
+        "X-AUTH": token,
       },
     };
 
     logger.debug("Calling Filebrowser API endpoint: %s", endpoint);
 
-    const [status,, data] = await httpProxy(url, params);
+    const [status, , data] = await httpProxy(url, params);
 
     if (status !== 200) {
       logger.error("Error calling Filebrowser API: %d. Data: %s", status, data);

--- a/src/widgets/filebrowser/widget.js
+++ b/src/widgets/filebrowser/widget.js
@@ -2,7 +2,6 @@ import filebrowserProxyHandler from "./proxy";
 
 const widget = {
   api: "{url}/api/{endpoint}",
-  loginURL: "{url}/api/login",
   proxyHandler: filebrowserProxyHandler,
 
   mappings: {

--- a/src/widgets/filebrowser/widget.js
+++ b/src/widgets/filebrowser/widget.js
@@ -1,0 +1,15 @@
+import filebrowserProxyHandler from "./proxy";
+
+const widget = {
+  api: "{url}/api/{endpoint}",
+  loginURL: "{url}/api/login",
+  proxyHandler: filebrowserProxyHandler,
+
+  mappings: {
+    usage: {
+      endpoint: "usage",
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -25,6 +25,7 @@ import downloadstation from "./downloadstation/widget";
 import emby from "./emby/widget";
 import esphome from "./esphome/widget";
 import evcc from "./evcc/widget";
+import filebrowser from "./filebrowser/widget";
 import fileflows from "./fileflows/widget";
 import firefly from "./firefly/widget";
 import flood from "./flood/widget";
@@ -166,6 +167,7 @@ const widgets = {
   emby,
   esphome,
   evcc,
+  filebrowser,
   fileflows,
   firefly,
   flood,


### PR DESCRIPTION
<!--
==== STOP ====================
======== STOP ================
============ STOP ============
================ STOP ========
==================== STOP ====

⚠️ Before opening this pull request please review the guidelines in the checklist below.

If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.
-->

## Proposed change

### Filebrowser Widget

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

Filebrowser requires a token for each API request. This will be generated automatically from the username and password using `https://{hostname}/api/login`. It returns the token as a string. The token will then be used for `https://{hostname}/api/usage` to get the usage `used` and `total`. This endpoints returns a dictionary like this:

```json
{
    "total": 15875321102336,
    "used": 8775814610944
}
```
This widget will show `used`, `total` and `available`(calculated from `total`-`used`).

Closes #4400

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [x] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
