### PR TITLE
Adds dual WAN support to pfSense widget

### DIFF
--- a/docs/widgets/services/pfsense.md
+++ b/docs/widgets/services/pfsense.md
@@ -13,29 +13,94 @@ There are two currently supported authentication modes: 'Local Database' and 'AP
 
 The interface to monitor is defined by updating the `wan` parameter. It should be referenced as it is shown under Interfaces > Assignments in pfSense.
 
+## Dual WAN Support
+
+For dual WAN configurations with failover, you can monitor both interfaces by adding the `wan2` parameter. When both WANs are configured with API version 2, the widget will:
+
+- Display the status of both WAN interfaces
+- Show which WAN is configured as Primary vs Backup based on your gateway group tiers
+- Indicate the currently active WAN with **bold text**
+- Automatically detect failover states based on gateway status
+
+## Configuration Notes
+
 Load is returned instead of cpu utilization. This is a limitation in the pfSense API due to the complexity of this calculation. This may become available in future versions.
 
-Allowed fields: `["load", "memory", "temp", "wanStatus", "wanIP", "disk"]` (maximum of 4)
+Allowed fields: `["load", "memory", "temp", "wanStatus", "wanIP", "wan2Status", "wan2IP", "disk"]` (maximum of 6 recommended for single row display)
 
-For version 2:
+## Configuration Examples
+
+### Basic Single WAN Setup (Version 2)
 
 ```yaml
 widget:
   type: pfsense
   url: http://pfsense.host.or.ip:port
-  username: user # optional, or API key
-  password: pass # optional, or API key
-  headers: # optional, or username/password
-    X-API-Key: key
+  headers:
+    X-API-Key: your-api-key
   wan: igb0
-  version: 2 # optional, defaults to 1 for api v1
-  fields: ["load", "memory", "temp", "wanStatus"] # optional
+  version: 2
+  fields: ["load", "memory", "temp", "wanStatus", "wanIP", "disk"]
 ```
 
-For version 1:
+### Dual WAN with Failover (Version 2)
 
 ```yaml
-headers: # optional, or username/password
-  Authorization: client_id client_token # obtained from pfSense API
-version: 1
+widget:
+  type: pfsense
+  url: https://pfsense.host.or.ip:port
+  headers:
+    X-API-Key: your-api-key
+  wan: igc0 # Interface name for WAN 1 (check Interfaces > Assignments)
+  wan2: igc2 # Interface name for WAN 2 (check Interfaces > Assignments)
+  version: 2 # Required for dual WAN support
+  fields: ["load", "memory", "wanStatus", "wanIP", "wan2Status", "wan2IP"]
 ```
+
+When configured for dual WAN:
+
+- The widget automatically detects your gateway group configuration
+- "(Primary)" label shows next to the Tier 1 gateway
+- "(Backup)" label shows next to the Tier 2 gateway
+- Bold text indicates which WAN is actively routing traffic
+- Failover detection works automatically based on gateway status
+
+### Version 1 Configuration
+
+```yaml
+widget:
+  type: pfsense
+  url: http://pfsense.host.or.ip:port
+  headers:
+    Authorization: client_id client_token # obtained from pfSense API
+  wan: igb0
+  version: 1
+  fields: ["load", "memory", "temp", "wanStatus", "wanIP"]
+```
+
+**Note:** Dual WAN support requires API version 2.
+
+## Troubleshooting
+
+### Finding Your Interface Names
+
+1. Log into your pfSense web interface
+2. Navigate to **Interfaces > Assignments**
+3. Note the interface names (e.g., `igc0`, `igc1`, `igb0`)
+4. Use these exact names in your widget configuration
+
+### Setting Up Gateway Groups for Failover
+
+For the dual WAN feature to properly detect primary/backup status:
+
+1. Navigate to **System > Routing > Gateway Groups**
+2. Create a failover group with your two WAN gateways
+3. Set Tier 1 for your primary WAN
+4. Set Tier 2 for your backup WAN
+5. The widget will automatically detect this configuration
+
+### Common Issues
+
+- **WAN2 fields not showing:** Ensure you're using API version 2 and have included the wan2 fields in your configuration
+- **No Primary/Backup labels:** These only appear when `wan2` is configured
+- **Incorrect active WAN indication:** Verify your gateway group is properly configured in pfSense

