### PR TITLE
Update traefik.md for note a potential API Error solution

### DIFF
--- a/docs/widgets/services/traefik.md
+++ b/docs/widgets/services/traefik.md
@@ -8,6 +8,8 @@ Learn more about [Traefik](https://github.com/traefik/traefik).
 No extra configuration is required.
 If your traefik install requires authentication, include the username and password used to login to the web interface.
 
+If you get an API Error then you may need to set `--api.insecure=false` to support this: <https://doc.traefik.io/traefik/master/operations/api/#insecure>
+
 Allowed fields: `["routers", "services", "middleware"]`.
 
 ```yaml


### PR DESCRIPTION
## Proposed change

Add note about potentially needing `--api.insecure=true` in the traefik config to allow the Traefik widget API access. Included a link to the official Traefik docs for how to do this and only quoted the CLI change for brevity.

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [x] Documentation only
- [ ] Other (please explain)
