### PR TITLE
Feature: Unraid widget

### DIFF
--- a/docs/widgets/services/unraid.md
+++ b/docs/widgets/services/unraid.md
@@ -1,0 +1,25 @@
+---
+title: Unraid
+description: Unraid Widget Configuration
+---
+
+Learn more about [Unraid](https://unraid.net/).
+
+The Unraid widget allows you to monitor the resources of an Unraid server.
+
+You will need an API key with the **GUEST** (read only) role: [Managing API Keys](https://docs.unraid.net/API/how-to-use-the-api/#managing-api-keys)
+
+The widget can display metrics for selected Unraid pools. If using one of the "pool" fields, you must also add the pool name to the settings.
+
+Allowed fields: `["cpu","memoryPercent","memoryAvailable","memoryUsed","notifications","arrayFreeSpace","arrayUsedSpace","arrayUsedPercent","status","pool1UsedSpace","pool1FreeSpace","pool1UsedPercent","pool2UsedSpace","pool2FreeSpace","pool2UsedPercent","pool3UsedSpace","pool3FreeSpace","pool3UsedPercent","pool4UsedSpace","pool4FreeSpace","pool4UsedPercent"]`
+
+```yaml
+widget:
+  type: unraid
+  url: https://unraid.host.or.ip
+  key: api-key
+  pool1: # optional, name of pool for pool1... fields
+  pool2: # optional, name of pool for pool2... fields
+  pool3: # optional, name of pool for pool3... fields
+  pool4: # optional, name of pool for pool4... fields
+```

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1083,5 +1083,30 @@
         "nextMonthlyCost": "Next Month",
         "previousMonthlyCost": "Prev. Month",
         "nextRenewingSubscription": "Next Payment"
+    },
+    "unraid": {
+        "STARTED": "Started",
+        "STOPPED": "Stopped",
+        "NEW_ARRAY": "New Array",
+        "RECON_DISK": "Reconstructing Disk",
+        "DISABLE_DISK": "Disk Disabled",
+        "SWAP_DSBL": "Swap Disable",
+        "INVALID_EXPANSION": "Invalid Expansion",
+        "PARITY_NOT_BIGGEST": "Parity Not Biggest",
+        "TOO_MANY_MISSING_DISKS": "Too Many Missing Disks",
+        "NEW_DISK_TOO_SMALL": "New Disk Too Small",
+        "NO_DATA_DISKS": "No Data Disks",
+        "notifications": "Notifications",
+        "status": "Status",
+        "cpu": "CPU",
+        "memoryPercent": "Memory Used (%)",
+        "memoryUsed": "Memory Used",
+        "memoryAvailable": "Memory Available",
+        "arrayUsedSpace": "Array Used",
+        "arrayFreeSpace": "Array Free",
+        "arrayUsedPercent": "Array Used (%)",
+        "poolUsedSpace": "{{pool}} Used",
+        "poolFreeSpace": "{{pool}} Free",
+        "poolUsedPercent": "{{pool}} Used (%)"
     }
 }

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -396,6 +396,12 @@ export function cleanServiceGroups(groups) {
           // unifi
           site,
 
+          // unraid
+          pool1,
+          pool2,
+          pool3,
+          pool4,
+
           // vikunja
           enableTaskList,
 
@@ -609,6 +615,16 @@ export function cleanServiceGroups(groups) {
         }
         if (type === "grafana") {
           if (alerts) widget.alerts = alerts;
+        }
+        if (type === "unraid") {
+          if (pool1) widget.pool1 = pool1;
+          if (pool2) widget.pool2 = pool2;
+          if (pool3) widget.pool3 = pool3;
+          if (pool4) widget.pool4 = pool4;
+          if (fieldsList && fieldsList.length > 0) {
+            widget.display = fieldsList;
+            widget.fields = null;
+          }
         }
         return widget;
       });

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -139,6 +139,7 @@ const components = {
   truenas: dynamic(() => import("./truenas/component")),
   unifi: dynamic(() => import("./unifi/component")),
   unmanic: dynamic(() => import("./unmanic/component")),
+  unraid: dynamic(() => import("./unraid/component")),
   uptimekuma: dynamic(() => import("./uptimekuma/component")),
   uptimerobot: dynamic(() => import("./uptimerobot/component")),
   urbackup: dynamic(() => import("./urbackup/component")),

--- a/src/widgets/unraid/component.jsx
+++ b/src/widgets/unraid/component.jsx
@@ -1,0 +1,53 @@
+import Block from "components/services/widget/block";
+import Container from "components/services/widget/container";
+import { useTranslation } from "next-i18next";
+
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+const UNRAID_DEFAULT_FIELDS = ["status", "cpu", "memoryPercent", "notifications"];
+const MAX_ALLOWED_FIELDS = 4;
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+  const { widget } = service;
+
+  const { data, error } = useWidgetAPI(widget);
+
+  if (error) {
+    return <Container service={service} error={error} />;
+  }
+
+  if (!data) {
+    if (!widget.display?.length > 0) {
+      widget.display = UNRAID_DEFAULT_FIELDS;
+    } else if (widget.display.length > MAX_ALLOWED_FIELDS) {
+      widget.display = widget.display.slice(0, MAX_ALLOWED_FIELDS);
+    }
+
+    return (
+      <Container service={service}>
+        {widget.display.map((field) => {
+          const poolMatch = field.match(/^(pool\d)(.+)/);
+          if (poolMatch) {
+            const poolName = widget?.[poolMatch[1]] || poolMatch[1];
+            const fieldName = "pool" + poolMatch[2];
+            return <Block key={field} label={t(`unraid.${fieldName}`, { pool: poolName })} />;
+          }
+          return <Block key={field} label={`unraid.${field}`} />;
+        })}
+      </Container>
+    );
+  }
+
+  return (
+    <Container service={service}>
+      {data.map((data) => (
+        <Block
+          key={data.key ?? data.label}
+          label={data.poolName ? t(data.label, { pool: data.poolName }) : data.label}
+          value={t(data.t, { value: data.value })}
+        />
+      ))}
+    </Container>
+  );
+}

