### PR TITLE
Performance: emby widget prevent sessions query if now playing disabled

### DIFF
--- a/src/widgets/emby/component.jsx
+++ b/src/widgets/emby/component.jsx
@@ -211,7 +211,7 @@ export default function Component({ service }) {
     data: sessionsData,
     error: sessionsError,
     mutate: sessionMutate,
-  } = useWidgetAPI(widget, enableNowPlaying ? "Sessions" : undefined, {
+  } = useWidgetAPI(widget, enableNowPlaying ? "Sessions" : "", {
     refreshInterval: enableNowPlaying ? 5000 : undefined,
   });
 


### PR DESCRIPTION
## Proposed change

Implemented check for enableNowPlaying in emby widget to avoid unnecessary sessions api calls if the feature is disabled.

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes. (Not applicable here)
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
