### PR TITLE
Add information for custom widgets in docker images

### DIFF
--- a/docs/widgets/authoring/tutorial.md
+++ b/docs/widgets/authoring/tutorial.md
@@ -4,6 +4,7 @@ description: Follow along with this guide to learn how to create a custom widget
 ---
 
 In this guide, we'll walk through the process of creating a custom widget for Homepage. We'll cover the basic structure of a widget, how to use translations, and how to fetch data from an API. By the end of this guide, you'll have a solid understanding of how to build your own custom widget.
+Note that if you want to use a custom widget in a docker setup, you will have to build your own image since adding a custom widget requires editing some files that are minified during the image creation process. If you don't want to do this, maybe using the customapi widget might work for you.
 
 **Prerequisites:**
 


### PR DESCRIPTION
## Proposed change

Just adding some documentation to explain how custom widgets cannot be added to the official docker image (from what I understand), and maybe what people want is the customapi.

I just spent some time understanding how the custom widgets work but it wasn't really what I needed in the end, so this might help future people get that faster than I did.

Feel free to reject if you don't think this is a useful addition to the documentation.

Closes # (issue)

N/A

## Type of change

Documentation edit

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [x ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ x] If applicable, I have added corresponding documentation changes.
- [ x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/more/development/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/more/development/#service-widget-guidelines).
- [x ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/more/development/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/more/development/#code-linting).
- [x ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x ] In the description above I have disclosed the use of AI tools in the coding of this PR.
