### PR TITLE
feat: add snippets information widget

### DIFF
--- a/docs/widgets/info/snippets.md
+++ b/docs/widgets/info/snippets.md
@@ -1,0 +1,43 @@
+---
+title: Snippets
+description: Snippets Information Widget Configuration
+---
+
+The Snippets widget displays groups of commands or text snippets with a click-to-copy button. It's useful for frequently used commands, connection strings, API endpoints, or any text you regularly need to copy.
+
+## Configuration
+
+The widget is configured in `widgets.yaml` under the `snippets` type:
+
+```yaml
+- type: snippets
+  groups:
+    - name: Docker
+      items:
+        - command: docker ps -a
+          description: List all containers
+        - command: docker compose up -d
+          description: Start services
+    - name: SSH
+      items:
+        - command: ssh user@server
+          description: Connect to server
+```
+
+## Options
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `groups` | array | Yes | List of snippet groups |
+| `groups[].name` | string | No | Group heading (omit for ungrouped snippets) |
+| `groups[].items` | array | Yes | List of snippet items |
+| `groups[].items[].command` | string | Yes | The text to display and copy |
+| `groups[].items[].description` | string | No | Short description shown next to the command |
+
+## Behavior
+
+- Hovering over a snippet row reveals a copy button
+- Clicking the button copies the command text to the clipboard
+- A checkmark icon confirms the copy for 2 seconds
+- Descriptions are hidden on small screens to save space
+- The clipboard API requires a secure context (HTTPS or localhost)

--- a/docs/widgets/info/snippets.md
+++ b/docs/widgets/info/snippets.md
@@ -26,13 +26,13 @@ The widget is configured in `widgets.yaml` under the `snippets` type:
 
 ## Options
 
-| Option | Type | Required | Description |
-|--------|------|----------|-------------|
-| `groups` | array | Yes | List of snippet groups |
-| `groups[].name` | string | No | Group heading (omit for ungrouped snippets) |
-| `groups[].items` | array | Yes | List of snippet items |
-| `groups[].items[].command` | string | Yes | The text to display and copy |
-| `groups[].items[].description` | string | No | Short description shown next to the command |
+| Option                         | Type   | Required | Description                                 |
+| ------------------------------ | ------ | -------- | ------------------------------------------- |
+| `groups`                       | array  | Yes      | List of snippet groups                      |
+| `groups[].name`                | string | No       | Group heading (omit for ungrouped snippets) |
+| `groups[].items`               | array  | Yes      | List of snippet items                       |
+| `groups[].items[].command`     | string | Yes      | The text to display and copy                |
+| `groups[].items[].description` | string | No       | Short description shown next to the command |
 
 ## Behavior
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -196,6 +196,7 @@ nav:
           - widgets/info/openweathermap.md
           - widgets/info/resources.md
           - widgets/info/search.md
