### PR TITLE
Unifi Widget: Allow both LAN and WLAN blocks to display

### DIFF
--- a/src/widgets/unifi/component.jsx
+++ b/src/widgets/unifi/component.jsx
@@ -62,15 +62,11 @@ export default function Component({ service }) {
       {wan.show && <Block label="unifi.wan" value={wan.status === "ok" ? t("unifi.up") : t("unifi.down")} />}
 
       {lan.show && <Block label="unifi.lan_users" value={t("common.number", { value: lan.num_user })} />}
-      {lan.show && (
-        <Block label="unifi.lan_devices" value={t("common.number", { value: lan.num_adopted })} />
-      )}
+      {lan.show && <Block label="unifi.lan_devices" value={t("common.number", { value: lan.num_adopted })} />}
       {lan.show && <Block label="unifi.lan" value={lan.up ? t("unifi.up") : t("unifi.down")} />}
 
       {wlan.show && <Block label="unifi.wlan_users" value={t("common.number", { value: wlan.num_user })} />}
-      {wlan.show && (
-        <Block label="unifi.wlan_devices" value={t("common.number", { value: wlan.num_adopted })} />
-      )}
+      {wlan.show && <Block label="unifi.wlan_devices" value={t("common.number", { value: wlan.num_adopted })} />}
       {wlan.show && <Block label="unifi.wlan" value={wlan.up ? t("unifi.up") : t("unifi.down")} />}
     </Container>
   );


### PR DESCRIPTION

## Proposed change

Before this change some Unifi LAN stats would not show if WLAN was showing, and some WLAN stats would not show if LAN stats were showing.

This change allows both WLAN and LAN stats to display, regardless of the status of the other


<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
