### PR TITLE
Add multiple optional fields to Tailscale widget

### DIFF
--- a/docs/widgets/services/tailscale.md
+++ b/docs/widgets/services/tailscale.md
@@ -9,7 +9,9 @@ You will need to generate an API access token from the [keys page](https://login
 
 To find your device ID, go to the [machine overview page](https://login.tailscale.com/admin/machines) and select your machine. In the "Machine Details" section, copy your `ID`. It will end with `CNTRL`.
 
-Allowed fields: `["address", "last_seen", "expires"]`.
+Allowed fields: `["address", "last_seen", "expires", "user", "name", "hostname", "client_version", "update_available", "os", "created", "last_seen", "expires", "authorized", "is_external", "tags"]`.
+
+See [Tailscale's API reference](https://tailscale.com/api#tag/devices/get/device/{deviceId}) for more information on each field.
 
 ```yaml
 widget:

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -324,6 +324,19 @@
     },
     "tailscale": {
         "address": "Address",
+        "user": "User",
+        "name": "Name",
+        "hostname": "Hostname",
+        "client_version": "Client Version",
+        "update_available": "Update Available",
+        "os": "OS",
+        "created": "Created",
+        "device": "Device",
+        "status": "Status",
+        "none": "None",
+        "authorized": "Authorized",
+        "tags": "Tags",
+        "is_external": "Is External",
         "expires": "Expires",
         "never": "Never",
         "last_seen": "Last Seen",
@@ -334,7 +347,9 @@
         "hours": "{{number}}h",
         "minutes": "{{number}}m",
         "seconds": "{{number}}s",
-        "ago": "{{value}} Ago"
+        "ago": "{{value}} Ago",
+        "yes": "Yes",
+        "no": "No"
     },
     "technitium": {
         "totalQueries": "Queries",

--- a/src/widgets/tailscale/component.jsx
+++ b/src/widgets/tailscale/component.jsx
@@ -8,7 +8,7 @@ export default function Component({ service }) {
   const { t } = useTranslation();
 
   const { widget } = service;
-  
+
   const { data: statsData, error: statsError } = useWidgetAPI(widget, "device");
 
   const MAX_ALLOWED_FIELDS = 4;
@@ -85,7 +85,7 @@ export default function Component({ service }) {
   return (
     <Container service={service}>
       <Block label="tailscale.address" value={address} />
-      <Block label="tailscale.user" value={user} />    
+      <Block label="tailscale.user" value={user} />
       <Block label="tailscale.hostname" value={hostname} />
       <Block label="tailscale.name" value={name} />
       <Block label="tailscale.last_seen" value={getLastSeen()} />

--- a/src/widgets/tailscale/component.jsx
+++ b/src/widgets/tailscale/component.jsx
@@ -8,8 +8,18 @@ export default function Component({ service }) {
   const { t } = useTranslation();
 
   const { widget } = service;
-
+  
   const { data: statsData, error: statsError } = useWidgetAPI(widget, "device");
+
+  const MAX_ALLOWED_FIELDS = 4;
+
+  if (!widget.fields?.length) {
+    widget.fields = ["address", "last_seen", "expires"];
+  }
+
+  if (widget.fields?.length > MAX_ALLOWED_FIELDS) {
+    widget.fields = widget.fields.slice(0, MAX_ALLOWED_FIELDS);
+  }
 
   if (statsError || statsData?.message) {
     return <Container service={service} error={statsError ?? statsData} />;
@@ -27,9 +37,19 @@ export default function Component({ service }) {
 
   const {
     addresses: [address],
+    user,
+    name,
+    hostname,
+    clientVersion,
+    updateAvailable,
+    os,
+    created,
     keyExpiryDisabled,
     lastSeen,
     expires,
+    authorized,
+    isExternal,
+    tags,
   } = statsData;
 
   const now = new Date();
@@ -65,8 +85,18 @@ export default function Component({ service }) {
   return (
     <Container service={service}>
       <Block label="tailscale.address" value={address} />
+      <Block label="tailscale.user" value={user} />    
+      <Block label="tailscale.hostname" value={hostname} />
+      <Block label="tailscale.name" value={name} />
       <Block label="tailscale.last_seen" value={getLastSeen()} />
       <Block label="tailscale.expires" value={getExpiry()} />
+      <Block label="tailscale.client_version" value={clientVersion} />
+      <Block label="tailscale.os" value={os} />
+      <Block label="tailscale.created" value={t("common.relativeDate", { value: created })} />
+      <Block label="tailscale.authorized" value={authorized ? t("tailscale.yes") : t("tailscale.no")} />
+      <Block label="tailscale.is_external" value={isExternal ? t("tailscale.yes") : t("tailscale.no")} />
+      <Block label="tailscale.update_available" value={updateAvailable ? t("tailscale.yes") : t("tailscale.no")} />
+      <Block label="tailscale.tags" value={tags?.length > 0 ? tags.join(", ") : t("tailscale.none")} />
     </Container>
   );
 }


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

Added some more fields to the Tailscale widget, coming directly from the [Tailscale API](https://tailscale.com/api#tag/devices/get/device/{deviceId})

* user - The user who registered the Tailscale device.
* hostname
* name - The MagicDNS name of the device.
* client_version - The version of the Tailscale client.
* os
* created - Relative date.
* authorized - If the device has been authorized to join the tailnet.
* is_external - If the device is not a member of, but has been shared into, the tailnet.
* update_available - If an update is available for the Tailscale client.
* tags - ACL tags for the device.

The fields default to the original set (address, last_seen, expires) if not present.
The number of fields is limited to 4.

(shoutout to claha for [this PR](https://github.com/gethomepage/homepage/pull/2109), which I only discovered after finishing mine)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.