### PR TITLE
feat: Add mobile Quick Launch button and URL triggers

### DIFF
--- a/docs/configs/settings.md
+++ b/docs/configs/settings.md
@@ -469,7 +469,7 @@ The mobile Quick Launch button can be customized or disabled:
 ```yaml
 quicklaunch:
   mobileButton:
-    enabled: true  # false to disable the button entirely
+    enabled: true # false to disable the button entirely
     position: left # left, right, bottom-left, bottom-right, top-left, top-right
 ```
 
@@ -478,15 +478,18 @@ quicklaunch:
 You can trigger Quick Launch via URL parameters or hash fragments. This is useful for creating bookmarks or links that directly open the search interface:
 
 **URL Parameters:**
+
 - `?quicklaunch` or `?search` - Opens Quick Launch
 - `?search&q=term` - Opens Quick Launch with pre-filled search term
 - `?quicklaunch&query=term` - Opens Quick Launch with pre-filled search term
 
 **Hash Fragments:**
+
 - `#quicklaunch` - Opens Quick Launch
 - `#search` - Opens Quick Launch
 
 **Examples:**
+
 - `https://your-homepage.com/?quicklaunch` - Opens Quick Launch
 - `https://your-homepage.com/?search&q=docker` - Opens Quick Launch searching for "docker"
 - `https://your-homepage.com/#quicklaunch` - Opens Quick Launch via hash

--- a/src/components/quicklaunch-button.jsx
+++ b/src/components/quicklaunch-button.jsx
@@ -1,5 +1,5 @@
-import { useContext } from "react";
 import { useTranslation } from "next-i18next";
+import { useContext } from "react";
 import { FiSearch } from "react-icons/fi";
 import { SettingsContext } from "utils/contexts/settings";
 
@@ -24,7 +24,7 @@ export default function QuickLaunchButton({ onClick }) {
     "bottom-left": "bottom-6 left-6",
     "bottom-right": "bottom-6 right-6",
     "top-left": "top-6 left-6",
-    "top-right": "top-6 right-6"
+    "top-right": "top-6 right-6",
   };
 
   return (

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -243,31 +243,30 @@ function Home({ initialSettings }) {
       const searchParams = url.searchParams;
 
       // Check for quicklaunch trigger patterns
-      if (searchParams.has('quicklaunch') ||
-          searchParams.has('search') ||
-          url.hash === '#quicklaunch' ||
-          url.hash === '#search') {
-
+      if (
+        searchParams.has("quicklaunch") ||
+        searchParams.has("search") ||
+        url.hash === "#quicklaunch" ||
+        url.hash === "#search"
+      ) {
         // Get initial search string from URL if provided
-        const initialSearch = searchParams.get('q') ||
-                            searchParams.get('query') ||
-                            searchParams.get('search') || '';
+        const initialSearch = searchParams.get("q") || searchParams.get("query") || searchParams.get("search") || "";
 
         setSearchString(initialSearch);
         setSearching(true);
 
         // Clean up URL to remove trigger parameters
         const cleanUrl = new URL(window.location.href);
-        cleanUrl.searchParams.delete('quicklaunch');
-        cleanUrl.searchParams.delete('search');
-        cleanUrl.searchParams.delete('q');
-        cleanUrl.searchParams.delete('query');
-        if (cleanUrl.hash === '#quicklaunch' || cleanUrl.hash === '#search') {
-          cleanUrl.hash = '';
+        cleanUrl.searchParams.delete("quicklaunch");
+        cleanUrl.searchParams.delete("search");
+        cleanUrl.searchParams.delete("q");
+        cleanUrl.searchParams.delete("query");
+        if (cleanUrl.hash === "#quicklaunch" || cleanUrl.hash === "#search") {
+          cleanUrl.hash = "";
         }
 
         // Update URL without reloading page
-        window.history.replaceState({}, '', cleanUrl.toString());
+        window.history.replaceState({}, "", cleanUrl.toString());
       }
     };
 
@@ -275,10 +274,10 @@ function Home({ initialSettings }) {
     handleUrlQuickLaunch();
 
     // Listen for hash changes
-    window.addEventListener('hashchange', handleUrlQuickLaunch);
+    window.addEventListener("hashchange", handleUrlQuickLaunch);
 
     return () => {
-      window.removeEventListener('hashchange', handleUrlQuickLaunch);
+      window.removeEventListener("hashchange", handleUrlQuickLaunch);
     };
   }, [setSearchString, setSearching]);
 


### PR DESCRIPTION
## Summary
Adds mobile accessibility to Quick Launch feature through a configurable floating button and URL-based triggers.

## Changes
- **Mobile Quick Launch Button**: Configurable floating button for mobile devices
- **Default Position**: Bottom-left corner (user configurable)
- **Position Options**: 6 positioning choices (left, right, bottom-left, bottom-right, top-left, top-right)
- **Disable Option**: Can be completely disabled via settings
- **URL Triggers**: Support for ?quicklaunch, #search, and pre-filled search terms
- **Backward Compatible**: Existing keyboard shortcuts remain unchanged

## Configuration Examples
```yaml
quicklaunch:
  mobileButton:
    enabled: true  # false to disable
    position: left # positioning options
```

## URL Examples
- `?quicklaunch` - Opens Quick Launch
- `?search&q=docker` - Opens Quick Launch searching for "docker"
- `#quicklaunch` - Opens Quick Launch via hash

## Test plan
- [x] Button appears on mobile devices (bottom-left by default)
- [x] Button can be positioned in different corners
- [x] Button can be disabled entirely
- [x] URL triggers work for opening Quick Launch
- [x] Pre-filled search terms work via URL parameters
- [x] Existing keyboard functionality unchanged
- [x] ESLint passes
- [x] Build succeeds

Fixes: Mobile users had no way to access Quick Launch feature

🤖 Generated with [Claude Code](https://claude.ai/code)