### PR TITLE
Enhancement: treat 'error' as custom api field when mapped

### DIFF
--- a/src/widgets/customapi/component.jsx
+++ b/src/widgets/customapi/component.jsx
@@ -166,7 +166,11 @@ export default function Component({ service }) {
     refreshInterval: Math.max(1000, refreshInterval),
   });
 
-  if (customError) {
+  // if mappings includes an error field and the data contains an error field then show data even if there is an error
+  const mappingsIncludesError = Array.isArray(mappings) && mappings.find((mapping) => mapping.field === "error");
+  const errorIsData = customData && typeof customData === "object" && "error" in customData;
+
+  if (customError && !(mappingsIncludesError && errorIsData)) {
     return <Container service={service} error={customError} />;
   }
 


### PR DESCRIPTION
<!--
==== STOP ====================
======== STOP ================
============ STOP ============
================ STOP ========
==================== STOP ====

⚠️ Before opening this pull request please review the guidelines in the checklist below.

If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.
-->

## Proposed change

I.e. if you specify 'error' as a field, we dont treat it as an error

<img width="451" height="122" alt="Screenshot 2025-11-21 at 10 13 20 AM" src="https://github.com/user-attachments/assets/5bb7b03a-ab72-44db-a2cb-3ebef6d144ca" />


Closes #5995

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