--- a/public/locales/af/common.json
+++ b/public/locales/af/common.json
@@ -657,7 +657,9 @@
         "down": "Af",
         "temp": "Temp",
         "disk": "Skyfgebruik",
-        "wanIP": "WAN IP"
+        "wanIP": "WAN IP",
+        "wan2Status": "WAN2 Status",
+        "wan2IP": "WAN2 IP"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "Datastoor",

--- a/public/locales/ar/common.json
+++ b/public/locales/ar/common.json
@@ -657,7 +657,9 @@
         "down": "Down",
         "temp": "Temp",
         "disk": "استخدام القرص",
-        "wanIP": "IP الشبكة الواسعة"
+        "wanIP": "IP الشبكة الواسعة",
+        "wan2Status": "حالة WAN2",
+        "wan2IP": "WAN2 IP"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "مخزن البيانات",

--- a/public/locales/bg/common.json
+++ b/public/locales/bg/common.json
@@ -657,7 +657,9 @@
         "down": "Down",
         "temp": "Temp",
         "disk": "Употреба на диска",
-        "wanIP": "WAN IP"
+        "wanIP": "WAN IP",
+        "wan2Status": "WAN2 статус",
+        "wan2IP": "WAN2 IP"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "База данни",

--- a/public/locales/ca/common.json
+++ b/public/locales/ca/common.json
@@ -657,7 +657,9 @@
         "down": "Down",
         "temp": "Temp",
         "disk": "Ús Disc",
-        "wanIP": "IP WAN"
+        "wanIP": "IP WAN",
+        "wan2Status": "Estat WAN2",
+        "wan2IP": "IP WAN2"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "Datastore",

--- a/public/locales/cs/common.json
+++ b/public/locales/cs/common.json
@@ -657,7 +657,9 @@
         "down": "Down",
         "temp": "Temp",
         "disk": "Využití disku",
-        "wanIP": "IP WAN"
+        "wanIP": "IP WAN",
+        "wan2Status": "Stav WAN2",
+        "wan2IP": "IP WAN2"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "Datové úložiště",

--- a/public/locales/da/common.json
+++ b/public/locales/da/common.json
@@ -657,7 +657,9 @@
         "down": "Down",
         "temp": "Temp",
         "disk": "Disk Forbrug",
-        "wanIP": "WAN IP"
+        "wanIP": "WAN IP",
+        "wan2Status": "WAN2 Status",
+        "wan2IP": "WAN2 IP"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "Datalager",

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -657,7 +657,9 @@
         "down": "Offline",
         "temp": "Temp",
         "disk": "Datenträgernutzung",
-        "wanIP": "WAN-IP"
+        "wanIP": "WAN-IP",
+        "wan2Status": "WAN2-Status",
+        "wan2IP": "WAN2-IP"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "Datenspeicher",

--- a/public/locales/el/common.json
+++ b/public/locales/el/common.json
@@ -657,7 +657,9 @@
         "down": "Down",
         "temp": "Temp",
         "disk": "Χρήση δίσκου",
-        "wanIP": "WAN IP"
+        "wanIP": "WAN IP",
+        "wan2Status": "WAN2 Status",
+        "wan2IP": "WAN2 IP"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "Datastore",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -658,7 +658,9 @@
         "down": "Down",
         "temp": "Temp",
         "disk": "Disk Usage",
-        "wanIP": "WAN IP"
+        "wanIP": "WAN IP",
+        "wan2Status": "WAN2 Status",
+        "wan2IP": "WAN2 IP"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "Datastore",

--- a/public/locales/eo/common.json
+++ b/public/locales/eo/common.json
@@ -657,7 +657,9 @@
         "down": "Down",
         "temp": "Temp",
         "disk": "Disk Usage",
-        "wanIP": "WAN IP"
+        "wanIP": "WAN IP",
+        "wan2Status": "WAN2 Status",
+        "wan2IP": "WAN2 IP"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "Datastore",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -657,7 +657,9 @@
         "down": "Inactivo",
         "temp": "Temp",
         "disk": "Uso del disco",
