### PR TITLE
Chore: add security context, liveness probe and config mount to k8s deployment example

### DIFF
--- a/docs/installation/k8s.md
+++ b/docs/installation/k8s.md
@@ -233,7 +233,6 @@ spec:
             runAsGroup: 1000
             seccompProfile:
               type: RuntimeDefault
-            # readOnlyRootFilesystem: true # Maximum security but throws a warning
           env:
             - name: MY_POD_IP
               valueFrom:

--- a/docs/installation/k8s.md
+++ b/docs/installation/k8s.md
@@ -223,13 +223,35 @@ spec:
         - name: homepage
           image: "ghcr.io/gethomepage/homepage:latest"
           imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+            # readOnlyRootFilesystem: true # Maximum security but throws a warning
           env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
             - name: HOMEPAGE_ALLOWED_HOSTS
-              value: gethomepage.dev # required, may need port. See gethomepage.dev/installation/#homepage_allowed_hosts
+              value: "$(MY_POD_IP):3000,gethomepage.dev" # required, may need port. See gethomepage.dev/installation/#homepage_allowed_hosts
+              # Do not remove the value before the comma, required for the k8s probe to work !
           ports:
             - name: http
               containerPort: 3000
               protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /api/healthcheck
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 15
           volumeMounts:
             - mountPath: /app/config/custom.js
               name: homepage-config
@@ -257,12 +279,18 @@ spec:
               subPath: widgets.yaml
             - mountPath: /app/config/logs
               name: logs
+            - mountPath: /app/config
+              name: config
       volumes:
         - name: homepage-config
           configMap:
             name: homepage
         - name: logs
-          emptyDir: {}
+          emptyDir:
+            {}
+        - name: config
+          emptyDir:
+            {}
 ```
 
 #### Ingress

--- a/docs/installation/k8s.md
+++ b/docs/installation/k8s.md
@@ -239,8 +239,7 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
             - name: HOMEPAGE_ALLOWED_HOSTS
-              value: "$(MY_POD_IP):3000,gethomepage.dev" # required, may need port. See gethomepage.dev/installation/#homepage_allowed_hosts
-              # Do not remove the value before the comma, required for the k8s probe to work !
+              value: "$(MY_POD_IP):3000,gethomepage.dev" # See gethomepage.dev/installation/#homepage_allowed_hosts . Value before the comma is required for the k8s probe
           ports:
             - name: http
               containerPort: 3000

--- a/docs/installation/k8s.md
+++ b/docs/installation/k8s.md
@@ -284,11 +284,7 @@ spec:
           configMap:
             name: homepage
         - name: logs
-          emptyDir:
-            {}
-        - name: config
-          emptyDir:
-            {}
+          emptyDir: {}
 ```
 
 #### Ingress

--- a/docs/installation/k8s.md
+++ b/docs/installation/k8s.md
@@ -277,8 +277,6 @@ spec:
               subPath: widgets.yaml
             - mountPath: /app/config/logs
               name: logs
-            - mountPath: /app/config
-              name: config
       volumes:
         - name: homepage-config
           configMap:


### PR DESCRIPTION

## Proposed change

Hi ! I updated the deployment file for k8s with : 

- A liveness probe that lets k8s know if the container is running fine, like a Docker health check
- Security contexts to match [restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted)

I tested everything, and it works on my K8s Talos cluster.

The only thing I want to discuss is this : 

`# readOnlyRootFilesystem: true # Maximum security but throws a warning`

When you enable that, the / fs of the container is readOnly, this is why I mount the config folder in a emptyDIr that is writable so homepage works. But It shows : 

```
[2026-02-26T01:14:34.915Z] warn: Failed to update prerender cache for /en [Error: EROFS: read-only file system, open '/app/.next/server/pages/en.html'] {
  errno: -30,
  code: 'EROFS',
  syscall: 'open',
  path: '/app/.next/server/pages/en.html'
}
```

But everything works fine...

If I mount an emptydir in /app/.next/server/pages/, everything is broken... So I stopped here. Can we make the cache dir in another place ? Like /tmp or /var ?? I left that option commented to not disturb anyone by default.



## Type of change

Better k8s deployment file in the install documentation

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [x] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [ ] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] In the description above I have disclosed the use of AI tools in the coding of this PR.
