### PR TITLE
Enhancement: summarize charge power of all loadpoints in evcc widget

### DIFF
--- a/src/widgets/evcc/component.jsx
+++ b/src/widgets/evcc/component.jsx
@@ -45,10 +45,7 @@ export default function Component({ service }) {
       <Block label="evcc.pv_power" value={`${toKilowatts(t, data.pvPower)} ${t("evcc.kilowatt")}`} />
       <Block label="evcc.grid_power" value={`${toKilowatts(t, gridPower)} ${t("evcc.kilowatt")}`} />
       <Block label="evcc.home_power" value={`${toKilowatts(t, data.homePower)} ${t("evcc.kilowatt")}`} />
-      <Block
-        label="evcc.charge_power"
-        value={`${toKilowatts(t, totalChargePower)} ${t("evcc.kilowatt")}`}
-      />
+      <Block label="evcc.charge_power" value={`${toKilowatts(t, totalChargePower)} ${t("evcc.kilowatt")}`} />
     </Container>
   );
 }

--- a/src/widgets/evcc/component.jsx
+++ b/src/widgets/evcc/component.jsx
@@ -35,6 +35,11 @@ export default function Component({ service }) {
   // broken by evcc v0.133.0 https://github.com/evcc-io/evcc/commit/9dcb1fa0a7c08dd926b79309aa1f676a5fc6c8aa
   const gridPower = data.gridPower ?? data.grid?.power ?? 0;
 
+  // Sum chargePower of all loadpoints
+  const totalChargePower = Array.isArray(data.loadpoints)
+    ? data.loadpoints.reduce((sum, lp) => sum + (lp.chargePower ?? 0), 0)
+    : 0;
+
   return (
     <Container service={service}>
       <Block label="evcc.pv_power" value={`${toKilowatts(t, data.pvPower)} ${t("evcc.kilowatt")}`} />
@@ -42,7 +47,7 @@ export default function Component({ service }) {
       <Block label="evcc.home_power" value={`${toKilowatts(t, data.homePower)} ${t("evcc.kilowatt")}`} />
       <Block
         label="evcc.charge_power"
-        value={`${toKilowatts(t, data.loadpoints[0].chargePower)} ${t("evcc.kilowatt")}`}
+        value={`${toKilowatts(t, totalChargePower)} ${t("evcc.kilowatt")}`}
       />
     </Container>
   );


### PR DESCRIPTION
## Proposed change

Currently the evcc widget is only providing the current charge_Power of the first evcc loadpoint only. In case a evcc user configured more than one loadpoint (like me), charge_power is not reflecting it.

<img width="233" height="59" alt="image" src="https://github.com/user-attachments/assets/5965898f-8495-42bc-9726-194efa2d6342" />

With PR the chargePower sum of all loadpoints will be shown by the evcc widget.

Refer to feature request #5648.

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
