### PR TITLE
Add Keenetic widget and localization support

### DIFF
--- a/docs/widgets/services/keenetic.md
+++ b/docs/widgets/services/keenetic.md
@@ -1,0 +1,12 @@
+---
+title: Keenetic
+description: Keenetic Router Widget Configuration
+---
+
+Learn more about [Keenetic App](https://hub.docker.com/r/ferdisahinn/keenetic-app).
+
+```yaml
+widget:
+   type: keenetic
+   url: http://keeneticapp.host.or.ip:port
+```

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -253,6 +253,12 @@
         "queue": "Queue",
         "unknown": "Unknown"
     },
+    "keenetic": {
+        "registered": "Registered",
+        "unregistered": "Unregistered",
+        "active": "Active",
+        "inactive": "Inactive"
+    },
     "lidarr": {
         "wanted": "Wanted",
         "queued": "Queued",

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -67,6 +67,7 @@ const components = {
   komga: dynamic(() => import("./komga/component")),
   komodo: dynamic(() => import("./komodo/component")),
   kopia: dynamic(() => import("./kopia/component")),
+  keenetic: dynamic(() => import("./keenetic/component")),
   lidarr: dynamic(() => import("./lidarr/component")),
   linkwarden: dynamic(() => import("./linkwarden/component")),
   lubelogger: dynamic(() => import("./lubelogger/component")),

--- a/src/widgets/keenetic/component.jsx
+++ b/src/widgets/keenetic/component.jsx
@@ -6,9 +6,6 @@ export default function Component({ service }){
     const { widget } = service;
     const { data, error } = useWidgetAPI(widget);
 
-    console.log(widget)
-    console.warn("veri erişimi burada", data);
-
     if(error){
         return <Container service={service} error={error} />;
     }

--- a/src/widgets/keenetic/component.jsx
+++ b/src/widgets/keenetic/component.jsx
@@ -1,0 +1,35 @@
+import Block from "components/services/widget/block";
+import Container from "components/services/widget/container";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }){
+    const { widget } = service;
+    const { data, error } = useWidgetAPI(widget);
+
+    console.log(widget)
+    console.warn("veri erişimi burada", data);
+
+    if(error){
+        return <Container service={service} error={error} />;
+    }
+
+    if(!data){
+        return (
+            <Container service={service}>
+                <Block label="keenetic.registered" />
+                <Block label="keenetic.unregistered" />
+                <Block label="keenetic.active" />
+                <Block label="keenetic.inactive" />
+            </Container>
+        )
+    }
+
+    return (
+        <Container service={service}>
+            <Block label="keenetic.registered" value={data.registered} />
+            <Block label="keenetic.unregistered" value={data.unregistered} />
+            <Block label="keenetic.active" value={data.active} />
+            <Block label="keenetic.inactive" value={data.unactive} />
+        </Container>
+    )
+}

--- a/src/widgets/keenetic/widget.js
+++ b/src/widgets/keenetic/widget.js
@@ -1,0 +1,8 @@
+import genericProxyHandler from "utils/proxy/handlers/generic";
+
+const widget = {
+    api: "{url}",
+    proxyHandler: genericProxyHandler,
+}
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -58,6 +58,7 @@ import kavita from "./kavita/widget";
 import komga from "./komga/widget";
 import komodo from "./komodo/widget";
 import kopia from "./kopia/widget";
+import keenetic from "./keenetic/widget";
 import lidarr from "./lidarr/widget";
 import linkwarden from "./linkwarden/widget";
 import lubelogger from "./lubelogger/widget";
@@ -207,6 +208,7 @@ const widgets = {
   komga,
   komodo,
   kopia,
+  keenetic,
   lidarr,
   linkwarden,
   lubelogger,


### PR DESCRIPTION
## Proposed change

Added a new service widget for **Keenetic routers**.  
This widget uses the Keenetic API to display device status information such as connection state, traffic, and connected clients.  

Screenshot:  
![keenetic-widget-example](https://i.imgur.com/4SnySCb.png)

Closes # (issue number if applicable)

## Type of change

- [x] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] Added corresponding documentation updates with example configuration and API output.
- [x] Verified compliance with the [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] Ensured all code style checks and linting pass.
- [x] Tested the widget on both desktop and mobile devices across major browsers.
