### PR TITLE
Change: use byterate for beszel network field

### DIFF
--- a/src/widgets/beszel/component.jsx
+++ b/src/widgets/beszel/component.jsx
@@ -54,7 +54,10 @@ export default function Component({ service }) {
         <Block label="beszel.cpu" value={t("common.percent", { value: system.info.cpu, maximumFractionDigits: 2 })} />
         <Block label="beszel.memory" value={t("common.percent", { value: system.info.mp, maximumFractionDigits: 2 })} />
         <Block label="beszel.disk" value={t("common.percent", { value: system.info.dp, maximumFractionDigits: 2 })} />
-        <Block label="beszel.network" value={t("common.percent", { value: system.info.b, maximumFractionDigits: 2 })} />
+        <Block
+          label="beszel.network"
+          value={t("common.byterate", { value: system.info.bb, maximumFractionDigits: 2 })}
+        />
       </Container>
     );
   }

--- a/src/widgets/beszel/component.test.jsx
+++ b/src/widgets/beszel/component.test.jsx
@@ -76,6 +76,35 @@ describe("widgets/beszel/component", () => {
     expect(screen.queryByText("beszel.updated")).toBeNull();
   });
 
+  it("renders optional fields", () => {
+    useWidgetAPI.mockReturnValue({
+      data: {
+        totalItems: 1,
+        items: [
+          {
+            id: "sys1",
+            name: "MySystem",
+            status: "up",
+            updated: 123,
+            info: { cpu: 10, mp: 20, dp: 30, b: 40, bb: 14.5 },
+          },
+        ],
+      },
+      error: undefined,
+    });
+
+    const service = {
+      widget: { type: "beszel", systemId: "sys1", fields: ["name", "disk", "network"] },
+    };
+    const { container } = renderWithProviders(<Component service={service} />, { settings: { hideErrors: false } });
+
+    expect(service.widget.fields).toEqual(["name", "disk", "network"]);
+    expect(container.querySelectorAll(".service-block")).toHaveLength(3);
+    expectBlockValue(container, "beszel.name", "MySystem");
+    expectBlockValue(container, "beszel.disk", 30);
+    expectBlockValue(container, "beszel.network", 14.5);
+  });
+
   it("renders error when systemId is not found", () => {
     useWidgetAPI.mockReturnValue({
       data: { totalItems: 1, items: [{ id: "sys1", name: "MySystem", status: "up", info: {} }] },


### PR DESCRIPTION
<!--
==== STOP ====================
======== STOP ================
============ STOP ============
================ STOP ========
==================== STOP ====

⚠️ Before opening this pull request please review the guidelines in the checklist below.

If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.
-->
<img width="401" height="134" alt="Screenshot 2026-03-06 at 11 17 45 PM" src="https://github.com/user-attachments/assets/7f52b62c-7cea-459a-9c8f-a88f1b6e67cc" />

## Proposed change

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

Closes #6401

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [ ] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] In the description above I have disclosed the use of AI tools in the coding of this PR.
