### PR TITLE
fix: calendar widget - auto highlighting the 2 days before the day set as firstDayInWeek

### DIFF
--- a/src/widgets/calendar/monthly.jsx
+++ b/src/widgets/calendar/monthly.jsx
@@ -8,14 +8,27 @@ import Event, { compareDateTimezone } from "./event";
 const cellStyle = "relative w-10 flex items-center justify-center flex-col";
 const monthButton = "pl-6 pr-6 ml-2 mr-2 hover:bg-theme-100/20 dark:hover:bg-white/5 rounded-md cursor-pointer";
 
-export function Day({ weekNumber, weekday, events, colorVariants, showDate, setShowDate, currentDate }) {
+function wrapSubtract(val, sub) {
+  return ((val - sub - 1 + 7) % 7) + 1;
+}
+
+export function Day({
+  weekNumber,
+  weekday,
+  events,
+  colorVariants,
+  showDate,
+  setShowDate,
+  currentDate,
+  weekendDaysIds,
+}) {
   const cellDate = showDate.set({ weekday, weekNumber, weekYear: showDate.year }).startOf("day");
   const filteredEvents = events?.filter((event) => compareDateTimezone(cellDate, event));
 
   const dayStyles = (displayDate) => {
     let style = "h-9 ";
 
-    if ([6, 7].includes(displayDate.weekday)) {
+    if (weekendDaysIds.includes(displayDate.weekday)) {
       // weekend style
       style += "text-red-500 ";
       // different month style
@@ -95,6 +108,11 @@ export default function Monthly({ service, colorVariants, events, showDate, setS
     return <div className="w-full text-center" />;
   }
 
+  let firstWeekendDayId = wrapSubtract(dayInWeekId[firstDayInWeekCalendar], 1);
+  let secondWeekendDayId = wrapSubtract(dayInWeekId[firstDayInWeekCalendar], 2);
+
+  const weekendDaysIds = [firstWeekendDayId, secondWeekendDayId];
+
   const firstWeek = DateTime.local(showDate.year, showDate.month, 1).setLocale(i18n.language);
 
   const weekIncrementChange = dayInWeekId[firstDayInWeekCalendar] > firstWeek.weekday ? -1 : 0;
@@ -162,6 +180,7 @@ export default function Monthly({ service, colorVariants, events, showDate, setS
                 showDate={showDate}
                 setShowDate={setShowDate}
                 currentDate={currentDate}
+                weekendDaysIds={weekendDaysIds}
               />
             )),
           )}


### PR DESCRIPTION
## Proposed change

Currently the "weekend" (red highlight) days are hardcoded as Saturday and Sunday, which makes sense if the week starts on Monday.  However,  we are allowing to change the first day of the week to any arbitrary day but then it looks wrong to mark Saturday and Sunday as the weekend. 

This fixes that by automatically highlighting the 2 previous days to the day configured as `firstDayInWeek` in `services.yaml`.

Before, with Sunday as `firstDayInWeek`

<img width="862" height="272" alt="image" src="https://github.com/user-attachments/assets/c4ce1c59-94d3-454a-b480-8e154a05c63f" />


After, Friday and Saturday are marked as the "weekend" (which is correct in countries where Sunday is a working day).

<img width="854" height="277" alt="image" src="https://github.com/user-attachments/assets/a2dbad30-7422-4bff-af2f-30135344470f" />


## Type of change

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
