### PR TITLE
Romm widget fix Total Size

### DIFF
--- a/src/widgets/romm/component.jsx
+++ b/src/widgets/romm/component.jsx
@@ -43,7 +43,7 @@ export default function Component({ service }) {
         <Block label="romm.saves" value={t("common.number", { value: response.SAVES })} />
         <Block label="romm.states" value={t("common.number", { value: response.STATES })} />
         <Block label="romm.screenshots" value={t("common.number", { value: response.SCREENSHOTS })} />
-        <Block label="romm.totalfilesize" value={t("common.bytes", { value: response.FILESIZE })} />
+        <Block label="romm.totalfilesize" value={t("common.bytes", { value: response.TOTAL_FILESIZE_BYTES })} />
       </Container>
     );
   }


### PR DESCRIPTION
this PR fixes the total size.
the endpoint has
http://romm/api/stats
```json
{
  "PLATFORMS": 9,
  "ROMS": 134,
  "SAVES": 0,
  "STATES": 0,
  "SCREENSHOTS": 0,
  "TOTAL_FILESIZE_BYTES": 739302279671
}
```
<img width="291" height="133" alt="Screenshot_20250724_211332" src="https://github.com/user-attachments/assets/024add20-4855-4764-bb24-d87dca3f92bc" />