--- a/src/widgets/unraid/proxy.js
+++ b/src/widgets/unraid/proxy.js
@@ -1,0 +1,211 @@
+import getServiceWidget from "utils/config/service-helpers";
+import createLogger from "utils/logger";
+import { asJson } from "utils/proxy/api-helpers";
+import { httpProxy } from "utils/proxy/http";
+
+const logger = createLogger("unraidProxyHandler");
+
+const UNRAID_DEFAULT_FIELDS = ["status", "cpu", "memoryAvailable", "notifications"];
+const MAX_ALLOWED_FIELDS = 4;
+
+const graphqlQuery = `
+{
+  array {
+    state
+    capacity {
+      kilobytes {
+        free
+        total
+        used
+      }
+    }
+    caches {
+      name
+      fsType
+      fsSize
+      fsFree
+      fsUsed
+    }
+  }
+  metrics {
+    memory {
+      active
+      available
+      percentTotal
+    }
+    cpu {
+      percentTotal
+    }
+  }
+  notifications {
+    overview {
+      unread {
+        total
+      }
+    }
+  }
+}
+`;
+
+function getBlock(field, data, widget) {
+  if (field.startsWith("pool")) {
+    const pool = field.match(/^pool[1-4]/)?.[0]; // Match pool1, pool2, etc.
+    if (pool) {
+      // Get the last part of the field, e.g., "UsedSpace" from "pool1UsedSpace"
+      const param = field.replace(pool, "");
+      const poolName = widget?.[pool] || pool;
+      const label = "unraid.pool" + param;
+      const cache = data?.array?.caches?.find((c) => c.name === poolName);
+
+      switch (param) {
+        case "UsedSpace":
+          return {
+            poolName,
+            label,
+            t: "common.bytes",
+            key: field,
+            value: cache?.fsUsed != null ? cache.fsUsed * 1000 : "-",
+          };
+        case "FreeSpace":
+          return {
+            poolName,
+            label,
+            key: field,
+            t: "common.bytes",
+            value: cache?.fsFree != null ? cache.fsFree * 1000 : "-",
+          };
+        case "UsedPercent":
+          return {
+            poolName,
+            label,
+            key: field,
+            t: "common.percent",
+            value: (cache?.fsUsed / cache?.fsSize) * 100 ?? null,
+          };
+      }
+    }
+  }
+
+  switch (field) {
+    case "status":
+      return { label: "unraid.status", t: data?.array?.state != null ? `unraid.${data.array.state}` : "-", value: "" };
+    case "cpu":
+      return { label: "unraid.cpu", t: "common.percent", value: data?.metrics?.cpu?.percentTotal ?? null };
+    case "memoryPercent":
+      return { label: "unraid.memoryPercent", t: "common.percent", value: data?.metrics?.memory?.percentTotal ?? null };
+    case "notifications":
+      return {
+        label: "unraid.notifications",
+        t: "common.number",
+        value: data?.notifications?.overview?.unread?.total ?? null,
+      };
+    case "memoryAvailable":
+      return { label: "unraid.memoryAvailable", t: "common.bbytes", value: data?.metrics?.memory?.available ?? null };
+    case "memoryUsed":
+      return { label: "unraid.memoryUsed", t: "common.bbytes", value: data?.metrics?.memory?.active ?? null };
+    case "arrayFreeSpace":
+      return {
+        label: "unraid.arrayFreeSpace",
+        t: "common.bytes",
+        value: data?.array?.capacity?.kilobytes?.free * 1000 ?? null,
+      };
+    case "arrayUsedSpace":
+      return {
+        label: "unraid.arrayUsedSpace",
+        t: "common.bytes",
+        value: data?.array?.capacity?.kilobytes?.used * 1000 ?? null,
+      };
+    case "arrayUsedPercent":
+      return {
+        label: "unraid.arrayUsedPercent",
+        t: "common.percent",
+        value: (data?.array?.capacity?.kilobytes?.used / data?.array?.capacity?.kilobytes?.total) * 100 ?? null,
+      };
+  }
+
+  return null;
+}
+
+function processUnraidResponse(data, widget) {
+  const response = [];
+
+  try {
+    data = asJson(data)?.data;
+
+    widget.fields.forEach((field) => {
+      const block = getBlock(field, data, widget);
+      if (block) {
+        response.push(block);
+      }
+    });
+  } catch (error) {
+    return { error: error.message };
+  }
+
+  return response;
+}
+
+export default async function unraidProxyHandler(req, res) {
+  const { group, service, index } = req.query;
+
+  if (!group || !service) {
+    logger.debug("Invalid or missing service '%s' or group '%s'", service, group);
+    return res.status(400).json({ error: "Invalid proxy service type" });
+  }
+
+  const widget = await getServiceWidget(group, service, index);
+  if (!widget) {
+    logger.debug("Invalid or missing widget for service '%s' in group '%s'", service, group);
+    return res.status(400).json({ error: "Invalid proxy service type" });
+  }
+
+  if (!widget.fields?.length > 0) {
+    widget.fields = UNRAID_DEFAULT_FIELDS;
+  } else if (widget.fields.length > MAX_ALLOWED_FIELDS) {
+    widget.fields = widget.fields.slice(0, MAX_ALLOWED_FIELDS);
+  }
+
+  const url = new URL(widget.url + "/graphql");
+
+  const headers = {
+    "Content-Type": "application/json",
+    Accept: `application/json`,
+    "X-API-Key": `${widget.key}`,
+  };
+
+  const params = {
+    method: "POST",
+    headers,
+    withCredentials: true,
+    credentials: "include",
+  };
+  params.body = JSON.stringify({
+    query: graphqlQuery,
+  });
+
+  const [status, , data] = await httpProxy(url, params);
+
+  if (status === 204 || status === 304) {
+    return res.status(status).end();
+  }
+
+  if (status !== 200) {
+    logger.error(
+      "Error getting data from Unraid for service '%s' in group '%s': %d.  Data: %s",
+      service,
+      group,
+      status,
+      data,
+    );
+    return res.status(status).send({ error: { message: "Error calling Unraid API.", data } });
+  }
+
+  const result = processUnraidResponse(data, widget);
+  if (result.error) {
+    logger.error("Error processing Unraid data: %s", result.error);
+    return res.status(500).send({ error: { message: "Error processing Unraid API response", data: result.error } });
+  }
+
+  res.setHeader("Content-Type", "application/json");
+  return res.status(status).send(result);
+}