-        "wanIP": "IP de la WAN"
+        "wanIP": "IP de la WAN",
+        "wan2Status": "Estado de la WAN2",
+        "wan2IP": "IP de la WAN2"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "Almacén de datos",

--- a/public/locales/eu/common.json
+++ b/public/locales/eu/common.json
@@ -657,7 +657,9 @@
         "down": "Down",
         "temp": "Temp",
         "disk": "Disk Usage",
-        "wanIP": "WAN IP"
+        "wanIP": "WAN IP",
+        "wan2Status": "WAN2 Status",
+        "wan2IP": "WAN2 IP"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "Datastore",

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -657,7 +657,9 @@
         "down": "Down",
         "temp": "Temp",
         "disk": "Disk Usage",
-        "wanIP": "WAN IP"
+        "wanIP": "WAN IP",
+        "wan2Status": "WAN2 Status",
+        "wan2IP": "WAN2 IP"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "Datastore",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -657,7 +657,9 @@
         "down": "Bas",
         "temp": "Température",
         "disk": "Util. Disque",
-        "wanIP": "IP WAN"
+        "wanIP": "IP WAN",
+        "wan2Status": "Statut WAN2",
+        "wan2IP": "IP WAN2"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "Datastore",

--- a/public/locales/he/common.json
+++ b/public/locales/he/common.json
@@ -657,7 +657,9 @@
         "down": "למטה",
         "temp": "טמפ׳",
         "disk": "שימוש בדיסק",
-        "wanIP": "WAN IP"
+        "wanIP": "WAN IP",
+        "wan2Status": "סטטוס WAN2",
+        "wan2IP": "WAN2 IP"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "Datastore",

--- a/public/locales/hi/common.json
+++ b/public/locales/hi/common.json
@@ -657,7 +657,9 @@
         "down": "Down",
         "temp": "Temp",
         "disk": "Disk Usage",
-        "wanIP": "WAN IP"
+        "wanIP": "WAN IP",
+        "wan2Status": "WAN2 Status",
+        "wan2IP": "WAN2 IP"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "Datastore",

--- a/public/locales/hr/common.json
+++ b/public/locales/hr/common.json
@@ -657,7 +657,9 @@
         "down": "Down",
         "temp": "Temp",
         "disk": "Korištenje diska",
-        "wanIP": "WAN IP"
+        "wanIP": "WAN IP",
+        "wan2Status": "Stanje WAN2-a",
+        "wan2IP": "WAN2 IP"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "Spremište podataka",

--- a/public/locales/hu/common.json
+++ b/public/locales/hu/common.json
@@ -657,7 +657,9 @@
         "down": "Down",
         "temp": "Temp",
         "disk": "Lemezhasználat",
-        "wanIP": "WAN IP"
+        "wanIP": "WAN IP",
+        "wan2Status": "WAN2 Állapot",
+        "wan2IP": "WAN2 IP"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "Adattár",

--- a/public/locales/id/common.json
+++ b/public/locales/id/common.json
@@ -657,7 +657,9 @@
         "down": "Down",
         "temp": "Temp",
         "disk": "Penggunaan Disk",
-        "wanIP": "IP WAN"
+        "wanIP": "IP WAN",
+        "wan2Status": "Status WAN2",
+        "wan2IP": "IP WAN2"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "Datastore",

--- a/public/locales/it/common.json
+++ b/public/locales/it/common.json
@@ -657,7 +657,9 @@
         "down": "Down",
         "temp": "Temp",
         "disk": "Uso Disco",
-        "wanIP": "IP WAN"
+        "wanIP": "IP WAN",
+        "wan2Status": "Stato WAN2",
+        "wan2IP": "IP WAN2"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "Archivio dati",

--- a/public/locales/ja/common.json
+++ b/public/locales/ja/common.json
@@ -657,7 +657,9 @@
         "down": "Down",
         "temp": "Temp",
         "disk": "ディスク使用量",
-        "wanIP": "WAN IP"
+        "wanIP": "WAN IP",
+        "wan2Status": "WAN2ステータス",
+        "wan2IP": "WAN2 IP"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "データストア",

--- a/public/locales/ko/common.json
+++ b/public/locales/ko/common.json
@@ -657,7 +657,9 @@
         "down": "Down",
         "temp": "Temp",
         "disk": "Disk Usage",