+          - widgets/info/snippets.md
           - widgets/info/stocks.md
           - widgets/info/unifi_controller.md
   - "Learn":

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,1184 +1,1188 @@
 {
-    "common": {
-        "bytes": "{{value, bytes}}",
-        "bits": "{{value, bytes(bits: true)}}",
-        "bbytes": "{{value, bytes(binary: true)}}",
-        "bbits": "{{value, bytes(bits: true; binary: true)}}",
-        "byterate": "{{value, rate(bits: false)}}",
-        "bibyterate": "{{value, rate(bits: false; binary: true)}}",
-        "bitrate": "{{value, rate(bits: true)}}",
-        "bibitrate": "{{value, rate(bits: true; binary: true)}}",
-        "percent": "{{value, percent}}",
-        "number": "{{value, number}}",
-        "ms": "{{value, number}}",
-        "date": "{{value, date}}",
-        "relativeDate": "{{value, relativeDate}}",
-        "duration": "{{value, duration}}",
-        "months": "mo",
-        "days": "d",
-        "hours": "h",
-        "minutes": "m",
-        "seconds": "s"
-    },
-    "widget": {
-        "missing_type": "Missing Widget Type: {{type}}",
-        "api_error": "API Error",
-        "information": "Information",
-        "status": "Status",
-        "url": "URL",
-        "raw_error": "Raw Error",
-        "response_data": "Response Data"
-    },
-    "weather": {
-        "current": "Current Location",
-        "allow": "Click to allow",
-        "updating": "Updating",
-        "wait": "Please wait"
-    },
-    "search": {
-        "placeholder": "Search…"
-    },
-    "resources": {
-        "cpu": "CPU",
-        "mem": "MEM",
-        "total": "Total",
-        "free": "Free",
-        "used": "Used",
-        "load": "Load",
-        "temp": "TEMP",
-        "max": "Max",
-        "uptime": "UP"
-    },
-    "unifi": {
-        "users": "Users",
-        "uptime": "Uptime",
-        "days": "Days",
-        "wan": "WAN",
-        "lan": "LAN",
-        "wlan": "WLAN",
-        "devices": "Devices",
-        "lan_devices": "LAN Devices",
-        "wlan_devices": "WLAN Devices",
-        "lan_users": "LAN Users",
-        "wlan_users": "WLAN Users",
-        "up": "UP",
-        "down": "DOWN",
-        "wait": "Please wait",
-        "empty_data": "Subsystem status unknown"
-    },
-    "docker": {
-        "rx": "RX",
-        "tx": "TX",
-        "mem": "MEM",
-        "cpu": "CPU",
-        "running": "Running",
-        "offline": "Offline",
-        "error": "Error",
-        "unknown": "Unknown",
-        "healthy": "Healthy",
-        "starting": "Starting",
-        "unhealthy": "Unhealthy",
-        "not_found": "Not Found",
-        "exited": "Exited",
-        "partial": "Partial"
-    },
-    "ping": {
-        "error": "Error",
-        "ping": "Ping",
-        "down": "Down",
-        "up": "Up",
-        "not_available": "Not Available"
-    },
-    "siteMonitor": {
-        "http_status": "HTTP status",
-        "error": "Error",
-        "response": "Response",
-        "down": "Down",
-        "up": "Up",
-        "not_available": "Not Available"
-    },
-    "emby": {
-        "playing": "Playing",
-        "transcoding": "Transcoding",
-        "bitrate": "Bitrate",
-        "no_active": "No Active Streams",
-        "movies": "Movies",
-        "series": "Series",
-        "episodes": "Episodes",
-        "songs": "Songs"
-    },
-    "jellyfin": {
-        "playing": "Playing",
-        "transcoding": "Transcoding",
-        "bitrate": "Bitrate",
-        "no_active": "No Active Streams",
-        "movies": "Movies",
-        "series": "Series",
-        "episodes": "Episodes",
-        "songs": "Songs"
-    },
-    "esphome": {
-        "offline": "Offline",
-        "offline_alt": "Offline",
-        "online": "Online",
-        "total": "Total",
-        "unknown": "Unknown"
-    },
-    "evcc": {
-        "pv_power": "Production",
-        "battery_soc": "Battery",
-        "grid_power": "Grid",
-        "home_power": "Consumption",
-        "charge_power": "Charger",
-        "kilowatt": "kW"
-    },
-    "flood": {
-        "download": "Download",
-        "upload": "Upload",
-        "leech": "Leech",
-        "seed": "Seed"
-    },
-    "freshrss": {
-        "subscriptions": "Subscriptions",
-        "unread": "Unread"
-    },
-    "fritzbox": {
-        "connectionStatus": "Status",
-        "connectionStatusUnconfigured": "Unconfigured",
-        "connectionStatusConnecting": "Connecting",
-        "connectionStatusAuthenticating": "Authenticating",
-        "connectionStatusPendingDisconnect": "Pending Disconnect",
-        "connectionStatusDisconnecting": "Disconnecting",
-        "connectionStatusDisconnected": "Disconnected",
-        "connectionStatusConnected": "Connected",
-        "uptime": "Uptime",
-        "maxDown": "Max. Down",
-        "maxUp": "Max. Up",
-        "down": "Down",
-        "up": "Up",
-        "received": "Received",
-        "sent": "Sent",
-        "externalIPAddress": "Ext. IP",
-        "externalIPv6Address": "Ext. IPv6",
-        "externalIPv6Prefix": "Ext. IPv6-Prefix"
-    },
-    "caddy": {
-        "upstreams": "Upstreams",
-        "requests": "Current requests",
-        "requests_failed": "Failed requests"
-    },
-    "changedetectionio": {
-        "totalObserved": "Total Observed",
-        "diffsDetected": "Diffs Detected"
-    },
-    "channelsdvrserver": {
-        "shows": "Shows",
-        "recordings": "Recordings",
-        "scheduled": "Scheduled",
-        "passes": "Passes"
-    },
-    "tautulli": {
-        "playing": "Playing",
-        "transcoding": "Transcoding",
-        "bitrate": "Bitrate",
-        "no_active": "No Active Streams",
-        "plex_connection_error": "Check Plex Connection"
-    },
-    "tracearr": {
-        "no_active": "No Active Streams",
-        "streams": "Streams",
-        "transcodes": "Transcodes",
-        "directplay": "Direct Play",
-        "bitrate": "Bitrate"
-    },
-    "omada": {
-        "connectedAp": "Connected APs",
-        "activeUser": "Active devices",
-        "alerts": "Alerts",
-        "connectedGateways": "Connected gateways",
-        "connectedSwitches": "Connected switches"
-    },
-    "nzbget": {
-        "rate": "Rate",
-        "remaining": "Remaining",
-        "downloaded": "Downloaded"
-    },
-    "plex": {
-        "streams": "Active Streams",
-        "albums": "Albums",
-        "movies": "Movies",
-        "tv": "TV Shows"
-    },
-    "sabnzbd": {
-        "rate": "Rate",
-        "queue": "Queue",
-        "timeleft": "Time Left"
-    },
-    "rutorrent": {
-        "active": "Active",
-        "upload": "Upload",
-        "download": "Download"
-    },
-    "transmission": {
-        "download": "Download",
-        "upload": "Upload",
-        "leech": "Leech",
-        "seed": "Seed"
-    },
-    "qbittorrent": {
-        "download": "Download",
-        "upload": "Upload",
-        "leech": "Leech",
-        "seed": "Seed"
-    },
-    "qnap": {
-        "cpuUsage": "CPU Usage",
-        "memUsage": "MEM Usage",
-        "systemTempC": "System Temp",
-        "poolUsage": "Pool Usage",
-        "volumeUsage": "Volume Usage",
-        "invalid": "Invalid"
-    },
-    "deluge": {
-        "download": "Download",
-        "upload": "Upload",
-        "leech": "Leech",
-        "seed": "Seed"
-    },
-    "develancacheui": {
-        "cachehitbytes": "Cache Hit Bytes",
-        "cachemissbytes": "Cache Miss Bytes"
-    },
-    "downloadstation": {
-        "download": "Download",
-        "upload": "Upload",
-        "leech": "Leech",
-        "seed": "Seed"
-    },
-    "sonarr": {
-        "wanted": "Wanted",
-        "queued": "Queued",
-        "series": "Series",
-        "queue": "Queue",
-        "unknown": "Unknown"
-    },
-    "radarr": {
-        "wanted": "Wanted",
-        "missing": "Missing",
-        "queued": "Queued",
-        "movies": "Movies",
-        "queue": "Queue",
-        "unknown": "Unknown"
-    },
-    "lidarr": {
-        "wanted": "Wanted",
-        "queued": "Queued",
-        "artists": "Artists"
-    },
-    "readarr": {
-        "wanted": "Wanted",
-        "queued": "Queued",
-        "books": "Books"
-    },
-    "bazarr": {
-        "missingEpisodes": "Missing Episodes",
-        "missingMovies": "Missing Movies"
-    },
-    "ombi": {
-        "pending": "Pending",
-        "approved": "Approved",
-        "available": "Available"
-    },
-    "seerr": {
-        "pending": "Pending",
-        "approved": "Approved",
-        "available": "Available",
-        "completed": "Completed",
-        "processing": "Processing",
-        "issues": "Open Issues"
-    },
-    "netalertx": {
-        "total": "Total",
-        "connected": "Connected",
-        "new_devices": "New Devices",
-        "down_alerts": "Down Alerts"
-    },
-    "pihole": {
-        "queries": "Queries",
-        "blocked": "Blocked",
-        "blocked_percent": "Blocked %",
-        "gravity": "Gravity"
-    },
-    "adguard": {
-        "queries": "Queries",
-        "blocked": "Blocked",
-        "filtered": "Filtered",
-        "latency": "Latency"
-    },
-    "speedtest": {
-        "upload": "Upload",
-        "download": "Download",
-        "ping": "Ping"
-    },
-    "portainer": {
-        "running": "Running",
-        "stopped": "Stopped",
-        "total": "Total"
-    },
-    "suwayomi": {
-      "download": "Downloaded",
-      "nondownload": "Non-Downloaded",
-      "read": "Read",
-      "unread": "Unread",
-      "downloadedread": "Downloaded & Read",
-      "downloadedunread": "Downloaded & Unread",
-      "nondownloadedread": "Non-Downloaded & Read",
-      "nondownloadedunread": "Non-Downloaded & Unread"
-    },
-    "tailscale": {
-        "address": "Address",
-        "expires": "Expires",
-        "never": "Never",
-        "last_seen": "Last Seen",
-        "now": "Now",
-        "years": "{{number}}y",
-        "weeks": "{{number}}w",
-        "days": "{{number}}d",
-        "hours": "{{number}}h",
-        "minutes": "{{number}}m",
-        "seconds": "{{number}}s",
-        "ago": "{{value}} Ago"
-    },
-    "technitium": {
-        "totalQueries": "Queries",
-        "totalNoError": "Success",
-        "totalServerFailure": "Failures",
-        "totalNxDomain": "NX Domains",
-        "totalRefused": "Refused",
-        "totalAuthoritative": "Authoritative",
-        "totalRecursive": "Recursive",
-        "totalCached": "Cached",
-        "totalBlocked": "Blocked",
-        "totalDropped": "Dropped",
-        "totalClients": "Clients"
-    },
-    "tdarr": {
-        "queue": "Queue",
-        "processed": "Processed",
-        "errored": "Errored",
-        "saved": "Saved"
-    },
-    "traefik": {
-        "routers": "Routers",
-        "services": "Services",
-        "middleware": "Middleware"
-    },
-    "trilium": {
-        "version": "Version",
-        "notesCount": "Notes",
-        "dbSize": "Database Size",
-        "unknown": "Unknown"
-    },
-    "navidrome": {
-        "nothing_streaming": "No Active Streams",
-        "please_wait": "Please Wait"
-    },
-    "npm": {
-        "enabled": "Enabled",
-        "disabled": "Disabled",
-        "total": "Total"
-    },
-    "coinmarketcap": {
-        "configure": "Configure one or more crypto currencies to track",
-        "1hour": "1 Hour",
-        "1day": "1 Day",
-        "7days": "7 Days",
-        "30days": "30 Days"
-    },
-    "gotify": {
-        "apps": "Applications",
-        "clients": "Clients",
-        "messages": "Messages"
-    },
-    "prowlarr": {
-        "enableIndexers": "Indexers",
-        "numberOfGrabs": "Grabs",
-        "numberOfQueries": "Queries",
-        "numberOfFailGrabs": "Fail Grabs",
-        "numberOfFailQueries": "Fail Queries"
-    },
-    "jackett": {
-        "configured": "Configured",
-        "errored": "Errored"
-    },
-    "strelaysrv": {
-        "numActiveSessions": "Sessions",
-        "numConnections": "Connections",
-        "dataRelayed": "Relayed",
-        "transferRate": "Rate"
-    },
-    "mastodon": {
-        "user_count": "Users",
-        "status_count": "Posts",
-        "domain_count": "Domains"
-    },
-    "medusa": {
-        "wanted": "Wanted",
-        "queued": "Queued",
-        "series": "Series"
-    },
-    "minecraft": {
-        "players": "Players",
-        "version": "Version",
-        "status": "Status",
-        "up": "Online",
-        "down": "Offline"
-    },
-    "miniflux": {
-        "read": "Read",
-        "unread": "Unread"
-    },
-    "authentik": {
-        "users": "Users",
-        "loginsLast24H": "Logins (24h)",
-        "failedLoginsLast24H": "Failed Logins (24h)"
-    },
-    "proxmox": {
-        "mem": "MEM",
-        "cpu": "CPU",
-        "lxc": "LXC",
-        "vms": "VMs"
-    },
-    "glances": {
-        "cpu": "CPU",
-        "load": "Load",
-        "wait": "Please wait",
-        "temp": "TEMP",
-        "_temp": "Temp",
-        "warn": "Warn",
-        "uptime": "UP",
-        "total": "Total",
-        "free": "Free",
-        "used": "Used",
-        "days": "d",
-        "hours": "h",
-        "crit": "Crit",
-        "read": "Read",
-        "write": "Write",
-        "gpu": "GPU",
-        "mem": "Mem",
-        "swap": "Swap"
-    },
-    "quicklaunch": {
-        "bookmark": "Bookmark",
-        "service": "Service",
-        "search": "Search",
-        "custom": "Custom",
-        "visit": "Visit",
-        "url": "URL",
-        "searchsuggestion": "Suggestion"
-    },
-    "wmo": {
-        "0-day": "Sunny",
-        "0-night": "Clear",
-        "1-day": "Mainly Sunny",
-        "1-night": "Mainly Clear",
-        "2-day": "Partly Cloudy",
-        "2-night": "Partly Cloudy",
-        "3-day": "Cloudy",
-        "3-night": "Cloudy",
-        "45-day": "Foggy",
-        "45-night": "Foggy",
-        "48-day": "Foggy",
-        "48-night": "Foggy",
-        "51-day": "Light Drizzle",
-        "51-night": "Light Drizzle",
-        "53-day": "Drizzle",
-        "53-night": "Drizzle",
-        "55-day": "Heavy Drizzle",
-        "55-night": "Heavy Drizzle",
-        "56-day": "Light Freezing Drizzle",
-        "56-night": "Light Freezing Drizzle",
-        "57-day": "Freezing Drizzle",
-        "57-night": "Freezing Drizzle",
-        "61-day": "Light Rain",
-        "61-night": "Light Rain",
-        "63-day": "Rain",
-        "63-night": "Rain",
-        "65-day": "Heavy Rain",
-        "65-night": "Heavy Rain",
-        "66-day": "Freezing Rain",
-        "66-night": "Freezing Rain",
-        "67-day": "Freezing Rain",
-        "67-night": "Freezing Rain",
-        "71-day": "Light Snow",
-        "71-night": "Light Snow",
-        "73-day": "Snow",
-        "73-night": "Snow",
-        "75-day": "Heavy Snow",
-        "75-night": "Heavy Snow",
-        "77-day": "Snow Grains",
-        "77-night": "Snow Grains",
-        "80-day": "Light Showers",
-        "80-night": "Light Showers",
-        "81-day": "Showers",
-        "81-night": "Showers",
-        "82-day": "Heavy Showers",
-        "82-night": "Heavy Showers",
-        "85-day": "Snow Showers",
-        "85-night": "Snow Showers",
-        "86-day": "Snow Showers",
-        "86-night": "Snow Showers",
-        "95-day": "Thunderstorm",
-        "95-night": "Thunderstorm",
-        "96-day": "Thunderstorm With Hail",
-        "96-night": "Thunderstorm With Hail",
-        "99-day": "Thunderstorm With Hail",
-        "99-night": "Thunderstorm With Hail"
-    },
-    "homebridge": {
-        "available_update": "System",
-        "updates": "Updates",
-        "update_available": "Update Available",
-        "up_to_date": "Up to Date",
-        "child_bridges": "Child Bridges",
-        "child_bridges_status": "{{ok}}/{{total}}",
-        "up": "Up",
-        "pending": "Pending",
-        "down": "Down",
-        "ok": "Ok"
-    },
-    "healthchecks": {
-        "new": "New",
-        "up": "Up",
-        "grace": "In Grace Period",
-        "down": "Down",
-        "paused": "Paused",
-        "status": "Status",
-        "last_ping": "Last Ping",
-        "never": "No pings yet"
-    },
-    "watchtower": {
-        "containers_scanned": "Scanned",
-        "containers_updated": "Updated",
-        "containers_failed": "Failed"
-    },
-    "autobrr": {
-        "approvedPushes": "Approved",
-        "rejectedPushes": "Rejected",
-        "filters": "Filters",
-        "indexers": "Indexers"
-    },
-    "tubearchivist": {
-        "downloads": "Queue",
-        "videos": "Videos",
-        "channels": "Channels",
-        "playlists": "Playlists"
-    },
-    "truenas": {
-        "load": "System Load",
-        "uptime": "Uptime",
-        "alerts": "Alerts"
-    },
-    "pyload": {
-        "speed": "Speed",
-        "active": "Active",
-        "queue": "Queue",
-        "total": "Total"
-    },
-    "gluetun": {
-        "public_ip": "Public IP",
-        "region": "Region",
-        "country": "Country",
-        "port_forwarded": "Port Forwarded"
-    },
-    "hdhomerun": {
-        "channels": "Channels",
-        "hd": "HD",
-        "tunerCount": "Tuners",
-        "channelNumber": "Channel",
-        "channelNetwork": "Network",
-        "signalStrength": "Strength",
-        "signalQuality": "Quality",
-        "symbolQuality": "Quality",
-        "networkRate": "Bitrate",
-        "clientIP": "Client"
-    },
-    "scrutiny": {
-        "passed": "Passed",
-        "failed": "Failed",
-        "unknown": "Unknown"
-    },
-    "paperlessngx": {
-        "inbox": "Inbox",
-        "total": "Total"
-    },
-    "pangolin": {
-        "orgs": "Orgs",
-        "sites": "Sites",
-        "resources": "Resources",
-        "targets": "Targets",
-        "traffic": "Traffic",
-        "in": "In",
-        "out": "Out"
-    },
-    "peanut": {
-        "battery_charge": "Battery Charge",
-        "ups_load": "UPS Load",
-        "ups_status": "UPS Status",
-        "online": "Online",
-        "on_battery": "On Battery",
-        "low_battery": "Low Battery"
-    },
-    "nextdns": {
-        "wait": "Please Wait",
-        "no_devices": "No Device Data Received"
-    },
-    "mikrotik": {
-        "cpuLoad": "CPU Load",
-        "memoryUsed": "Memory Used",
-        "uptime": "Uptime",
-        "numberOfLeases": "Leases"
-    },
-    "xteve": {
-        "streams_all": "All Streams",
-        "streams_active": "Active Streams",
-        "streams_xepg": "XEPG Channels"
-    },
-    "opendtu": {
-        "yieldDay": "Today",
-        "absolutePower": "Power",
-        "relativePower": "Power %",
-        "limit": "Limit"
-    },
-    "opnsense": {
-        "cpu": "CPU Load",
-        "memory": "Active Memory",
-        "wanUpload": "WAN Upload",
-        "wanDownload": "WAN Download"
-    },
-    "moonraker": {
-        "printer_state": "Printer State",
-        "print_status": "Print Status",
-        "print_progress": "Progress",
-        "layers": "Layers"
-    },
-    "octoprint": {
-        "printer_state": "Status",
-        "temp_tool": "Tool temp",
-        "temp_bed": "Bed temp",
-        "job_completion": "Completion"
-    },
-    "cloudflared": {
-        "origin_ip": "Origin IP",
-        "status": "Status"
-    },
-    "pfsense": {
-        "load": "Load Avg",
-        "memory": "Mem Usage",
-        "wanStatus": "WAN Status",
-        "up": "Up",
-        "down": "Down",
-        "temp": "Temp",
-        "disk": "Disk Usage",
-        "wanIP": "WAN IP"
-    },
-    "proxmoxbackupserver": {
-        "datastore_usage": "Datastore",
-        "failed_tasks_24h": "Failed Tasks 24h",
-        "cpu_usage": "CPU",
-        "memory_usage": "Memory"
-    },
-    "immich": {
-        "users": "Users",
-        "photos": "Photos",
-        "videos": "Videos",
-        "storage": "Storage"
-    },
-    "uptimekuma": {
-        "up": "Sites Up",
-        "down": "Sites Down",
-        "uptime": "Uptime",
-        "incident": "Incident",
-        "m": "m"
-    },
-    "atsumeru": {
-        "series": "Series",
-        "archives": "Archives",
-        "chapters": "Chapters",
-        "categories": "Categories"
-    },
-    "komga": {
-        "libraries": "Libraries",
-        "series": "Series",
-        "books": "Books"
-    },
-    "diskstation": {
-        "days": "Days",
-        "uptime": "Uptime",
-        "volumeAvailable": "Available"
-    },
-    "dispatcharr": {
-        "channels": "Channels",
-        "streams": "Streams"
-    },
-    "mylar": {
-        "series": "Series",
-        "issues": "Issues",
-        "wanted": "Wanted"
-    },
-    "photoprism": {
-        "albums": "Albums",
-        "photos": "Photos",
-        "videos": "Videos",
-        "people": "People"
-    },
-    "fileflows": {
-        "queue": "Queue",
-        "processing": "Processing",
-        "processed": "Processed",
-        "time": "Time"
-    },
-    "firefly": {
-        "networth": "Net Worth",
-        "budget": "Budget"
-    },
-    "grafana": {
-        "dashboards": "Dashboards",
-        "datasources": "Data Sources",
-        "totalalerts": "Total Alerts",
-        "alertstriggered": "Alerts Triggered"
-    },
-    "nextcloud": {
-        "cpuload": "Cpu Load",
-        "memoryusage": "Memory Usage",
-        "freespace": "Free Space",
-        "activeusers": "Active Users",
-        "numfiles": "Files",
-        "numshares": "Shared Items"
-    },
-    "kopia": {
-        "status": "Status",
-        "size": "Size",
-        "lastrun": "Last Run",
-        "nextrun": "Next Run",
-        "failed": "Failed"
-    },
-    "unmanic": {
-        "active_workers": "Active Workers",
-        "total_workers": "Total Workers",
-        "records_total": "Queue Length"
-    },
-    "pterodactyl": {
-        "servers": "Servers",
-        "nodes": "Nodes"
-    },
-    "prometheus": {
-        "targets_up": "Targets Up",
-        "targets_down": "Targets Down",
-        "targets_total": "Total Targets"
-    },
-    "gatus": {
-        "up": "Sites Up",
-        "down": "Sites Down",
-        "uptime": "Uptime"
-    },
-    "ghostfolio": {
-        "gross_percent_today": "Today",
-        "gross_percent_1y": "One year",
-        "gross_percent_max": "All time",
-        "net_worth": "Net Worth"
-    },
-    "audiobookshelf": {
-        "podcasts": "Podcasts",
-        "books": "Books",
-        "podcastsDuration": "Duration",
-        "booksDuration": "Duration"
-    },
-    "homeassistant": {
-        "people_home": "People Home",
-        "lights_on": "Lights On",
-        "switches_on": "Switches On"
-    },
-    "whatsupdocker": {
-        "monitoring": "Monitoring",
-        "updates": "Updates"
-    },
-    "calibreweb": {
-        "books": "Books",
-        "authors": "Authors",
-        "categories": "Categories",
-        "series": "Series"
-    },
-    "booklore": {
-        "libraries": "Libraries",
-        "books": "Books",
-        "reading": "Reading",
-        "finished": "Finished"
-    },
-    "jdownloader": {
-        "downloadCount": "Queue",
-        "downloadBytesRemaining": "Remaining",
-        "downloadTotalBytes": "Size",
-        "downloadSpeed": "Speed"
-    },
-    "kavita": {
-        "seriesCount": "Series",
-        "totalFiles": "Files"
-    },
-    "azuredevops": {
-        "result": "Result",
-        "status": "Status",
-        "buildId": "Build ID",
-        "succeeded": "Succeeded",
-        "notStarted": "Not Started",
-        "failed": "Failed",
-        "canceled": "Canceled",
-        "inProgress": "In Progress",
-        "totalPrs": "Total PRs",
-        "myPrs": "My PRs",
-        "approved": "Approved"
-    },
-    "gamedig": {
-        "status": "Status",
-        "online": "Online",
-        "offline": "Offline",
-        "name": "Name",
-        "map": "Map",
-        "currentPlayers": "Current players",
-        "players": "Players",
-        "maxPlayers": "Max players",
-        "bots": "Bots",
-        "ping": "Ping"
-    },
-    "urbackup": {
-        "ok" : "Ok",
-        "errored": "Errors",
-        "noRecent": "Out of Date",
-        "totalUsed": "Used Storage"
-    },
-    "mealie": {
-        "recipes": "Recipes",
-        "users": "Users",
-        "categories": "Categories",
-        "tags": "Tags"
-    },
-    "openmediavault": {
-        "downloading": "Downloading",
-        "total": "Total",
-        "running": "Running",
-        "stopped": "Stopped",
-        "passed": "Passed",
-        "failed": "Failed"
-    },
-    "openwrt": {
-        "uptime": "Uptime",
-        "cpuLoad": "CPU Load Avg (5m)",
-        "up": "Up",
-        "down": "Down",
-        "bytesTx": "Transmitted",
-        "bytesRx": "Received"
-    },
-    "uptimerobot": {
-        "status": "Status",
-        "uptime": "Uptime",
-        "lastDown": "Last Downtime",
-        "downDuration": "Downtime Duration",
-        "sitesUp": "Sites Up",
-        "sitesDown": "Sites Down",
-        "paused": "Paused",
-        "notyetchecked": "Not Yet Checked",
-        "up": "Up",
-        "seemsdown": "Seems Down",
-        "down": "Down",
-        "unknown": "Unknown"
-    },
-    "calendar": {
-        "inCinemas": "In cinemas",
-        "physicalRelease": "Physical release",
-        "digitalRelease": "Digital release",
-        "noEventsToday": "No events for today!",
-        "noEventsFound": "No events found",
-        "errorWhenLoadingData": "Error when loading calendar data"
-    },
-    "romm": {
-        "platforms": "Platforms",
-        "totalRoms": "Games",
-        "saves": "Saves",
-        "states": "States",
-        "screenshots": "Screenshots",
-        "totalfilesize": "Total Size"
-    },
-    "mailcow": {
-      "domains": "Domains",
-      "mailboxes": "Mailboxes",
-      "mails": "Mails",
-      "storage": "Storage"
-    },
-    "netdata": {
-      "warnings": "Warnings",
-      "criticals": "Criticals"
-    },
-    "plantit": {
-        "events": "Events",
-        "plants": "Plants",
-        "photos": "Photos",
-        "species": "Species"
-    },
-    "gitea": {
-      "notifications": "Notifications",
-      "issues": "Issues",
-      "pulls": "Pull Requests",
-      "repositories": "Repositories"
-    },
-    "stash": {
-        "scenes": "Scenes",
-        "scenesPlayed": "Scenes Played",
-        "playCount": "Total Plays",
-        "playDuration": "Time Watched",
-        "sceneSize": "Scenes Size",
-        "sceneDuration": "Scenes Duration",
-        "images": "Images",
-        "imageSize": "Images Size",
-        "galleries": "Galleries",
-        "performers": "Performers",
-        "studios": "Studios",
-        "movies": "Movies",
-        "tags": "Tags",
-        "oCount": "O Count"
-    },
-    "tandoor": {
-        "users": "Users",
-        "recipes": "Recipes",
-        "keywords": "Keywords"
-    },
-    "homebox": {
-        "items": "Items",
-        "totalWithWarranty": "With Warranty",
-        "locations": "Locations",
-        "labels": "Labels",
-        "users": "Users",
-        "totalValue": "Total Value"
-    },
-    "crowdsec": {
-        "alerts": "Alerts",
-        "bans": "Bans"
-    },
-    "wgeasy": {
-        "connected": "Connected",
-        "enabled": "Enabled",
-        "disabled": "Disabled",
-        "total": "Total"
-    },
-    "swagdashboard": {
-        "proxied": "Proxied",
-        "auth": "With Auth",
-        "outdated": "Outdated",
-        "banned": "Banned"
-    },
-    "myspeed": {
-        "ping": "Ping",
-        "download": "Download",
-        "upload": "Upload"
-    },
-    "stocks": {
-        "stocks": "Stocks",
-        "loading": "Loading",
-        "open": "Open - US Market",
-        "closed": "Closed - US Market",
-        "invalidConfiguration": "Invalid Configuration"
-    },
-    "frigate": {
-        "cameras": "Cameras",
-        "uptime": "Uptime",
-        "version": "Version"
-    },
-    "linkwarden": {
-        "links": "Links",
-        "collections": "Collections",
-        "tags": "Tags"
-    },
-    "zabbix": {
-      "unclassified": "Not classified",
-      "information": "Information",
-      "warning": "Warning",
-      "average": "Average",
-      "high": "High",
-      "disaster": "Disaster"
-    },
-    "lubelogger": {
-      "vehicle": "Vehicle",
-      "vehicles": "Vehicles",
-      "serviceRecords": "Service Records",
-      "reminders": "Reminders",
-      "nextReminder": "Next Reminder",
-      "none": "None"
-    },
-    "vikunja": {
-      "projects": "Active Projects",
-      "tasks7d": "Tasks Due This Week",
-      "tasksOverdue": "Overdue Tasks",
-      "tasksInProgress": "Tasks In Progress"
-    },
-    "headscale": {
-      "name": "Name",
-      "address": "Address",
-      "last_seen": "Last Seen",
-      "status": "Status",
-      "online": "Online",
-      "offline": "Offline"
-    },
-    "beszel": {
-      "name": "Name",
-      "systems": "Systems",
-      "up": "Up",
-      "down": "Down",
-      "paused": "Paused",
-      "pending": "Pending",
-      "status": "Status",
-      "updated": "Updated",
-      "cpu": "CPU",
-      "memory": "MEM",
-      "disk": "Disk",
-      "network": "NET"
-    },
-    "argocd": {
-        "apps": "Apps",
-        "synced": "Synced",
-        "outOfSync": "Out Of Sync",
-        "healthy": "Healthy",
-        "degraded": "Degraded",
-        "progressing": "Progressing",
-        "missing": "Missing",
-        "suspended": "Suspended"
-    },
-    "spoolman": {
-        "loading": "Loading"
-    },
-    "gitlab": {
-        "groups": "Groups",
-        "issues": "Issues",
-        "merges": "Merge Requests",
-        "projects": "Projects"
-    },
-    "apcups": {
-        "status": "Status",
-        "load": "Load",
-        "bcharge":"Battery Charge",
-        "timeleft":"Time Left"
-    },
-    "karakeep": {
-        "bookmarks": "Bookmarks",
-        "favorites": "Favorites",
-        "archived": "Archived",
-        "highlights": "Highlights",
-        "lists": "Lists",
-        "tags": "Tags"
-    },
-    "slskd": {
-        "slskStatus": "Network",
-        "connected": "Connected",
-        "disconnected": "Disconnected",
-        "updateStatus": "Update",
-        "update_yes": "Available",
-        "update_no": "Up to Date",
-        "downloads": "Downloads",
-        "uploads": "Uploads",
-        "sharedFiles": "Files"
-    },
-    "jellystat": {
-        "songs": "Songs",
-        "movies": "Movies",
-        "episodes": "Episodes",
-        "other": "Other"
-    },
-    "checkmk": {
-        "serviceErrors": "Service issues",
-        "hostErrors": "Host issues"
-    },
-    "komodo": {
-        "total": "Total",
-        "running": "Running",
-        "stopped": "Stopped",
-        "down": "Down",
-        "unhealthy": "Unhealthy",
-        "unknown": "Unknown",
-        "servers": "Servers",
-        "stacks": "Stacks",
-        "containers": "Containers"
-    },
-    "filebrowser": {
-        "available": "Available",
-        "used": "Used",
-        "total": "Total"
-    },
-    "wallos": {
-        "activeSubscriptions": "Subscriptions",
-        "thisMonthlyCost": "This Month",
-        "nextMonthlyCost": "Next Month",
-        "previousMonthlyCost": "Prev. Month",
-        "nextRenewingSubscription": "Next Payment"
-    },
-    "unraid": {
-        "STARTED": "Started",
-        "STOPPED": "Stopped",
-        "NEW_ARRAY": "New Array",
-        "RECON_DISK": "Reconstructing Disk",
-        "DISABLE_DISK": "Disk Disabled",
-        "SWAP_DSBL": "Swap Disable",
-        "INVALID_EXPANSION": "Invalid Expansion",
-        "PARITY_NOT_BIGGEST": "Parity Not Biggest",
-        "TOO_MANY_MISSING_DISKS": "Too Many Missing Disks",
-        "NEW_DISK_TOO_SMALL": "New Disk Too Small",
-        "NO_DATA_DISKS": "No Data Disks",
-        "notifications": "Notifications",
-        "status": "Status",
-        "cpu": "CPU",
-        "memoryUsed": "Memory Used",
-        "memoryAvailable": "Memory Available",
-        "arrayUsed": "Array Used",
-        "arrayFree": "Array Free",
-        "poolUsed": "{{pool}} Used",
-        "poolFree": "{{pool}} Free"
-    },
-    "backrest": {
-        "num_plans": "Plans",
-        "num_success_30": "Successes",
-        "num_failure_30": "Failures",
-        "num_success_latest": "Succeeding",
-        "num_failure_latest": "Failing",
-        "bytes_added_30": "Bytes Added"
-    },
-    "yourspotify": {
-      "songs": "Songs",
-      "time":  "Time",
-      "artists": "Artists"
-    },
-    "arcane": {
-        "containers": "Containers",
-        "images": "Images",
-        "image_updates": "Image Updates",
-        "images_unused": "Unused",
-        "environment_required": "Environment ID Required"
-    },
-    "dockhand": {
-        "running": "Running",
-        "stopped": "Stopped",
-        "cpu": "CPU",
-        "memory": "Memory",
-        "images": "Images",
-        "volumes": "Volumes",
-        "events_today": "Events Today",
-        "pending_updates": "Pending Updates",
-        "stacks": "Stacks",
-        "paused": "Paused",
-        "total": "Total",
-        "environment_not_found": "Environment Not Found"
-    },
-    "sparkyfitness": {
-        "eaten": "Eaten",
-        "burned": "Burned",
-        "remaining": "Remaining",
-        "steps": "Steps"
-    }
+  "common": {
+    "bytes": "{{value, bytes}}",
+    "bits": "{{value, bytes(bits: true)}}",
+    "bbytes": "{{value, bytes(binary: true)}}",
+    "bbits": "{{value, bytes(bits: true; binary: true)}}",
+    "byterate": "{{value, rate(bits: false)}}",
+    "bibyterate": "{{value, rate(bits: false; binary: true)}}",
+    "bitrate": "{{value, rate(bits: true)}}",
+    "bibitrate": "{{value, rate(bits: true; binary: true)}}",
+    "percent": "{{value, percent}}",
+    "number": "{{value, number}}",
+    "ms": "{{value, number}}",
+    "date": "{{value, date}}",
+    "relativeDate": "{{value, relativeDate}}",
+    "duration": "{{value, duration}}",
+    "months": "mo",
+    "days": "d",
+    "hours": "h",
+    "minutes": "m",
+    "seconds": "s"
+  },
+  "widget": {
+    "missing_type": "Missing Widget Type: {{type}}",
+    "api_error": "API Error",
+    "information": "Information",
+    "status": "Status",
+    "url": "URL",
+    "raw_error": "Raw Error",
+    "response_data": "Response Data"
+  },
+  "weather": {
+    "current": "Current Location",
+    "allow": "Click to allow",
+    "updating": "Updating",
+    "wait": "Please wait"
+  },
+  "search": {
+    "placeholder": "Search…"
+  },
+  "resources": {
+    "cpu": "CPU",
+    "mem": "MEM",
+    "total": "Total",
+    "free": "Free",
+    "used": "Used",
+    "load": "Load",
+    "temp": "TEMP",
+    "max": "Max",
+    "uptime": "UP"
+  },
+  "unifi": {
+    "users": "Users",
+    "uptime": "Uptime",
+    "days": "Days",
+    "wan": "WAN",
+    "lan": "LAN",
+    "wlan": "WLAN",
+    "devices": "Devices",
+    "lan_devices": "LAN Devices",
+    "wlan_devices": "WLAN Devices",
+    "lan_users": "LAN Users",
+    "wlan_users": "WLAN Users",
+    "up": "UP",
+    "down": "DOWN",
+    "wait": "Please wait",
+    "empty_data": "Subsystem status unknown"
+  },
+  "docker": {
+    "rx": "RX",
+    "tx": "TX",
+    "mem": "MEM",
+    "cpu": "CPU",
+    "running": "Running",
+    "offline": "Offline",
+    "error": "Error",
+    "unknown": "Unknown",
+    "healthy": "Healthy",
+    "starting": "Starting",
+    "unhealthy": "Unhealthy",
+    "not_found": "Not Found",
+    "exited": "Exited",
+    "partial": "Partial"
+  },
+  "ping": {
+    "error": "Error",
+    "ping": "Ping",
+    "down": "Down",
+    "up": "Up",
+    "not_available": "Not Available"
+  },
+  "siteMonitor": {
+    "http_status": "HTTP status",
+    "error": "Error",
+    "response": "Response",
+    "down": "Down",
+    "up": "Up",
+    "not_available": "Not Available"
+  },
+  "emby": {
+    "playing": "Playing",
+    "transcoding": "Transcoding",
+    "bitrate": "Bitrate",
+    "no_active": "No Active Streams",
+    "movies": "Movies",
+    "series": "Series",
+    "episodes": "Episodes",
+    "songs": "Songs"
+  },
+  "jellyfin": {
+    "playing": "Playing",
+    "transcoding": "Transcoding",
+    "bitrate": "Bitrate",
+    "no_active": "No Active Streams",
+    "movies": "Movies",
+    "series": "Series",
+    "episodes": "Episodes",
+    "songs": "Songs"
+  },
+  "esphome": {
+    "offline": "Offline",
+    "offline_alt": "Offline",
+    "online": "Online",
+    "total": "Total",
+    "unknown": "Unknown"
+  },
+  "evcc": {
+    "pv_power": "Production",
+    "battery_soc": "Battery",
+    "grid_power": "Grid",
+    "home_power": "Consumption",
+    "charge_power": "Charger",
+    "kilowatt": "kW"
+  },
+  "flood": {
+    "download": "Download",
+    "upload": "Upload",
+    "leech": "Leech",
+    "seed": "Seed"
+  },
+  "freshrss": {
+    "subscriptions": "Subscriptions",
+    "unread": "Unread"
+  },
+  "fritzbox": {
+    "connectionStatus": "Status",
+    "connectionStatusUnconfigured": "Unconfigured",
+    "connectionStatusConnecting": "Connecting",
+    "connectionStatusAuthenticating": "Authenticating",
+    "connectionStatusPendingDisconnect": "Pending Disconnect",
+    "connectionStatusDisconnecting": "Disconnecting",
+    "connectionStatusDisconnected": "Disconnected",
+    "connectionStatusConnected": "Connected",
+    "uptime": "Uptime",
+    "maxDown": "Max. Down",
+    "maxUp": "Max. Up",
+    "down": "Down",
+    "up": "Up",
+    "received": "Received",
+    "sent": "Sent",
+    "externalIPAddress": "Ext. IP",
+    "externalIPv6Address": "Ext. IPv6",
+    "externalIPv6Prefix": "Ext. IPv6-Prefix"
+  },
+  "caddy": {
+    "upstreams": "Upstreams",
+    "requests": "Current requests",
+    "requests_failed": "Failed requests"
+  },
+  "changedetectionio": {
+    "totalObserved": "Total Observed",
+    "diffsDetected": "Diffs Detected"
+  },
+  "channelsdvrserver": {
+    "shows": "Shows",
+    "recordings": "Recordings",
+    "scheduled": "Scheduled",
+    "passes": "Passes"
+  },
+  "tautulli": {
+    "playing": "Playing",
+    "transcoding": "Transcoding",
+    "bitrate": "Bitrate",
+    "no_active": "No Active Streams",
+    "plex_connection_error": "Check Plex Connection"
+  },
+  "tracearr": {
+    "no_active": "No Active Streams",
+    "streams": "Streams",
+    "transcodes": "Transcodes",
+    "directplay": "Direct Play",
+    "bitrate": "Bitrate"
+  },
+  "omada": {
+    "connectedAp": "Connected APs",
+    "activeUser": "Active devices",
+    "alerts": "Alerts",
+    "connectedGateways": "Connected gateways",
+    "connectedSwitches": "Connected switches"
+  },
+  "nzbget": {
+    "rate": "Rate",
+    "remaining": "Remaining",
+    "downloaded": "Downloaded"
+  },
+  "plex": {
+    "streams": "Active Streams",
+    "albums": "Albums",
+    "movies": "Movies",
+    "tv": "TV Shows"
+  },
+  "sabnzbd": {
+    "rate": "Rate",
+    "queue": "Queue",
+    "timeleft": "Time Left"
+  },
+  "rutorrent": {
+    "active": "Active",
+    "upload": "Upload",
+    "download": "Download"
+  },
+  "transmission": {
+    "download": "Download",
+    "upload": "Upload",
+    "leech": "Leech",
+    "seed": "Seed"
+  },
+  "qbittorrent": {
+    "download": "Download",
+    "upload": "Upload",
+    "leech": "Leech",
+    "seed": "Seed"
+  },
+  "qnap": {
+    "cpuUsage": "CPU Usage",
+    "memUsage": "MEM Usage",
+    "systemTempC": "System Temp",
+    "poolUsage": "Pool Usage",
+    "volumeUsage": "Volume Usage",
+    "invalid": "Invalid"
+  },
+  "deluge": {
+    "download": "Download",
+    "upload": "Upload",
+    "leech": "Leech",
+    "seed": "Seed"
+  },
+  "develancacheui": {
+    "cachehitbytes": "Cache Hit Bytes",
+    "cachemissbytes": "Cache Miss Bytes"
+  },
+  "downloadstation": {
+    "download": "Download",
+    "upload": "Upload",
+    "leech": "Leech",
+    "seed": "Seed"
+  },
+  "sonarr": {
+    "wanted": "Wanted",
+    "queued": "Queued",
+    "series": "Series",
+    "queue": "Queue",
+    "unknown": "Unknown"
+  },
+  "radarr": {
+    "wanted": "Wanted",
+    "missing": "Missing",
+    "queued": "Queued",
+    "movies": "Movies",
+    "queue": "Queue",
+    "unknown": "Unknown"
+  },
+  "lidarr": {
+    "wanted": "Wanted",
+    "queued": "Queued",
+    "artists": "Artists"
+  },
+  "readarr": {
+    "wanted": "Wanted",
+    "queued": "Queued",
+    "books": "Books"
+  },
+  "bazarr": {
+    "missingEpisodes": "Missing Episodes",
+    "missingMovies": "Missing Movies"
+  },
+  "ombi": {
+    "pending": "Pending",
+    "approved": "Approved",
+    "available": "Available"
+  },
+  "seerr": {
+    "pending": "Pending",
+    "approved": "Approved",
+    "available": "Available",
+    "completed": "Completed",
+    "processing": "Processing",
+    "issues": "Open Issues"
+  },
+  "netalertx": {
+    "total": "Total",
+    "connected": "Connected",
+    "new_devices": "New Devices",
+    "down_alerts": "Down Alerts"
+  },
+  "pihole": {
+    "queries": "Queries",
+    "blocked": "Blocked",
+    "blocked_percent": "Blocked %",
+    "gravity": "Gravity"
+  },
+  "adguard": {
+    "queries": "Queries",
+    "blocked": "Blocked",
+    "filtered": "Filtered",
+    "latency": "Latency"
+  },
+  "speedtest": {
+    "upload": "Upload",
+    "download": "Download",
+    "ping": "Ping"
+  },
+  "portainer": {
+    "running": "Running",
+    "stopped": "Stopped",
+    "total": "Total"
+  },
+  "suwayomi": {
+    "download": "Downloaded",
+    "nondownload": "Non-Downloaded",
+    "read": "Read",
+    "unread": "Unread",
+    "downloadedread": "Downloaded & Read",
+    "downloadedunread": "Downloaded & Unread",
+    "nondownloadedread": "Non-Downloaded & Read",
+    "nondownloadedunread": "Non-Downloaded & Unread"
+  },
+  "tailscale": {
+    "address": "Address",
+    "expires": "Expires",
+    "never": "Never",
+    "last_seen": "Last Seen",
+    "now": "Now",
+    "years": "{{number}}y",
+    "weeks": "{{number}}w",
+    "days": "{{number}}d",
+    "hours": "{{number}}h",
+    "minutes": "{{number}}m",
+    "seconds": "{{number}}s",
+    "ago": "{{value}} Ago"
+  },
+  "technitium": {
+    "totalQueries": "Queries",
+    "totalNoError": "Success",
+    "totalServerFailure": "Failures",
+    "totalNxDomain": "NX Domains",
+    "totalRefused": "Refused",
+    "totalAuthoritative": "Authoritative",
+    "totalRecursive": "Recursive",
+    "totalCached": "Cached",
+    "totalBlocked": "Blocked",
+    "totalDropped": "Dropped",
+    "totalClients": "Clients"
+  },
+  "tdarr": {
+    "queue": "Queue",
+    "processed": "Processed",
+    "errored": "Errored",
+    "saved": "Saved"
+  },
+  "traefik": {
+    "routers": "Routers",
+    "services": "Services",
+    "middleware": "Middleware"
+  },
+  "trilium": {
+    "version": "Version",
+    "notesCount": "Notes",
+    "dbSize": "Database Size",
+    "unknown": "Unknown"
+  },
+  "navidrome": {
+    "nothing_streaming": "No Active Streams",
+    "please_wait": "Please Wait"
+  },
+  "npm": {
+    "enabled": "Enabled",
+    "disabled": "Disabled",
+    "total": "Total"
+  },
+  "coinmarketcap": {
+    "configure": "Configure one or more crypto currencies to track",
+    "1hour": "1 Hour",
+    "1day": "1 Day",
+    "7days": "7 Days",
+    "30days": "30 Days"
+  },
+  "gotify": {
+    "apps": "Applications",
+    "clients": "Clients",
+    "messages": "Messages"
+  },
+  "prowlarr": {
+    "enableIndexers": "Indexers",
+    "numberOfGrabs": "Grabs",
+    "numberOfQueries": "Queries",
+    "numberOfFailGrabs": "Fail Grabs",
+    "numberOfFailQueries": "Fail Queries"
+  },
+  "jackett": {
+    "configured": "Configured",
+    "errored": "Errored"
+  },
+  "strelaysrv": {
+    "numActiveSessions": "Sessions",
+    "numConnections": "Connections",
+    "dataRelayed": "Relayed",
+    "transferRate": "Rate"
+  },
+  "mastodon": {
+    "user_count": "Users",
+    "status_count": "Posts",
+    "domain_count": "Domains"
+  },
+  "medusa": {
+    "wanted": "Wanted",
+    "queued": "Queued",
+    "series": "Series"
+  },
+  "minecraft": {
+    "players": "Players",
+    "version": "Version",
+    "status": "Status",
+    "up": "Online",
+    "down": "Offline"
+  },
+  "miniflux": {
+    "read": "Read",
+    "unread": "Unread"
+  },
+  "authentik": {
+    "users": "Users",
+    "loginsLast24H": "Logins (24h)",
+    "failedLoginsLast24H": "Failed Logins (24h)"
+  },
+  "proxmox": {
+    "mem": "MEM",
+    "cpu": "CPU",
+    "lxc": "LXC",
+    "vms": "VMs"
+  },
+  "glances": {
+    "cpu": "CPU",
+    "load": "Load",
+    "wait": "Please wait",
+    "temp": "TEMP",
+    "_temp": "Temp",
+    "warn": "Warn",
+    "uptime": "UP",
+    "total": "Total",
+    "free": "Free",
+    "used": "Used",
+    "days": "d",
+    "hours": "h",
+    "crit": "Crit",
+    "read": "Read",
+    "write": "Write",
+    "gpu": "GPU",
+    "mem": "Mem",
+    "swap": "Swap"
+  },
+  "quicklaunch": {
+    "bookmark": "Bookmark",
+    "service": "Service",
+    "search": "Search",
+    "custom": "Custom",
+    "visit": "Visit",
+    "url": "URL",
+    "searchsuggestion": "Suggestion"
+  },
+  "wmo": {
+    "0-day": "Sunny",
+    "0-night": "Clear",
+    "1-day": "Mainly Sunny",
+    "1-night": "Mainly Clear",
+    "2-day": "Partly Cloudy",
+    "2-night": "Partly Cloudy",
+    "3-day": "Cloudy",
+    "3-night": "Cloudy",
+    "45-day": "Foggy",
+    "45-night": "Foggy",
+    "48-day": "Foggy",
+    "48-night": "Foggy",
+    "51-day": "Light Drizzle",
+    "51-night": "Light Drizzle",
+    "53-day": "Drizzle",
+    "53-night": "Drizzle",
+    "55-day": "Heavy Drizzle",
+    "55-night": "Heavy Drizzle",
+    "56-day": "Light Freezing Drizzle",
+    "56-night": "Light Freezing Drizzle",
+    "57-day": "Freezing Drizzle",
+    "57-night": "Freezing Drizzle",
+    "61-day": "Light Rain",
+    "61-night": "Light Rain",
+    "63-day": "Rain",
+    "63-night": "Rain",
+    "65-day": "Heavy Rain",
+    "65-night": "Heavy Rain",
+    "66-day": "Freezing Rain",
+    "66-night": "Freezing Rain",
+    "67-day": "Freezing Rain",
+    "67-night": "Freezing Rain",
+    "71-day": "Light Snow",
+    "71-night": "Light Snow",
+    "73-day": "Snow",
+    "73-night": "Snow",
+    "75-day": "Heavy Snow",
+    "75-night": "Heavy Snow",
+    "77-day": "Snow Grains",
+    "77-night": "Snow Grains",
+    "80-day": "Light Showers",
+    "80-night": "Light Showers",
+    "81-day": "Showers",
+    "81-night": "Showers",
+    "82-day": "Heavy Showers",
+    "82-night": "Heavy Showers",
+    "85-day": "Snow Showers",
+    "85-night": "Snow Showers",
+    "86-day": "Snow Showers",
+    "86-night": "Snow Showers",
+    "95-day": "Thunderstorm",
+    "95-night": "Thunderstorm",
+    "96-day": "Thunderstorm With Hail",
+    "96-night": "Thunderstorm With Hail",
+    "99-day": "Thunderstorm With Hail",
+    "99-night": "Thunderstorm With Hail"
+  },
+  "homebridge": {
+    "available_update": "System",
+    "updates": "Updates",
+    "update_available": "Update Available",
+    "up_to_date": "Up to Date",
+    "child_bridges": "Child Bridges",
+    "child_bridges_status": "{{ok}}/{{total}}",
+    "up": "Up",
+    "pending": "Pending",
+    "down": "Down",
+    "ok": "Ok"
+  },
+  "healthchecks": {
+    "new": "New",
+    "up": "Up",
+    "grace": "In Grace Period",
+    "down": "Down",
+    "paused": "Paused",
+    "status": "Status",
+    "last_ping": "Last Ping",
+    "never": "No pings yet"
+  },
+  "watchtower": {
+    "containers_scanned": "Scanned",
+    "containers_updated": "Updated",
+    "containers_failed": "Failed"
+  },
+  "autobrr": {
+    "approvedPushes": "Approved",
+    "rejectedPushes": "Rejected",
+    "filters": "Filters",
+    "indexers": "Indexers"
+  },
+  "tubearchivist": {
+    "downloads": "Queue",
+    "videos": "Videos",
+    "channels": "Channels",
+    "playlists": "Playlists"
+  },
+  "truenas": {
+    "load": "System Load",
+    "uptime": "Uptime",
+    "alerts": "Alerts"
+  },
+  "pyload": {
+    "speed": "Speed",
+    "active": "Active",
+    "queue": "Queue",
+    "total": "Total"
+  },
+  "gluetun": {
+    "public_ip": "Public IP",
+    "region": "Region",
+    "country": "Country",
+    "port_forwarded": "Port Forwarded"
+  },
+  "hdhomerun": {
+    "channels": "Channels",
+    "hd": "HD",
+    "tunerCount": "Tuners",
+    "channelNumber": "Channel",
+    "channelNetwork": "Network",
+    "signalStrength": "Strength",
+    "signalQuality": "Quality",
+    "symbolQuality": "Quality",
+    "networkRate": "Bitrate",
+    "clientIP": "Client"
+  },
+  "scrutiny": {
+    "passed": "Passed",
+    "failed": "Failed",
+    "unknown": "Unknown"
+  },
+  "paperlessngx": {
+    "inbox": "Inbox",
+    "total": "Total"
+  },
+  "pangolin": {
+    "orgs": "Orgs",
+    "sites": "Sites",
+    "resources": "Resources",
+    "targets": "Targets",
+    "traffic": "Traffic",
+    "in": "In",
+    "out": "Out"
+  },
+  "peanut": {
+    "battery_charge": "Battery Charge",
+    "ups_load": "UPS Load",
+    "ups_status": "UPS Status",
+    "online": "Online",
+    "on_battery": "On Battery",
+    "low_battery": "Low Battery"
+  },
+  "nextdns": {
+    "wait": "Please Wait",
+    "no_devices": "No Device Data Received"
+  },
+  "mikrotik": {
+    "cpuLoad": "CPU Load",
+    "memoryUsed": "Memory Used",
+    "uptime": "Uptime",
+    "numberOfLeases": "Leases"
+  },
+  "xteve": {
+    "streams_all": "All Streams",
+    "streams_active": "Active Streams",
+    "streams_xepg": "XEPG Channels"
+  },
+  "opendtu": {
+    "yieldDay": "Today",
+    "absolutePower": "Power",
+    "relativePower": "Power %",
+    "limit": "Limit"
+  },
+  "opnsense": {
+    "cpu": "CPU Load",
+    "memory": "Active Memory",
+    "wanUpload": "WAN Upload",
+    "wanDownload": "WAN Download"
+  },
+  "moonraker": {
+    "printer_state": "Printer State",
+    "print_status": "Print Status",
+    "print_progress": "Progress",
+    "layers": "Layers"
+  },
+  "octoprint": {
+    "printer_state": "Status",
+    "temp_tool": "Tool temp",
+    "temp_bed": "Bed temp",
+    "job_completion": "Completion"
+  },
+  "cloudflared": {
+    "origin_ip": "Origin IP",
+    "status": "Status"
+  },
+  "pfsense": {
+    "load": "Load Avg",
+    "memory": "Mem Usage",
+    "wanStatus": "WAN Status",
+    "up": "Up",
+    "down": "Down",
+    "temp": "Temp",
+    "disk": "Disk Usage",
+    "wanIP": "WAN IP"
+  },
+  "proxmoxbackupserver": {
+    "datastore_usage": "Datastore",
+    "failed_tasks_24h": "Failed Tasks 24h",
+    "cpu_usage": "CPU",
+    "memory_usage": "Memory"
+  },
+  "immich": {
+    "users": "Users",
+    "photos": "Photos",
+    "videos": "Videos",
+    "storage": "Storage"
+  },
+  "uptimekuma": {
+    "up": "Sites Up",
+    "down": "Sites Down",
+    "uptime": "Uptime",
+    "incident": "Incident",
+    "m": "m"
+  },
+  "atsumeru": {
+    "series": "Series",
+    "archives": "Archives",
+    "chapters": "Chapters",
+    "categories": "Categories"
+  },
+  "komga": {
+    "libraries": "Libraries",
+    "series": "Series",
+    "books": "Books"
+  },
+  "diskstation": {
+    "days": "Days",
+    "uptime": "Uptime",
+    "volumeAvailable": "Available"
+  },
+  "dispatcharr": {
+    "channels": "Channels",
+    "streams": "Streams"
+  },
+  "mylar": {
+    "series": "Series",
+    "issues": "Issues",
+    "wanted": "Wanted"
+  },
+  "photoprism": {
+    "albums": "Albums",
+    "photos": "Photos",
+    "videos": "Videos",
+    "people": "People"
+  },
+  "fileflows": {
+    "queue": "Queue",
+    "processing": "Processing",
+    "processed": "Processed",
+    "time": "Time"
+  },
+  "firefly": {
+    "networth": "Net Worth",
+    "budget": "Budget"
+  },
+  "grafana": {
+    "dashboards": "Dashboards",
+    "datasources": "Data Sources",
+    "totalalerts": "Total Alerts",
+    "alertstriggered": "Alerts Triggered"
+  },
+  "nextcloud": {
+    "cpuload": "Cpu Load",
+    "memoryusage": "Memory Usage",
+    "freespace": "Free Space",
+    "activeusers": "Active Users",
+    "numfiles": "Files",
+    "numshares": "Shared Items"
+  },
+  "kopia": {
+    "status": "Status",
+    "size": "Size",
+    "lastrun": "Last Run",
+    "nextrun": "Next Run",
+    "failed": "Failed"
+  },
+  "unmanic": {
+    "active_workers": "Active Workers",
+    "total_workers": "Total Workers",
+    "records_total": "Queue Length"
+  },
+  "pterodactyl": {
+    "servers": "Servers",
+    "nodes": "Nodes"
+  },
+  "prometheus": {
+    "targets_up": "Targets Up",
+    "targets_down": "Targets Down",
+    "targets_total": "Total Targets"
+  },
+  "gatus": {
+    "up": "Sites Up",
+    "down": "Sites Down",
+    "uptime": "Uptime"
+  },
+  "ghostfolio": {
+    "gross_percent_today": "Today",
+    "gross_percent_1y": "One year",
+    "gross_percent_max": "All time",
+    "net_worth": "Net Worth"
+  },
+  "audiobookshelf": {
+    "podcasts": "Podcasts",
+    "books": "Books",
+    "podcastsDuration": "Duration",
+    "booksDuration": "Duration"
+  },
+  "homeassistant": {
+    "people_home": "People Home",
+    "lights_on": "Lights On",
+    "switches_on": "Switches On"
+  },
+  "whatsupdocker": {
+    "monitoring": "Monitoring",
+    "updates": "Updates"
+  },
+  "calibreweb": {
+    "books": "Books",
+    "authors": "Authors",
+    "categories": "Categories",
+    "series": "Series"
+  },
+  "booklore": {
+    "libraries": "Libraries",
+    "books": "Books",
+    "reading": "Reading",
+    "finished": "Finished"
+  },
+  "jdownloader": {
+    "downloadCount": "Queue",
+    "downloadBytesRemaining": "Remaining",
+    "downloadTotalBytes": "Size",
+    "downloadSpeed": "Speed"
+  },
+  "kavita": {
+    "seriesCount": "Series",
+    "totalFiles": "Files"
+  },
+  "azuredevops": {
+    "result": "Result",
+    "status": "Status",
+    "buildId": "Build ID",
+    "succeeded": "Succeeded",
+    "notStarted": "Not Started",
+    "failed": "Failed",
+    "canceled": "Canceled",
+    "inProgress": "In Progress",
+    "totalPrs": "Total PRs",
+    "myPrs": "My PRs",
+    "approved": "Approved"
+  },
+  "gamedig": {
+    "status": "Status",
+    "online": "Online",
+    "offline": "Offline",
+    "name": "Name",
+    "map": "Map",
+    "currentPlayers": "Current players",
+    "players": "Players",
+    "maxPlayers": "Max players",
+    "bots": "Bots",
+    "ping": "Ping"
+  },
+  "urbackup": {
+    "ok": "Ok",
+    "errored": "Errors",
+    "noRecent": "Out of Date",
+    "totalUsed": "Used Storage"
+  },
+  "mealie": {
+    "recipes": "Recipes",
+    "users": "Users",
+    "categories": "Categories",
+    "tags": "Tags"
+  },
+  "openmediavault": {
+    "downloading": "Downloading",
+    "total": "Total",
+    "running": "Running",
+    "stopped": "Stopped",
+    "passed": "Passed",
+    "failed": "Failed"
+  },
+  "openwrt": {
+    "uptime": "Uptime",
+    "cpuLoad": "CPU Load Avg (5m)",
+    "up": "Up",
+    "down": "Down",
+    "bytesTx": "Transmitted",
+    "bytesRx": "Received"
+  },
+  "uptimerobot": {
+    "status": "Status",
+    "uptime": "Uptime",
+    "lastDown": "Last Downtime",
+    "downDuration": "Downtime Duration",
+    "sitesUp": "Sites Up",
+    "sitesDown": "Sites Down",
+    "paused": "Paused",
+    "notyetchecked": "Not Yet Checked",
+    "up": "Up",
+    "seemsdown": "Seems Down",
+    "down": "Down",
+    "unknown": "Unknown"
+  },
+  "calendar": {
+    "inCinemas": "In cinemas",
+    "physicalRelease": "Physical release",
+    "digitalRelease": "Digital release",
+    "noEventsToday": "No events for today!",
+    "noEventsFound": "No events found",
+    "errorWhenLoadingData": "Error when loading calendar data"
+  },
+  "romm": {
+    "platforms": "Platforms",
+    "totalRoms": "Games",
+    "saves": "Saves",
+    "states": "States",
+    "screenshots": "Screenshots",
+    "totalfilesize": "Total Size"
+  },
+  "mailcow": {
+    "domains": "Domains",
+    "mailboxes": "Mailboxes",
+    "mails": "Mails",
+    "storage": "Storage"
+  },
+  "netdata": {
+    "warnings": "Warnings",
+    "criticals": "Criticals"
+  },
+  "plantit": {
+    "events": "Events",
+    "plants": "Plants",
+    "photos": "Photos",
+    "species": "Species"
+  },
+  "gitea": {
+    "notifications": "Notifications",
+    "issues": "Issues",
+    "pulls": "Pull Requests",
+    "repositories": "Repositories"
+  },
+  "stash": {
+    "scenes": "Scenes",
+    "scenesPlayed": "Scenes Played",
+    "playCount": "Total Plays",
+    "playDuration": "Time Watched",
+    "sceneSize": "Scenes Size",
+    "sceneDuration": "Scenes Duration",
+    "images": "Images",
+    "imageSize": "Images Size",
+    "galleries": "Galleries",
+    "performers": "Performers",
+    "studios": "Studios",
+    "movies": "Movies",
+    "tags": "Tags",
+    "oCount": "O Count"
+  },
+  "tandoor": {
+    "users": "Users",
+    "recipes": "Recipes",
+    "keywords": "Keywords"
+  },
+  "homebox": {
+    "items": "Items",
+    "totalWithWarranty": "With Warranty",
+    "locations": "Locations",
+    "labels": "Labels",
+    "users": "Users",
+    "totalValue": "Total Value"
+  },
+  "crowdsec": {
+    "alerts": "Alerts",
+    "bans": "Bans"
+  },
+  "wgeasy": {
+    "connected": "Connected",
+    "enabled": "Enabled",
+    "disabled": "Disabled",
+    "total": "Total"
+  },
+  "swagdashboard": {
+    "proxied": "Proxied",
+    "auth": "With Auth",
+    "outdated": "Outdated",
+    "banned": "Banned"
+  },
+  "myspeed": {
+    "ping": "Ping",
+    "download": "Download",
+    "upload": "Upload"
+  },
+  "stocks": {
+    "stocks": "Stocks",
+    "loading": "Loading",
+    "open": "Open - US Market",
+    "closed": "Closed - US Market",
+    "invalidConfiguration": "Invalid Configuration"
+  },
+  "frigate": {
+    "cameras": "Cameras",
+    "uptime": "Uptime",
+    "version": "Version"
+  },
+  "linkwarden": {
+    "links": "Links",
+    "collections": "Collections",
+    "tags": "Tags"
+  },
+  "zabbix": {
+    "unclassified": "Not classified",
+    "information": "Information",
+    "warning": "Warning",
+    "average": "Average",
+    "high": "High",
+    "disaster": "Disaster"
+  },
+  "lubelogger": {
+    "vehicle": "Vehicle",
+    "vehicles": "Vehicles",
+    "serviceRecords": "Service Records",
+    "reminders": "Reminders",
+    "nextReminder": "Next Reminder",
+    "none": "None"
+  },
+  "vikunja": {
+    "projects": "Active Projects",
+    "tasks7d": "Tasks Due This Week",
+    "tasksOverdue": "Overdue Tasks",
+    "tasksInProgress": "Tasks In Progress"
+  },
+  "headscale": {
+    "name": "Name",
+    "address": "Address",
+    "last_seen": "Last Seen",
+    "status": "Status",
+    "online": "Online",
+    "offline": "Offline"
+  },
+  "beszel": {
+    "name": "Name",
+    "systems": "Systems",
+    "up": "Up",
+    "down": "Down",
+    "paused": "Paused",
+    "pending": "Pending",
+    "status": "Status",
+    "updated": "Updated",
+    "cpu": "CPU",
+    "memory": "MEM",
+    "disk": "Disk",
+    "network": "NET"
+  },
+  "argocd": {
+    "apps": "Apps",
+    "synced": "Synced",
+    "outOfSync": "Out Of Sync",
+    "healthy": "Healthy",
+    "degraded": "Degraded",
+    "progressing": "Progressing",
+    "missing": "Missing",
+    "suspended": "Suspended"
+  },
+  "spoolman": {
+    "loading": "Loading"
+  },
+  "gitlab": {
+    "groups": "Groups",
+    "issues": "Issues",
+    "merges": "Merge Requests",
+    "projects": "Projects"
+  },
+  "apcups": {
+    "status": "Status",
+    "load": "Load",
+    "bcharge": "Battery Charge",
+    "timeleft": "Time Left"
+  },
+  "karakeep": {
+    "bookmarks": "Bookmarks",
+    "favorites": "Favorites",
+    "archived": "Archived",
+    "highlights": "Highlights",
+    "lists": "Lists",
+    "tags": "Tags"
+  },
+  "slskd": {
+    "slskStatus": "Network",
+    "connected": "Connected",
+    "disconnected": "Disconnected",
+    "updateStatus": "Update",
+    "update_yes": "Available",
+    "update_no": "Up to Date",
+    "downloads": "Downloads",
+    "uploads": "Uploads",
+    "sharedFiles": "Files"
+  },
+  "jellystat": {
+    "songs": "Songs",
+    "movies": "Movies",
+    "episodes": "Episodes",
+    "other": "Other"
+  },
+  "checkmk": {
+    "serviceErrors": "Service issues",
+    "hostErrors": "Host issues"
+  },
+  "komodo": {
+    "total": "Total",
+    "running": "Running",
+    "stopped": "Stopped",
+    "down": "Down",
+    "unhealthy": "Unhealthy",
+    "unknown": "Unknown",
+    "servers": "Servers",
+    "stacks": "Stacks",
+    "containers": "Containers"
+  },
+  "filebrowser": {
+    "available": "Available",
+    "used": "Used",
+    "total": "Total"
+  },
+  "wallos": {
+    "activeSubscriptions": "Subscriptions",
+    "thisMonthlyCost": "This Month",
+    "nextMonthlyCost": "Next Month",
+    "previousMonthlyCost": "Prev. Month",
+    "nextRenewingSubscription": "Next Payment"
+  },
+  "unraid": {
+    "STARTED": "Started",
+    "STOPPED": "Stopped",
+    "NEW_ARRAY": "New Array",
+    "RECON_DISK": "Reconstructing Disk",
+    "DISABLE_DISK": "Disk Disabled",
+    "SWAP_DSBL": "Swap Disable",
+    "INVALID_EXPANSION": "Invalid Expansion",
+    "PARITY_NOT_BIGGEST": "Parity Not Biggest",
+    "TOO_MANY_MISSING_DISKS": "Too Many Missing Disks",
+    "NEW_DISK_TOO_SMALL": "New Disk Too Small",
+    "NO_DATA_DISKS": "No Data Disks",
+    "notifications": "Notifications",
+    "status": "Status",
+    "cpu": "CPU",
+    "memoryUsed": "Memory Used",
+    "memoryAvailable": "Memory Available",
+    "arrayUsed": "Array Used",
+    "arrayFree": "Array Free",
+    "poolUsed": "{{pool}} Used",
+    "poolFree": "{{pool}} Free"
+  },
+  "backrest": {
+    "num_plans": "Plans",
+    "num_success_30": "Successes",
+    "num_failure_30": "Failures",
+    "num_success_latest": "Succeeding",
+    "num_failure_latest": "Failing",
+    "bytes_added_30": "Bytes Added"
+  },
+  "yourspotify": {
+    "songs": "Songs",
+    "time": "Time",
+    "artists": "Artists"
+  },
+  "arcane": {
+    "containers": "Containers",
+    "images": "Images",
+    "image_updates": "Image Updates",
+    "images_unused": "Unused",
+    "environment_required": "Environment ID Required"
+  },
+  "dockhand": {
+    "running": "Running",
+    "stopped": "Stopped",
+    "cpu": "CPU",
+    "memory": "Memory",
+    "images": "Images",
+    "volumes": "Volumes",
+    "events_today": "Events Today",
+    "pending_updates": "Pending Updates",
+    "stacks": "Stacks",
+    "paused": "Paused",
+    "total": "Total",
+    "environment_not_found": "Environment Not Found"
+  },
+  "sparkyfitness": {
+    "eaten": "Eaten",
+    "burned": "Burned",
+    "remaining": "Remaining",
+    "steps": "Steps"
+  },
+  "snippets": {
+    "copy": "Copy to clipboard",
+    "copied": "Copied!"
+  }
 }

