### PR TITLE
Fix: properly handle UptimeRobot errors

### DIFF
--- a/src/widgets/uptimerobot/component.jsx
+++ b/src/widgets/uptimerobot/component.jsx
@@ -31,6 +31,10 @@ export default function Component({ service }) {
     );
   }
 
+  if (uptimerobotData.error) {
+    return <Container service={service} error={uptimerobotData.error} />;
+  }
+
   // multiple monitors
   if (uptimerobotData.pagination?.total > 1) {
     const sitesUp = uptimerobotData.monitors.filter((m) => m.status === 2).length;


### PR DESCRIPTION
<!--
==== STOP ====================
======== STOP ================
============ STOP ============
================ STOP ========
==================== STOP ====

⚠️ Before opening this pull request please review the guidelines in the checklist below.

If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.
-->

## Proposed change

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

*Note: reupload without the useWidgetAPI changes for POST requests*

Currently the UptimeRobot widget will show raw errors whenever the API is rate limiting our requests. Their rate limiting happens quite frequently, refreshing the page 3-5 times is enough to trigger it reliably.

<img width="743" height="127" alt="image" src="https://github.com/user-attachments/assets/9b6f7a76-1d1f-4f69-90a1-a5ee23cdcfaf" />

This fixes the error handling to show it as intended:

<img width="743" height="232" alt="image" src="https://github.com/user-attachments/assets/a382b468-fee3-4b64-af42-4766b327189a" />

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
