### PR TITLE
Fix Authentik widget API endpoints for compatibility with Authentik 2025.10.0

### DIFF
--- a/src/widgets/authentik/component.jsx
+++ b/src/widgets/authentik/component.jsx
@@ -11,11 +11,9 @@ export default function Component({ service }) {
 
   const { data: usersData, error: usersError } = useWidgetAPI(widget, "users");
 
-  const loginsEndpoint = widget.version === 2 ? "loginv2" : "login";
-  const { data: loginsData, error: loginsError } = useWidgetAPI(widget, loginsEndpoint);
+  const { data: loginsData, error: loginsError } = useWidgetAPI(widget, "login");
 
-  const failedLoginsEndpoint = widget.version === 2 ? "login_failedv2" : "login_failed";
-  const { data: failedLoginsData, error: failedLoginsError } = useWidgetAPI(widget, failedLoginsEndpoint);
+  const { data: failedLoginsData, error: failedLoginsError } = useWidgetAPI(widget, "login_failed");
 
   if (usersError || loginsError || failedLoginsError) {
     const finalError = usersError ?? loginsError ?? failedLoginsError;
@@ -32,25 +30,9 @@ export default function Component({ service }) {
     );
   }
 
-  let loginsLast24H;
-  let failedLoginsLast24H;
-  switch (widget.version) {
-    case 1:
-      const yesterday = new Date(Date.now()).setHours(-24);
-      loginsLast24H = loginsData.reduce(
-        (total, current) => (current.x_cord >= yesterday ? total + current.y_cord : total),
-        0,
-      );
-      failedLoginsLast24H = failedLoginsData.reduce(
-        (total, current) => (current.x_cord >= yesterday ? total + current.y_cord : total),
-        0,
-      );
-      break;
-    case 2:
-      loginsLast24H = loginsData[0]?.count || 0;
-      failedLoginsLast24H = failedLoginsData[0]?.count || 0;
-      break;
-  }
+  // Sum all login counts from the last 24 hours
+  const loginsLast24H = loginsData.reduce((total, current) => total + (current.count || 0), 0);
+  const failedLoginsLast24H = failedLoginsData.reduce((total, current) => total + (current.count || 0), 0);
 
   return (
     <Container service={service}>

--- a/src/widgets/authentik/widget.js
+++ b/src/widgets/authentik/widget.js
@@ -9,16 +9,16 @@ const widget = {
       endpoint: "core/users/?page_size=1",
     },
     login: {
-      endpoint: "events/events/per_month/?action=login",
+      endpoint: "events/events/volume/?action=login&history_days=1",
     },
     loginv2: {
-      endpoint: "events/events/volume/?action=login&&history_days=1",
+      endpoint: "events/events/volume/?action=login&history_days=1",
     },
     login_failed: {
-      endpoint: "events/events/per_month/?action=login_failed",
+      endpoint: "events/events/volume/?action=login_failed&history_days=1",
     },
     login_failedv2: {
-      endpoint: "events/events/volume/?action=login_failed&&history_days=1",
+      endpoint: "events/events/volume/?action=login_failed&history_days=1",
     },
   },
 };


### PR DESCRIPTION
## Summary
The Authentik widget was using deprecated `/per_month/` endpoints that no longer exist in recent Authentik versions (tested with 2025.10.0), causing 404 errors and preventing login statistics from displaying (showing "NaN" instead).

## Changes
- Updated all endpoint mappings from deprecated `/events/events/per_month/` to current `/events/events/volume/` API
- Fixed query parameter syntax (changed `&&` to `&` in v2 endpoints)
- Simplified component logic to use consistent data format across versions
- Removed version-specific data processing since all versions now use the same endpoint format

## Testing
- Tested with Authentik 2025.10.0
- Confirmed the `/api/v3/events/events/volume/` endpoint works correctly
- Widget now displays login and failed login counts properly

## Fixes
Resolves the issue where the widget displayed "NaN" for login counts and generated HTTP 404 errors in the logs when calling the non-existent `/per_month/` endpoint.

## Related
This issue was discussed in the community and affects users running recent versions of Authentik where the `/per_month/` API endpoint has been removed or changed.