--- a/src/components/widgets/snippets/snippets.jsx
+++ b/src/components/widgets/snippets/snippets.jsx
@@ -1,0 +1,78 @@
+import { useTranslation } from "next-i18next";
+import { useCallback, useState } from "react";
+import { MdCheck, MdContentCopy } from "react-icons/md";
+
+import Container from "../widget/container";
+import Raw from "../widget/raw";
+
+function SnippetRow({ command, description }) {
+  const { t } = useTranslation();
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(command);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // clipboard API may not be available (e.g. non-HTTPS)
+    }
+  }, [command]);
+
+  return (
+    <div className="flex flex-row items-center gap-2 py-0.5 group">
+      <code className="text-xs font-mono text-theme-800 dark:text-theme-200 truncate flex-1" title={command}>
+        {command}
+      </code>
+      {description && (
+        <span className="text-xs text-theme-600 dark:text-theme-400 whitespace-nowrap hidden sm:inline">
+          {description}
+        </span>
+      )}
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="flex-none p-0.5 rounded opacity-0 group-hover:opacity-100 transition-opacity text-theme-600 dark:text-theme-400 hover:text-theme-800 dark:hover:text-theme-200"
+        title={copied ? t("snippets.copied") : t("snippets.copy")}
+        aria-label={copied ? t("snippets.copied") : t("snippets.copy")}
+      >
+        {copied ? <MdCheck className="w-3.5 h-3.5 text-green-500" /> : <MdContentCopy className="w-3.5 h-3.5" />}
+      </button>
+    </div>
+  );
+}
+
+function SnippetGroup({ name, items }) {
+  return (
+    <div className="mb-2 last:mb-0">
+      {name && (
+        <div className="text-xs font-semibold text-theme-700 dark:text-theme-300 mb-0.5 uppercase tracking-wide">
+          {name}
+        </div>
+      )}
+      {items.map((item) => (
+        <SnippetRow key={item.command} command={item.command} description={item.description} />
+      ))}
+    </div>
+  );
+}
+
+export default function Snippets({ options }) {
+  const { groups } = options;
+
+  if (!groups || groups.length === 0) {
+    return null;
+  }
+
+  return (
+    <Container options={options} additionalClassNames="information-widget-snippets">
+      <Raw>
+        <div className="flex flex-col w-full p-1">
+          {groups.map((group) => (
+            <SnippetGroup key={group.name || group.items?.[0]?.command} name={group.name} items={group.items || []} />
+          ))}
+        </div>
+      </Raw>
+    </Container>
+  );
+}

