### PR TITLE
Change: adjust MySpeed blocks order

### DIFF
--- a/src/widgets/myspeed/component.jsx
+++ b/src/widgets/myspeed/component.jsx
@@ -34,14 +34,6 @@ export default function Component({ service }) {
   return (
     <Container service={service}>
       <Block
-        label="myspeed.ping"
-        value={t("common.ms", {
-          value: data[0].ping,
-          style: "unit",
-          unit: "millisecond",
-        })}
-      />
-      <Block
         label="myspeed.download"
         value={t("common.bitrate", {
           value: data[0].download * 1000 * 1000,
@@ -53,6 +45,14 @@ export default function Component({ service }) {
         value={t("common.bitrate", {
           value: data[0].upload * 1000 * 1000,
           decimals: 2,
+        })}
+      />
+      <Block
+        label="myspeed.ping"
+        value={t("common.ms", {
+          value: data[0].ping,
+          style: "unit",
+          unit: "millisecond",
         })}
       />
     </Container>


### PR DESCRIPTION

## Proposed change

Change the order of the fields in MySpeed widget so that they match the ones in speedtest-tracker one

`/src/widgets/speedtest/component.jsx` goes download, upload and ping
`/src/widgets/myspeed/component.jsx` goes ping, download and upload.

This change changes the order in myspeed so that both follow the same order.


Before: 
<img width="591" height="254" alt="image" src="https://github.com/user-attachments/assets/737a7e48-b2a0-4904-929d-87525daac519" />
After:
<img width="591" height="260" alt="image" src="https://github.com/user-attachments/assets/bf62af39-99c5-49a0-8c27-a6fa40140bc0" />


I have not opened an issue, cause the change was trivial to make.
But this actually goes with the widget guidelines about styling, making both use the same format.


## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
