### PR TITLE
fix(resources): use direct networkStats(iface) call for named interfaces in Docker

### DIFF
--- a/docs/widgets/info/resources.md
+++ b/docs/widgets/info/resources.md
@@ -15,6 +15,15 @@ _Note: unfortunately, the package used for getting CPU temp ([systeminformation]
 
 **Any disk you wish to access must be mounted to your container as a volume.**
 
+**To monitor a named host network interface** (e.g. `network: enp6s18`), the host sysfs must be accessible inside the container. Add the following volume mount to your Docker Compose service:
+
+```yaml
+volumes:
+  - /sys/class/net:/sys/class/net:ro
+```
+
+Without this mount, the widget can only report statistics for the container's own network interfaces, not the host machine's physical NICs. Using `network: true` (which monitors the container's default interface) works without any additional mounts.
+
 ```yaml
 - resources:
     cpu: true

--- a/src/__tests__/pages/api/widgets/resources.test.js
+++ b/src/__tests__/pages/api/widgets/resources.test.js
@@ -90,7 +90,8 @@ describe("pages/api/widgets/resources", () => {
   });
 
   it("returns 404 when requested network interface does not exist", async () => {
-    si.networkStats.mockResolvedValueOnce([{ iface: "en0" }]);
+    // networkStats(interfaceName) returns [] when the interface cannot be found
+    si.networkStats.mockResolvedValueOnce([]);
 
     const req = { query: { type: "network", interfaceName: "missing" } };
     const res = createMockRes();
@@ -99,6 +100,22 @@ describe("pages/api/widgets/resources", () => {
 
     expect(res.statusCode).toBe(404);
     expect(res.body).toEqual({ error: "Interface not found" });
+  });
+
+  it("returns network stats for a named host interface directly (Docker namespace fix)", async () => {
+    // networkStats(interfaceName) is called directly, bypassing os.networkInterfaces()
+    // enumeration which is network-namespace-aware and cannot see host NICs from a container.
+    si.networkStats.mockResolvedValueOnce([{ iface: "enp6s18", rx_bytes: 1000, tx_bytes: 500 }]);
+
+    const req = { query: { type: "network", interfaceName: "enp6s18" } };
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(si.networkStats).toHaveBeenCalledWith("enp6s18");
+    expect(res.statusCode).toBe(200);
+    expect(res.body.interface).toBe("enp6s18");
+    expect(res.body.network).toEqual({ iface: "enp6s18", rx_bytes: 1000, tx_bytes: 500 });
   });
 
   it("returns default interface network stats", async () => {

--- a/src/pages/api/widgets/resources.js
+++ b/src/pages/api/widgets/resources.js
@@ -59,17 +59,31 @@ export default async function handler(req, res) {
   }
 
   if (type === "network") {
-    let networkData = await si.networkStats("*");
+    let networkData;
     let interfaceDefault;
-    logger.debug("networkData:", JSON.stringify(networkData));
     if (interfaceName && interfaceName !== "default") {
-      networkData = networkData.filter((network) => network.iface === interfaceName).at(0);
+      // Call networkStats(interfaceName) directly instead of networkStats("*") + filter.
+      //
+      // When Homepage runs inside a Docker container, networkStats("*") enumerates
+      // interfaces via os.networkInterfaces(), which is network-namespace-aware and
+      // only returns the container's own interfaces (e.g. eth0, lo). This causes any
+      // named host NIC (e.g. enp6s18, eth0 on the host) to fail the filter and return
+      // a 404, even when /sys is correctly mounted.
+      //
+      // Calling networkStats(interfaceName) directly bypasses the enumeration step and
+      // reads statistics from /sys/class/net/<iface>/statistics/ via sysfs, which
+      // works correctly when /sys (or /sys/class/net) is bind-mounted from the host.
+      const result = await si.networkStats(interfaceName);
+      logger.debug("networkData:", JSON.stringify(result));
+      networkData = Array.isArray(result) && result.length > 0 ? result[0] : null;
       if (!networkData) {
         return res.status(404).json({
           error: "Interface not found",
         });
       }
     } else {
+      networkData = await si.networkStats("*");
+      logger.debug("networkData:", JSON.stringify(networkData));
       interfaceDefault = await si.networkInterfaceDefault();
       networkData = networkData.filter((network) => network.iface === interfaceDefault).at(0);
       if (!networkData) {


### PR DESCRIPTION
## Description

When Homepage runs inside a Docker container, the network widget fails to return stats for a named host interface (e.g. `enp6s18`), returning a 404 even when `/sys` is correctly mounted.

## Root Cause

`networkStats("*")` enumerates interfaces via `os.networkInterfaces()`, which is Docker network-namespace-aware. Inside a container, this only returns container interfaces (`eth0`, `lo`) — never the host NIC. The subsequent `.filter()` call finds no match and returns 404.

This is a different failure mode from the one fixed in #6102. That PR correctly added `"*"` to enumerate all interfaces, but the enumeration itself is broken in Docker for host NICs.

## Fix

When an explicit `interfaceName` is provided, call `si.networkStats(interfaceName)`  directly instead of `networkStats("*")` + filter. This reads from `/sys/class/net/<iface>/statistics/` via sysfs, bypassing namespace enumeration entirely and correctly returning host NIC stats.

The default interface path (`network: true`) is unchanged.

## Changes

- `src/pages/api/widgets/resources.js` — restructured named-interface path
- `src/__tests__/pages/api/widgets/resources.test.js` — updated existing test, added new test for Docker namespace fix
- `docs/widgets/info/resources.md` — added callout documenting required `/sys/class/net:/sys/class/net:ro` volume mount for named host NICs

## Testing

Tested on Homepage v1.10.1 running in Docker with host interface `enp6s18` and `/sys:/sys:ro` mounted. Widget correctly returns live rx/tx stats after this fix.

## AI Assistance

This fix was developed with AI assistance (Claude). The bug was discovered and diagnosed while debugging my own Homepage deployment, the root cause analysis and fix were developed collaboratively, and the tests and documentation were written with AI help. The fix has been verified working on my own system.