--- a/src/components/widgets/snippets/snippets.test.jsx
+++ b/src/components/widgets/snippets/snippets.test.jsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+
+import { fireEvent, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "test-utils/render-with-providers";
+
+import Snippets from "./snippets";
+
+describe("components/widgets/snippets", () => {
+  it("renders snippet groups with commands", () => {
+    const options = {
+      groups: [
+        {
+          name: "Docker",
+          items: [
+            { command: "docker ps", description: "List containers" },
+            { command: "docker compose up -d", description: "Start services" },
+          ],
+        },
+      ],
+    };
+
+    renderWithProviders(<Snippets options={options} />, { settings: { target: "_self" } });
+
+    expect(screen.getByText("Docker")).toBeInTheDocument();
+    expect(screen.getByText("docker ps")).toBeInTheDocument();
+    expect(screen.getByText("docker compose up -d")).toBeInTheDocument();
+    expect(screen.getByText("List containers")).toBeInTheDocument();
+  });
+
+  it("renders multiple groups", () => {
+    const options = {
+      groups: [
+        { name: "Group A", items: [{ command: "cmd-a" }] },
+        { name: "Group B", items: [{ command: "cmd-b" }] },
+      ],
+    };
+
+    renderWithProviders(<Snippets options={options} />, { settings: { target: "_self" } });
+
+    expect(screen.getByText("Group A")).toBeInTheDocument();
+    expect(screen.getByText("Group B")).toBeInTheDocument();
+    expect(screen.getByText("cmd-a")).toBeInTheDocument();
+    expect(screen.getByText("cmd-b")).toBeInTheDocument();
+  });
+
+  it("copies command to clipboard on button click", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    const options = {
+      groups: [{ name: "Test", items: [{ command: "echo hello", description: "Say hello" }] }],
+    };
+
+    renderWithProviders(<Snippets options={options} />, { settings: { target: "_self" } });
+
+    const copyButton = screen.getByRole("button");
+    fireEvent.click(copyButton);
+
+    expect(writeText).toHaveBeenCalledWith("echo hello");
+  });
+
+  it("renders nothing when groups is empty", () => {
+    const { container } = renderWithProviders(<Snippets options={{ groups: [] }} />, {
+      settings: { target: "_self" },
+    });
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders snippets without group name", () => {
+    const options = {
+      groups: [{ items: [{ command: "whoami" }] }],
+    };
+
+    renderWithProviders(<Snippets options={options} />, { settings: { target: "_self" } });
+
+    expect(screen.getByText("whoami")).toBeInTheDocument();
+  });
+});

