### PR TITLE
Update common.json

### DIFF
--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -61,8 +61,8 @@
         "wlan_devices": "WLAN-Geräte",
         "lan_users": "LAN-Benutzer",
         "wlan_users": "WLAN-Benutzer",
-        "up": "BETRIEBSZEIT",
-        "down": "EMPFANGEN",
+        "up": "UP",
+        "down": "DOWN",
         "wait": "Bitte warten",
         "empty_data": "Subsystem-Status unbekannt"
     },


### PR DESCRIPTION
Wrong translation for Unifi service

## Proposed change

The german translation for the Unifi service widget was wrong. "up" und "down" should indicate the WAN status while it was translated as it would be "uptime" and "downloaded".

There is no short translation of up and down, but everyone will unterstand "up" and "down".

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