--- a/src/widgets/unraid/widget.js
+++ b/src/widgets/unraid/widget.js
@@ -1,0 +1,7 @@
+import unraidProxyHandler from "./proxy";
+
+const widget = {
+  proxyHandler: unraidProxyHandler,
+};
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -130,6 +130,7 @@ import truenas from "./truenas/widget";
 import tubearchivist from "./tubearchivist/widget";
 import unifi from "./unifi/widget";
 import unmanic from "./unmanic/widget";
+import unraid from "./unraid/widget";
 import uptimekuma from "./uptimekuma/widget";
 import uptimerobot from "./uptimerobot/widget";
 import urbackup from "./urbackup/widget";
@@ -278,6 +279,7 @@ const widgets = {
   unifi,
   unifi_console: unifi,
   unmanic,
+  unraid,
   uptimekuma,
   uptimerobot,
   urbackup,


### PR DESCRIPTION
## Proposed change

Adds a service widget for [Unraid](https://unraid.net/). The widget provides a large selection of fields to accommodate varying configurations -- e.g., some users might not have an array to monitor, other users might have multiple pools, etc.

One unusual feature about how the widget operates is related to the `fields` option. When displaying information about a pool, the label is dynamic -- it includes the pool name and the metric being displayed (e.g., "TESTPOOL USED (%)" in the example rendering). This doesn't work with the filtering that `fields` does since the label no longer matches the field.

To work around that issue, I switch the option provided to the component from `fields` to `display` in `cleanServiceGroups`. I did it this way so that the user configuration remains consistent with other widgets. If you would rather I make that a unique option instead, I can do that too.

### API

Unraid 7.2 (currently in beta) and later provide a GraphQL API. Instructions to create an API key are linked in the doc.

#### Example Request

```
query {
  array {
    state
    capacity {
      kilobytes {
        free
        total
        used
      }
    }
    caches {
      name
      fsType
      fsSize
      fsFree
      fsUsed
    }
  }
  metrics {
    memory {
      active
      available
      percentTotal
    }
    cpu {
      percentTotal
    }
  }
  notifications {
    overview {
      unread {
        total
      }
    }
  }
}
```

#### Example Response

```
{
  "data": {
    "array": {
      "state": "STARTED",
      "capacity": {
        "kilobytes": {
          "free": "54563033",
          "total": "80462479",
          "used": "25899446"
        }
      },
      "caches": [
        {
          "name": "testpool",
          "fsType": "zfs",
          "fsSize": 51506053,
          "fsFree": 41501696,
          "fsUsed": 10004357
        },
        {
          "name": "testpool2",
          "fsType": null,
          "fsSize": null,
          "fsFree": null,
          "fsUsed": null
        }
      ]
    },
    "metrics": {
      "memory": {
        "active": 3248586752,
        "available": 2974113792,
        "percentTotal": 52.205416748397525
      },
      "cpu": {
        "percentTotal": 5.897821187077385
      }
    },
    "notifications": {
      "overview": {
        "unread": {
          "total": 0
        }
      }
    }
  }
}
```

### Example Rendering

<img width="583" height="114" alt="image" src="https://github.com/user-attachments/assets/ae2549d2-9b2b-47eb-93cc-c753089bc2e4" />

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [X] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

See #4514

## Checklist:

- [X] If applicable, I have added corresponding documentation changes.
- [X] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [X] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [X] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