--- a/src/components/widgets/widget.jsx
+++ b/src/components/widgets/widget.jsx
@@ -15,6 +15,7 @@ const widgetMappings = {
   longhorn: dynamic(() => import("components/widgets/longhorn/longhorn")),
   kubernetes: dynamic(() => import("components/widgets/kubernetes/kubernetes")),
   stocks: dynamic(() => import("components/widgets/stocks/stocks")),
+  snippets: dynamic(() => import("components/widgets/snippets/snippets")),
 };
 
 export default function Widget({ widget, style }) {


### PR DESCRIPTION
## Summary

- Adds a new **Snippets** information widget that displays configurable command snippets with one-click copy-to-clipboard
- Useful for homelab admins who frequently reference CLI commands, SSH connections, API endpoints, or other text they need to quickly copy
- Uses the Clipboard API (`navigator.clipboard.writeText`) with visual feedback (checkmark icon for 2s after copy)

## Configuration

```yaml
- type: snippets
  groups:
    - name: Docker
      items:
        - command: docker ps -a
          description: List all containers
        - command: docker compose up -d
          description: Start services
    - name: SSH
      items:
        - command: ssh user@server
```

## Implementation details

- New widget component at `src/components/widgets/snippets/snippets.jsx`
- Follows existing widget patterns: `Container` + `Raw` wrapper, `useTranslation` for i18n
- Copy button appears on hover (opacity transition), shows green checkmark after successful copy
- Supports grouped snippets with optional group names and optional descriptions per item
- Gracefully handles environments where Clipboard API is unavailable (non-HTTPS)
- 5 unit tests covering rendering, grouping, clipboard interaction, empty state, and nameless groups
- Full documentation page at `docs/widgets/info/snippets.md`
- i18n strings added to `public/locales/en/common.json`

## Related

- Discussion #4578 ("Copy to clipboard") — this widget provides a structured way to display and copy commands/text

## Test plan

- [x] All 1333 existing tests pass (524 test files)
- [x] 5 new tests for the snippets widget pass
- [x] ESLint passes with no warnings
- [x] Widget renders correctly with single and multiple groups
- [x] Copy to clipboard works (Clipboard API mock in tests)
- [x] Empty/missing groups renders nothing (no crash)
- [ ] Manual testing on a Homepage instance with the widget configured

## AI Disclosure

This PR was developed with assistance from Claude (Anthropic). The implementation follows existing Homepage widget patterns and conventions observed in the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)