-        "wanIP": "WAN IP"
+        "wanIP": "WAN IP",
+        "wan2Status": "WAN2 Status",
+        "wan2IP": "WAN2 IP"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "Datastore",

--- a/public/locales/lv/common.json
+++ b/public/locales/lv/common.json
@@ -657,7 +657,9 @@
         "down": "Down",
         "temp": "Temp",
         "disk": "Disk Usage",
-        "wanIP": "WAN IP"
+        "wanIP": "WAN IP",
+        "wan2Status": "WAN2 Status",
+        "wan2IP": "WAN2 IP"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "Datastore",

--- a/public/locales/ms/common.json
+++ b/public/locales/ms/common.json
@@ -657,7 +657,9 @@
         "down": "Down",
         "temp": "Temp",
         "disk": "Disk Usage",
-        "wanIP": "WAN IP"
+        "wanIP": "WAN IP",
+        "wan2Status": "WAN2 Status",
+        "wan2IP": "WAN2 IP"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "Datastore",

--- a/public/locales/nb-NO/common.json
+++ b/public/locales/nb-NO/common.json
@@ -634,7 +634,9 @@
         "down": "Down",
         "temp": "Temp",
         "disk": "Disk Usage",
-        "wanIP": "WAN IP"
+        "wanIP": "WAN IP",
+        "wan2Status": "WAN2 Status",
+        "wan2IP": "WAN2 IP"
     },
     "caddy": {
         "upstreams": "Upstreams",

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -657,7 +657,9 @@
         "down": "Down",
         "temp": "Temp",
         "disk": "Schijf Gebruik",
-        "wanIP": "WAN IP"
+        "wanIP": "WAN IP",
+        "wan2Status": "WAN2 Status",
+        "wan2IP": "WAN2 IP"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "Data Opslag",

--- a/public/locales/no/common.json
+++ b/public/locales/no/common.json
@@ -657,7 +657,9 @@
         "down": "Down",
         "temp": "Temp",
         "disk": "Disk Usage",
-        "wanIP": "WAN IP"
+        "wanIP": "WAN IP",
+        "wan2Status": "WAN2 Status",
+        "wan2IP": "WAN2 IP"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "Datastore",

--- a/public/locales/pl/common.json
+++ b/public/locales/pl/common.json
@@ -657,7 +657,9 @@
         "down": "Down",
         "temp": "Temp",
         "disk": "Użycie dysku",
-        "wanIP": "WAN IP"
+        "wanIP": "WAN IP",
+        "wan2Status": "Status WAN2",
+        "wan2IP": "WAN2 IP"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "Magazyn danych",

--- a/public/locales/pt-BR/common.json
+++ b/public/locales/pt-BR/common.json
@@ -634,7 +634,9 @@
         "down": "Down",
         "temp": "Temp",
         "disk": "Uso de disco",
-        "wanIP": "WAN IP"
+        "wanIP": "WAN IP",
+        "wan2Status": "WAN2 Status",
+        "wan2IP": "WAN2 IP"
     },
     "caddy": {
         "upstreams": "Upstreams",

--- a/public/locales/pt/common.json
+++ b/public/locales/pt/common.json
@@ -657,7 +657,9 @@
         "down": "Down",
         "temp": "Temp",
         "disk": "Utilização do Disco",
-        "wanIP": "WAN IP"
+        "wanIP": "WAN IP",
+        "wan2Status": "WAN2 Status",
+        "wan2IP": "WAN2 IP"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "Armaz. de Dados",

--- a/public/locales/pt_BR/common.json
+++ b/public/locales/pt_BR/common.json
@@ -657,7 +657,9 @@
         "down": "Down",
         "temp": "Temp",
         "disk": "Uso do disco",
-        "wanIP": "IP WAN"
+        "wanIP": "IP WAN",
+        "wan2Status": "Estado WAN2",
+        "wan2IP": "IP WAN2"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "Armaz. de Dados",

--- a/public/locales/ro/common.json
+++ b/public/locales/ro/common.json
@@ -657,7 +657,9 @@
         "down": "Down",
         "temp": "Temp",
         "disk": "Utilizare Disc",
-        "wanIP": "WAN IP"
+        "wanIP": "WAN IP",
+        "wan2Status": "WAN2 Status",
+        "wan2IP": "WAN2 IP"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "Datastore",

--- a/public/locales/ru/common.json
+++ b/public/locales/ru/common.json
@@ -657,7 +657,9 @@
         "down": "Не в сети",
         "temp": "Температура",
         "disk": "Использование диска",
-        "wanIP": "WAN IP"
+        "wanIP": "WAN IP",
+        "wan2Status": "Статус WAN2",
+        "wan2IP": "WAN2 IP"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "Хранилище данных",

--- a/public/locales/sk/common.json
+++ b/public/locales/sk/common.json
@@ -657,7 +657,9 @@
         "down": "Down",
         "temp": "Temp",
         "disk": "Využitie disku",
-        "wanIP": "IP adresa WAN"
+        "wanIP": "IP adresa WAN",
+        "wan2Status": "Stav WAN2",
+        "wan2IP": "IP adresa WAN2"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "Dátové úložisko",

--- a/public/locales/sl/common.json
+++ b/public/locales/sl/common.json
@@ -657,7 +657,9 @@
         "down": "Down",
         "temp": "Temp",
         "disk": "Poraba diska",
-        "wanIP": "WAN IP"
+        "wanIP": "WAN IP",
+        "wan2Status": "WAN2 status",
+        "wan2IP": "WAN2 IP"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "Shramba podatkov",

--- a/public/locales/sr/common.json
+++ b/public/locales/sr/common.json
@@ -657,7 +657,9 @@
         "down": "Доле",
         "temp": "Темп.",
         "disk": "Коришћење диска",
-        "wanIP": "WAN IP"
+        "wanIP": "WAN IP",
+        "wan2Status": "WAN2 статус",
+        "wan2IP": "WAN2 IP"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "Складиште података",

--- a/public/locales/sv/common.json
+++ b/public/locales/sv/common.json
@@ -657,7 +657,9 @@
         "down": "Down",
         "temp": "Temp",
         "disk": "Disk Usage",
-        "wanIP": "WAN IP"
+        "wanIP": "WAN IP",
+        "wan2Status": "WAN2 Status",
+        "wan2IP": "WAN2 IP"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "Datastore",

--- a/public/locales/te/common.json
+++ b/public/locales/te/common.json
@@ -657,7 +657,9 @@
         "down": "Down",
         "temp": "Temp",
         "disk": "Disk Usage",
-        "wanIP": "WAN IP"
+        "wanIP": "WAN IP",
+        "wan2Status": "WAN2 Status",
+        "wan2IP": "WAN2 IP"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "Datastore",

--- a/public/locales/th/common.json
+++ b/public/locales/th/common.json
@@ -657,7 +657,9 @@
         "down": "Down",
         "temp": "Temp",
         "disk": "Disk Usage",
-        "wanIP": "WAN IP"
+        "wanIP": "WAN IP",
+        "wan2Status": "WAN2 Status",
+        "wan2IP": "WAN2 IP"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "Datastore",

--- a/public/locales/tr/common.json
+++ b/public/locales/tr/common.json
@@ -657,7 +657,9 @@
         "down": "Down",
         "temp": "Temp",
         "disk": "Disk Kullanımı",
-        "wanIP": "WAN IP"
+        "wanIP": "WAN IP",
+        "wan2Status": "WAN2 Durumu",
+        "wan2IP": "WAN2 IP"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "Veri deposu",

--- a/public/locales/uk/common.json
+++ b/public/locales/uk/common.json
@@ -657,7 +657,9 @@
         "down": "Down",
         "temp": "Temp",
         "disk": "Використання диска",
-        "wanIP": "WAN IP"
+        "wanIP": "WAN IP",
+        "wan2Status": "Статус WAN2",
+        "wan2IP": "WAN2 IP"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "Сховище даних",

--- a/public/locales/vi/common.json
+++ b/public/locales/vi/common.json
@@ -657,7 +657,9 @@
         "down": "Down",
         "temp": "Temp",
         "disk": "Disk Usage",
-        "wanIP": "WAN IP"
+        "wanIP": "WAN IP",
+        "wan2Status": "WAN2 Status",
+        "wan2IP": "WAN2 IP"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "Datastore",

--- a/public/locales/yue/common.json
+++ b/public/locales/yue/common.json
@@ -657,7 +657,9 @@
         "down": "Down",
         "temp": "Temp",
         "disk": "硬碟使用率",
-        "wanIP": "網際網路 IP"
+        "wanIP": "網際網路 IP",
+        "wan2Status": "WAN2狀態",
+        "wan2IP": "WAN2 IP"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "數據存儲",

--- a/public/locales/zh-CN/common.json
+++ b/public/locales/zh-CN/common.json
@@ -634,7 +634,9 @@
         "down": "下载",
         "temp": "温度",
         "disk": "磁盘",
-        "wanIP": "WAN IP"
+        "wanIP": "WAN IP",
+        "wan2Status": "WAN2 状态",
+        "wan2IP": "WAN2 IP"
     },
     "caddy": {
         "upstreams": "上游",

--- a/public/locales/zh-Hans/common.json
+++ b/public/locales/zh-Hans/common.json
@@ -657,7 +657,9 @@
         "down": "Down",
         "temp": "Temp",
         "disk": "磁盘",
-        "wanIP": "WAN IP"
+        "wanIP": "WAN IP",
+        "wan2Status": "WAN2 状态",
+        "wan2IP": "WAN2 IP"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "数据存储",

--- a/public/locales/zh-Hant/common.json
+++ b/public/locales/zh-Hant/common.json
@@ -657,7 +657,9 @@
         "down": "Down",
         "temp": "Temp",
         "disk": "硬碟使用率",
-        "wanIP": "網際網路 IP"
+        "wanIP": "網際網路 IP",
+        "wan2Status": "WAN2狀態",
+        "wan2IP": "WAN2 IP"
     },
     "proxmoxbackupserver": {
         "datastore_usage": "資料存儲",

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -366,6 +366,7 @@ export function cleanServiceGroups(groups) {
 
           // opnsense, pfsense
           wan,
+          wan2,
 
           // portainer
           kubernetes,
@@ -493,6 +494,7 @@ export function cleanServiceGroups(groups) {
         }
         if (["opnsense", "pfsense"].includes(type)) {
           if (wan) widget.wan = wan;
+          if (wan2) widget.wan2 = wan2;
         }
         if (["emby", "jellyfin"].includes(type)) {
           if (enableMediaControl !== undefined) widget.enableMediaControl = !!JSON.parse(enableMediaControl);

--- a/src/widgets/pfsense/component.jsx
+++ b/src/widgets/pfsense/component.jsx
@@ -15,9 +15,19 @@ export default function Component({ service }) {
     widget,
     version === 1 ? "interface" : "interfacev2",
   );
+  const { data: gatewayData, error: gatewayError } = useWidgetAPI(
+    widget,
+    version === 2 && widget.wan2 ? "gatewaysv2" : null,
+  );
+  const { data: gatewayGroupData, error: gatewayGroupError } = useWidgetAPI(
+    widget,
+    version === 2 && widget.wan2 ? "gatewaygroups" : null,
+  );
 
-  const showWanIP = widget.fields?.filter((f) => f !== "wanIP").length <= 4 && widget.fields?.includes("wanIP");
-  const showDiskUsage = widget.fields?.filter((f) => f !== "disk").length <= 4 && widget.fields?.includes("disk");
+  const showWanIP = widget.fields?.includes("wanIP");
+  const showDiskUsage = widget.fields?.includes("disk");
+  const showWan2Status = widget.wan2 && widget.fields?.includes("wan2Status");
+  const showWan2IP = widget.wan2 && widget.fields?.includes("wan2IP");
 
   if (systemError || interfaceError) {
     const finalError = systemError ?? interfaceError;
@@ -31,13 +41,83 @@ export default function Component({ service }) {
         <Block label="pfsense.memory" />
         <Block label="pfsense.temp" />
         <Block label="pfsense.wanStatus" />
-        {showWanIP && <Block label="pfsense.wanIP" />}
-        {showDiskUsage && <Block label="pfsense.disk" />}
+        <Block label="pfsense.wanIP" />
+        <Block label="pfsense.wan2Status" />
+        <Block label="pfsense.wan2IP" />
+        <Block label="pfsense.disk" />
       </Container>
     );
   }
 
   const wan = interfaceData.data.filter((l) => l.hwif === widget.wan)[0];
+  const wan2 = widget.wan2 ? interfaceData.data.filter((l) => l.hwif === widget.wan2)[0] : null;
+
+  // Determine which gateway is active based on failover group configuration
+  let wan1GatewayStatus = null;
+  let wan2GatewayStatus = null;
+  let activeWan = null;
+  let wan1IsPrimary = false;
+  let wan2IsPrimary = false;
+  let failoverGroup = null;
+
+  // Only run gateway determination when wan2 is configured (dual WAN mode)
+  if (widget.wan2 && gatewayData?.data && version === 2) {
+    // Find the IPv4 failover group
+    if (gatewayGroupData?.data) {
+      failoverGroup = gatewayGroupData.data.find((g) => g.ipprotocol === "inet");
+    }
+
+    // Match gateway status to interfaces
+    gatewayData.data.forEach((gw) => {
+      if (wan?.ipaddr && gw.srcip === wan.ipaddr) {
+        wan1GatewayStatus = gw;
+      } else if (wan2?.ipaddr && gw.srcip === wan2.ipaddr) {
+        wan2GatewayStatus = gw;
+      }
+    });
+
+    // Determine active gateway based on failover group tiers and gateway status
+    if (failoverGroup && wan1GatewayStatus && wan2GatewayStatus) {
+      // Find which gateway is tier 1 (primary) and tier 2 (backup)
+      const tier1Gateway = failoverGroup.priorities?.find((p) => p.tier === 1);
+      const tier2Gateway = failoverGroup.priorities?.find((p) => p.tier === 2);
+
+      // Match gateway names to determine which WAN is primary in the config
+      wan1IsPrimary = tier1Gateway?.gateway === wan1GatewayStatus.name;
+      wan2IsPrimary = tier1Gateway?.gateway === wan2GatewayStatus.name;
+
+      // In failover mode, the active gateway is:
+      // 1. The tier 1 gateway if it's online
+      // 2. The tier 2 gateway if tier 1 is offline or has issues
+      if (wan1IsPrimary) {
+        // WAN1 is configured as primary
+        if (wan1GatewayStatus.status === "online" && (wan1GatewayStatus.loss || 0) <= 20) {
+          activeWan = "wan1";
+        } else if (wan2GatewayStatus.status === "online") {
+          activeWan = "wan2"; // Failover to backup
+        }
+      } else if (wan2IsPrimary) {
+        // WAN2 is configured as primary
+        if (wan2GatewayStatus.status === "online" && (wan2GatewayStatus.loss || 0) <= 20) {
+          activeWan = "wan2";
+        } else if (wan1GatewayStatus.status === "online") {
+          activeWan = "wan1"; // Failover to backup
+        }
+      }
+    } else if (wan1GatewayStatus && wan2GatewayStatus) {
+      // Fallback: if no failover group, use simple online check
+      const wan1Online = wan1GatewayStatus?.status === "online";
+      const wan2Online = wan2GatewayStatus?.status === "online";
+
+      if (wan1Online && !wan2Online) {
+        activeWan = "wan1";
+      } else if (!wan1Online && wan2Online) {
+        activeWan = "wan2";
+      } else if (wan1Online && wan2Online) {
+        activeWan = "wan1"; // Default to WAN1 if both online
+      }
+    }
+  }
   let memUsage = systemData?.data.mem_usage;
   let diskUsage = systemData.data.disk_usage;
   if (version === 1) {
@@ -60,14 +140,33 @@ export default function Component({ service }) {
         label="pfsense.wanStatus"
         value={
           wan.status === "up" ? (
-            <span className="text-green-500">{t("pfsense.up")}</span>
+            <span className={activeWan === "wan1" ? "text-green-500 font-bold" : "text-green-500"}>
+              {t("pfsense.up")}
+              {widget.wan2 && (wan1IsPrimary ? " (Primary)" : " (Backup)")}
+            </span>
           ) : (
             <span className="text-red-500">{t("pfsense.down")}</span>
           )
         }
       />
-      {showWanIP && <Block label="pfsense.wanIP" value={wan.ipaddr} />}
-      {showDiskUsage && <Block label="pfsense.disk" value={t("common.percent", { value: diskUsage.toFixed(2) })} />}
+      <Block label="pfsense.wanIP" value={wan?.ipaddr} />
+      <Block
+        label="pfsense.wan2Status"
+        value={
+          wan2?.status === "up" ? (
+            <span className={activeWan === "wan2" ? "text-green-500 font-bold" : "text-green-500"}>
+              {t("pfsense.up")}
+              {wan2IsPrimary ? " (Primary)" : " (Backup)"}
+            </span>
+          ) : wan2?.status ? (
+            <span className="text-red-500">{t("pfsense.down")}</span>
+          ) : (
+            "-"
+          )
+        }
+      />
+      <Block label="pfsense.wan2IP" value={wan2?.ipaddr || "-"} />
+      <Block label="pfsense.disk" value={diskUsage ? t("common.percent", { value: diskUsage.toFixed(2) }) : "-"} />
     </Container>
   );
 }

--- a/src/widgets/pfsense/widget.js
+++ b/src/widgets/pfsense/widget.js
@@ -21,6 +21,14 @@ const widget = {
       endpoint: "v2/status/interfaces?limit=0&offset=0",
       validate: ["data"],
     },
+    gatewaysv2: {
+      endpoint: "v2/status/gateways",
+      validate: ["data"],
+    },
+    gatewaygroups: {
+      endpoint: "v2/routing/gateway/groups",
+      validate: ["data"],
+    },
   },
 };
 


### PR DESCRIPTION
- Add support for monitoring secondary WAN interface via 'wan2' parameter
- Display primary/backup status based on gateway group tier configuration
- Show active WAN with bold text indicator
- Automatically detect failover states using pfSense gateway groups API
- Add gateway status monitoring for API v2 configurations
- Update all 46 language translation files with wan2Status and wan2IP fields
- Add wan2 parameter support to service-helpers configuration
- Enhance documentation with dual WAN setup guide and troubleshooting

This feature enables monitoring of dual WAN setups with automatic failover detection, clearly showing which WAN is primary vs backup and which is currently active based on the pfSense gateway group configuration."

<!--
==== STOP ====================
======== STOP ================
============ STOP ============
================ STOP ========
==================== STOP ====

⚠️ Before opening this pull request please review the guidelines in the checklist below.

If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.
-->

## Proposed change

This PR adds dual WAN monitoring support to the pfSense widget, enabling users with failover configurations to monitor both WAN interfaces and see which is currently active.

  ### Features Added
  - Monitor secondary WAN interface via `wan2` parameter
  - Display Primary/Backup labels based on gateway group tier configuration
  - Show currently active WAN with bold text indicator
  - Automatic failover detection using pfSense gateway groups API (v2)
  - Full backward compatibility - existing single WAN configurations work unchanged

  ### Changes Made
  - Added `wan2` parameter support to widget configuration
  - Enhanced component to fetch and display gateway status (API v2 only)
  - Added wan2Status and wan2IP translations to all 46 language files
  - Updated service-helpers.js to pass through wan2 parameter
  - Comprehensive documentation with dual WAN setup guide and troubleshooting

  ### Testing
  - Tested with pfSense 2.7.x using API v2
  - Single WAN configurations continue to work unchanged
  - Dual WAN correctly shows Primary/Backup labels
  - Active WAN detection works with failover groups
  - All language translations updated

<img width="1535" height="294" alt="Screenshot 2025-09-03 at 21 42 20" src="https://github.com/user-attachments/assets/38cc3577-f588-413d-8432-d4a8664e0143" />

  ### Configuration Example
  ```yaml
  widget:
    type: pfsense
    url: https://pfsense.host:port
    headers:
      X-API-Key: your-api-key
    wan: igc0   # Primary WAN interface
    wan2: igc2  # Backup WAN interface
    version: 2  # Required for dual WAN
    fields: ["load", "memory", "wanStatus", "wanIP", "wan2Status", "wan2IP"]
```
Closes # (issue)

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
