### PR TITLE
Enhancement: use lighter endpoints for qbittorrent

### DIFF
--- a/src/widgets/qbittorrent/component.jsx
+++ b/src/widgets/qbittorrent/component.jsx
@@ -10,13 +10,28 @@ export default function Component({ service }) {
   const { t } = useTranslation();
   const { widget } = service;
 
-  const { data: torrentData, error: torrentError } = useWidgetAPI(widget, "torrents");
+  const { data: transferData, error: transferError } = useWidgetAPI(widget, "transfer");
+  const { data: totalCountData, error: totalCountError } = useWidgetAPI(widget, "torrentCount");
+  const { data: completedCountData, error: completedCountError } = useWidgetAPI(widget, "torrentCount", {
+    filter: "completed",
+  });
+  const { data: leechTorrentData, error: leechTorrentError } = useWidgetAPI(
+    widget,
+    widget?.enableLeechProgress ? "torrents" : "",
+    widget?.enableLeechProgress ? { filter: "downloading" } : undefined,
+  );
 
-  if (torrentError) {
-    return <Container service={service} error={torrentError} />;
+  const apiError = transferError || totalCountError || completedCountError || leechTorrentError;
+  if (apiError) {
+    return <Container service={service} error={apiError} />;
   }
 
-  if (!torrentData) {
+  if (
+    !transferData ||
+    totalCountData === undefined ||
+    completedCountData === undefined ||
+    (widget?.enableLeechProgress && !leechTorrentData)
+  ) {
     return (
       <Container service={service}>
         <Block label="qbittorrent.leech" />
@@ -27,24 +42,15 @@ export default function Component({ service }) {
     );
   }
 
-  let rateDl = 0;
-  let rateUl = 0;
-  let completed = 0;
-  const leechTorrents = [];
+  const rateDl = Number(transferData?.dl_info_speed ?? 0);
+  const rateUl = Number(transferData?.up_info_speed ?? 0);
+  const totalCount = Number(totalCountData?.all ?? totalCountData?.count ?? totalCountData ?? 0);
+  const completedCount = Number(
+    completedCountData?.completed ?? completedCountData?.count ?? completedCountData?.all ?? completedCountData ?? 0,
+  );
+  const leech = Math.max(0, totalCount - completedCount);
 
-  for (let i = 0; i < torrentData.length; i += 1) {
-    const torrent = torrentData[i];
-    rateDl += torrent.dlspeed;
-    rateUl += torrent.upspeed;
-    if (torrent.progress === 1) {
-      completed += 1;
-    }
-    if (torrent.state.includes("DL") || torrent.state === "downloading") {
-      leechTorrents.push(torrent);
-    }
-  }
-
-  const leech = torrentData.length - completed;
+  const leechTorrents = Array.isArray(leechTorrentData) ? [...leechTorrentData] : [];
   const statePriority = [
     "downloading",
     "forcedDL",
@@ -55,7 +61,6 @@ export default function Component({ service }) {
     "queuedDL",
     "pausedDL",
   ];
-
   leechTorrents.sort((firstTorrent, secondTorrent) => {
     const firstStateIndex = statePriority.indexOf(firstTorrent.state);
     const secondStateIndex = statePriority.indexOf(secondTorrent.state);
@@ -70,7 +75,7 @@ export default function Component({ service }) {
       <Container service={service}>
         <Block label="qbittorrent.leech" value={t("common.number", { value: leech })} />
         <Block label="qbittorrent.download" value={t("common.bibyterate", { value: rateDl, decimals: 1 })} />
-        <Block label="qbittorrent.seed" value={t("common.number", { value: completed })} />
+        <Block label="qbittorrent.seed" value={t("common.number", { value: completedCount })} />
         <Block label="qbittorrent.upload" value={t("common.bibyterate", { value: rateUl, decimals: 1 })} />
       </Container>
       {widget?.enableLeechProgress &&

--- a/src/widgets/qbittorrent/component.test.jsx
+++ b/src/widgets/qbittorrent/component.test.jsx
@@ -34,19 +34,38 @@ describe("widgets/qbittorrent/component", () => {
     expect(screen.getByText("qbittorrent.upload")).toBeInTheDocument();
   });
 
-  it("computes leech/seed counts and upload/download rates, and can render leech progress entries", () => {
-    useWidgetAPI.mockReturnValue({
-      data: [
-        { name: "A", dlspeed: 10, upspeed: 1, progress: 1, state: "uploading" },
-        { name: "B", dlspeed: 5, upspeed: 2, progress: 0.5, state: "downloading", eta: 60, size: 100, amount_left: 50 },
-      ],
-      error: undefined,
+  it("uses lightweight endpoints for counts/rates and filtered torrents for leech progress", () => {
+    useWidgetAPI.mockImplementation((_widget, endpoint, query) => {
+      if (endpoint === "transfer") {
+        return { data: { dl_info_speed: 15, up_info_speed: 3 }, error: undefined };
+      }
+      if (endpoint === "torrentCount" && !query) {
+        return { data: 2, error: undefined };
+      }
+      if (endpoint === "torrentCount" && query?.filter === "completed") {
+        return { data: 1, error: undefined };
+      }
+      if (endpoint === "torrents" && query?.filter === "downloading") {
+        return {
+          data: [
+            {
+              name: "B",
+              progress: 0.5,
+              state: "downloading",
+              eta: 60,
+              size: 100,
+              amount_left: 50,
+            },
+          ],
+          error: undefined,
+        };
+      }
+      return { data: undefined, error: undefined };
     });
 
     const service = { widget: { type: "qbittorrent", enableLeechProgress: true } };
     const { container } = renderWithProviders(<Component service={service} />, { settings: { hideErrors: false } });
 
-    // total=2, completed=1 => leech=1
     expectBlockValue(container, "qbittorrent.leech", 1);
     expectBlockValue(container, "qbittorrent.seed", 1);
     expectBlockValue(container, "qbittorrent.download", 15);

--- a/src/widgets/qbittorrent/widget.js
+++ b/src/widgets/qbittorrent/widget.js
@@ -4,8 +4,16 @@ const widget = {
   proxyHandler: qbittorrentProxyHandler,
 
   mappings: {
+    transfer: {
+      endpoint: "transfer/info",
+    },
+    torrentCount: {
+      endpoint: "torrents/count",
+      optionalParams: ["filter"],
+    },
     torrents: {
       endpoint: "torrents/info",
+      optionalParams: ["filter"],
     },
   },
 };


### PR DESCRIPTION
<!--
==== STOP ====================
======== STOP ================
============ STOP ============
================ STOP ========
==================== STOP ====

⚠️ Before opening this pull request please review the guidelines in the checklist below.

If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.
-->

## Proposed change

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

Closes #6387

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [ ] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] In the description above I have disclosed the use of AI tools in the coding of this PR.
