### PR TITLE
Tweak: sanitize calendar integration URLs from markup

### DIFF
--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -619,7 +619,19 @@ export function cleanServiceGroups(groups) {
           if (refreshInterval) widget.refreshInterval = refreshInterval;
         }
         if (type === "calendar") {
-          if (integrations) widget.integrations = integrations;
+          if (integrations) {
+            if (Array.isArray(integrations)) {
+              widget.integrations = integrations.map((integration) => {
+                if (!integration || typeof integration !== "object") {
+                  return integration;
+                }
+                const { url, ...integrationWithoutUrl } = integration;
+                return integrationWithoutUrl;
+              });
+            } else {
+              widget.integrations = integrations;
+            }
+          }
           if (firstDayInWeek) widget.firstDayInWeek = firstDayInWeek;
           if (view) widget.view = view;
           if (maxEvents) widget.maxEvents = maxEvents;

--- a/src/utils/config/service-helpers.test.js
+++ b/src/utils/config/service-helpers.test.js
@@ -369,6 +369,47 @@ describe("utils/config/service-helpers", () => {
     expect(widgets.find((w) => w.type === "lubelogger")).toEqual(expect.objectContaining({ vehicleID: 12 }));
   });
 
+  it("cleanServiceGroups removes calendar integration urls from frontend widget payload", async () => {
+    const mod = await import("./service-helpers");
+    const { cleanServiceGroups } = mod;
+
+    const rawGroups = [
+      {
+        name: "Core",
+        services: [
+          {
+            name: "Calendar",
+            weight: 100,
+            widgets: [
+              {
+                type: "calendar",
+                integrations: [
+                  {
+                    type: "ical",
+                    name: "EPL Fixtures",
+                    url: "https://calendar.google.com/calendar/ical/example/public/basic.ics",
+                    color: "purple",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        groups: [],
+      },
+    ];
+
+    const cleaned = cleanServiceGroups(rawGroups);
+    const calendarWidget = cleaned[0].services[0].widgets[0];
+    expect(calendarWidget.integrations).toEqual([
+      {
+        type: "ical",
+        name: "EPL Fixtures",
+        color: "purple",
+      },
+    ]);
+  });
+
   it("findGroupByName deep-searches and annotates parent", async () => {
     const mod = await import("./service-helpers");
     const { findGroupByName } = mod;


### PR DESCRIPTION
<!--
==== STOP ====================
======== STOP ================
============ STOP ============
================ STOP ========
==================== STOP ====

⚠️ Before opening this pull request please review the guidelines in the checklist below.

If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.
-->

## Proposed change

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

Closes #6426

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [ ] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] In the description above I have disclosed the use of AI tools in the coding of this PR.
