### PR TITLE
Chore: change MySpeed blocks layout order

### DIFF
--- a/src/widgets/myspeed/component.jsx
+++ b/src/widgets/myspeed/component.jsx
@@ -24,9 +24,9 @@ export default function Component({ service }) {
   if (!data || (data && data.length === 0)) {
     return (
       <Container service={service}>
-        <Block label="myspeed.ping" />
         <Block label="myspeed.download" />
         <Block label="myspeed.upload" />
+        <Block label="myspeed.ping" />
       </Container>
     );
   }


### PR DESCRIPTION

## Proposed change

I forgot to change this in https://github.com/gethomepage/homepage/pull/5881

This change changes the order in Myspeed so that both follow the same order.
This PR addresses the order of the placeholder fields while data is still loading

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
