### PR TITLE
Fix: properly handle UptimeRobot errors

### DIFF
--- a/src/utils/proxy/use-widget-api.js
+++ b/src/utils/proxy/use-widget-api.js
@@ -11,7 +11,9 @@ export default function useWidgetAPI(widget, ...options) {
   if (options[0] === "") {
     url = null;
   }
-  const { data, error, mutate } = useSWR(url, config);
+  const method = (options && options[1]?.method) || "GET";
+  const fetcher = async (url) => fetch(url, { method }).then((r) => r.json());
+  const { data, error, mutate } = useSWR(url, fetcher, config);
   // make the data error the top-level error
   return { data, error: data?.error ?? error, mutate };
 }

--- a/src/widgets/uptimerobot/component.jsx
+++ b/src/widgets/uptimerobot/component.jsx
@@ -1,26 +1,18 @@
 import Block from "components/services/widget/block";
 import Container from "components/services/widget/container";
 import { useTranslation } from "next-i18next";
-import { useEffect, useState } from "react";
 
-import { formatProxyUrl } from "utils/proxy/api-helpers";
+import useWidgetAPI from "utils/proxy/use-widget-api";
 
 export default function Component({ service }) {
   const { widget } = service;
   const { t } = useTranslation();
 
-  const [uptimerobotData, setUptimerobotData] = useState(null);
+  const { data: uptimerobotData, error: uptimerobotError } = useWidgetAPI(widget, "getmonitors", { method: "POST" });
 
-  useEffect(() => {
-    async function fetchData() {
-      const url = formatProxyUrl(widget, "getmonitors");
-      const res = await fetch(url, { method: "POST" });
-      setUptimerobotData(await res.json());
-    }
-    if (!uptimerobotData) {
-      fetchData();
-    }
-  }, [widget, uptimerobotData]);
+  if (uptimerobotError) {
+    return <Container service={service} error={uptimerobotError} />;
+  }
 
   if (!uptimerobotData) {
     return (


### PR DESCRIPTION
<!--
==== STOP ====================
======== STOP ================
============ STOP ============
================ STOP ========
==================== STOP ====

⚠️ Before opening this pull request please review the guidelines in the checklist below.

If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.
-->

## Proposed change

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

Currently the UptimeRobot widget will show raw errors whenever the API is rate limiting our requests. Their rate limiting happens quite frequently, refreshing the page 3-5 times is enough to trigger it reliably.

<img width="743" height="127" alt="image" src="https://github.com/user-attachments/assets/9b6f7a76-1d1f-4f69-90a1-a5ee23cdcfaf" />

This fixes the error handling and make it use the `useWidgetAPI` hook to gain the benefits of SWR, as it is a POST request without any side effect

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
