### PR TITLE
Documentation: fix missing references to Wallos documentation doc

### DIFF
--- a/docs/widgets/services/index.md
+++ b/docs/widgets/services/index.md
@@ -143,6 +143,7 @@ You can also find a list of all available service widgets in the sidebar navigat
 - [UptimeRobot](uptimerobot.md)
 - [UrBackup](urbackup.md)
 - [Vikunja](vikunja.md)
+- [Wallos](wallos.md)
 - [Watchtower](watchtower.md)
 - [WGEasy](wgeasy.md)
 - [WhatsUpDocker](whatsupdocker.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -169,6 +169,7 @@ nav:
           - widgets/services/uptimerobot.md
           - widgets/services/urbackup.md
           - widgets/services/vikunja.md
+          - widgets/services/wallos.md
           - widgets/services/watchtower.md
           - widgets/services/wgeasy.md
           - widgets/services/whatsupdocker.md


### PR DESCRIPTION
## Proposed change

Since my PR #5562 for Wallos service widget has been shipped, I've noticed the documentation link is **missing** from the website's documentation index and sidebar. However, I can access the page by navigating to https://gethomepage.dev/widgets/services/wallos/:

<img width="4662" height="2238" alt="Screenshot From 2025-08-04 18-14-15" src="https://github.com/user-attachments/assets/f879422a-875e-4586-8a13-c138b438fb26" />

I've reviewed some other widgets' PRs and files, and I think the two files I've modified are what's required for the fix. But please correct me if more are missing.

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [x] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
