### PR TITLE
Feature:  UniFi Drive (UNAS) service widget

### DIFF
--- a/docs/widgets/services/unifi-drive.md
+++ b/docs/widgets/services/unifi-drive.md
@@ -1,0 +1,37 @@
+---
+title: UniFi Drive
+description: UniFi Drive Widget Configuration
+---
+
+Learn more about [UniFi Drive](https://ui.com/integrations/network-storage).
+
+## Configuration
+
+Displays storage statistics from your UniFi Network Attached Storage (UNAS) device.
+
+```yaml
+widget:
+  type: unifi_drive
+  url: https://unifi.host.or.ip
+  username: your_username
+  password: your_password
+```
+
+Allowed fields: `["url", "username", "password"]`
+
+!!! warning
+
+    Requires a local UniFi account with at least read privileges.
+
+!!! hint
+
+    If you receive an "API Error" with incorrect credentials, you may need to recreate the container or restart the service to clear the cache.
+
+## Fields
+
+The widget displays the following storage statistics:
+
+- `total` - Total storage capacity
+- `used` - Used storage amount
+- `available` - Free storage space
+- `status` - Health status (Healthy/Degraded)

--- a/docs/widgets/services/unifi-drive.md
+++ b/docs/widgets/services/unifi-drive.md
@@ -7,7 +7,9 @@ Learn more about [UniFi Drive](https://ui.com/integrations/network-storage).
 
 ## Configuration
 
-Displays storage statistics from your UniFi Network Attached Storage (UNAS) device.
+Displays storage statistics from your UniFi Network Attached Storage (UNAS) device. Requires a local UniFi account with at least read privileges.
+
+Allowed fields: `["total", "used", "available", "status"]`
 
 ```yaml
 widget:
@@ -17,21 +19,6 @@ widget:
   password: your_password
 ```
 
-Allowed fields: `["url", "username", "password"]`
-
-!!! warning
-
-    Requires a local UniFi account with at least read privileges.
-
 !!! hint
 
-    If you receive an "API Error" with incorrect credentials, you may need to recreate the container or restart the service to clear the cache.
-
-## Fields
-
-The widget displays the following storage statistics:
-
-- `total` - Total storage capacity
-- `used` - Used storage amount
-- `available` - Free storage space
-- `status` - Health status (Healthy/Degraded)
+    If you enter incorrect credentials and receive an "API Error", you may need to recreate the container or restart the service to clear the cache.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -171,6 +171,7 @@ nav:
           - widgets/services/truenas.md
           - widgets/services/tubearchivist.md
           - widgets/services/unifi-controller.md
+          - widgets/services/unifi-drive.md
           - widgets/services/unmanic.md
           - widgets/services/unraid.md
           - widgets/services/uptime-kuma.md

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -66,6 +66,15 @@
         "wait": "Please wait",
         "empty_data": "Subsystem status unknown"
     },
+    "unifi_drive": {
+        "total": "Total",
+        "used": "Used",
+        "available": "Available",
+        "status": "Status",
+        "healthy": "Healthy",
+        "degraded": "Degraded",
+        "no_data": "No storage data available"
+    },
     "docker": {
         "rx": "RX",
         "tx": "TX",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -67,10 +67,6 @@
         "empty_data": "Subsystem status unknown"
     },
     "unifi_drive": {
-        "total": "Total",
-        "used": "Used",
-        "available": "Available",
-        "status": "Status",
         "healthy": "Healthy",
         "degraded": "Degraded",
         "no_data": "No storage data available"

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -147,6 +147,7 @@ const components = {
   tubearchivist: dynamic(() => import("./tubearchivist/component")),
   truenas: dynamic(() => import("./truenas/component")),
   unifi: dynamic(() => import("./unifi/component")),
+  unifi_drive: dynamic(() => import("./unifi_drive/component")),
   unmanic: dynamic(() => import("./unmanic/component")),
   unraid: dynamic(() => import("./unraid/component")),
   uptimekuma: dynamic(() => import("./uptimekuma/component")),

--- a/src/widgets/unifi_drive/component.jsx
+++ b/src/widgets/unifi_drive/component.jsx
@@ -9,7 +9,7 @@ export default function Component({ service }) {
 
   const { widget } = service;
 
-  const { data: storageData, error: storageError } = useWidgetAPI(widget, "v1/systems/storage?type=detail");
+  const { data: storageData, error: storageError } = useWidgetAPI(widget, "storage");
 
   if (storageError) {
     return <Container service={service} error={storageError} />;

--- a/src/widgets/unifi_drive/component.jsx
+++ b/src/widgets/unifi_drive/component.jsx
@@ -1,0 +1,56 @@
+import Block from "components/services/widget/block";
+import Container from "components/services/widget/container";
+import { useTranslation } from "next-i18next";
+
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+
+  const { widget } = service;
+
+  const { data: storageData, error: storageError } = useWidgetAPI(widget, "v1/systems/storage?type=detail");
+
+  if (storageError) {
+    return <Container service={service} error={storageError} />;
+  }
+
+  if (!storageData) {
+    return (
+      <Container service={service}>
+        <Block label="unifi_drive.total" />
+        <Block label="unifi_drive.used" />
+        <Block label="unifi_drive.available" />
+        <Block label="unifi_drive.status" />
+      </Container>
+    );
+  }
+
+  const { data: storage } = storageData;
+
+  if (!storage) {
+    return (
+      <Container service={service}>
+        <Block value={t("unifi_drive.no_data")} />
+      </Container>
+    );
+  }
+
+  const { totalQuota, usage, status } = storage;
+  const usedBytes = (usage?.system || 0) + (usage?.myDrives || 0) + (usage?.sharedDrives || 0);
+  const availableBytes = Math.max(0, totalQuota - usedBytes);
+
+  const total = totalQuota > 0 ? t("common.bytes", { value: totalQuota }) : t("common.na");
+  const used = t("common.bytes", { value: usedBytes });
+  const available = t("common.bytes", { value: availableBytes });
+  const statusValue = status === "healthy" ? t("unifi_drive.healthy") : t("unifi_drive.degraded");
+
+  return (
+    <Container service={service}>
+      <Block label="unifi_drive.total" value={total} />
+      <Block label="unifi_drive.used" value={used} />
+      <Block label="unifi_drive.available" value={available} />
+      <Block label="unifi_drive.status" value={statusValue} />
+    </Container>
+  );
+}

--- a/src/widgets/unifi_drive/component.jsx
+++ b/src/widgets/unifi_drive/component.jsx
@@ -6,7 +6,6 @@ import useWidgetAPI from "utils/proxy/use-widget-api";
 
 export default function Component({ service }) {
   const { t } = useTranslation();
-
   const { widget } = service;
 
   const { data: storageData, error: storageError } = useWidgetAPI(widget, "storage");
@@ -18,10 +17,10 @@ export default function Component({ service }) {
   if (!storageData) {
     return (
       <Container service={service}>
-        <Block label="unifi_drive.total" />
-        <Block label="unifi_drive.used" />
-        <Block label="unifi_drive.available" />
-        <Block label="unifi_drive.status" />
+        <Block field="unifi_drive.total" label="resources.total" />
+        <Block field="unifi_drive.used" label="resources.used" />
+        <Block field="unifi_drive.available" label="resources.free" />
+        <Block field="unifi_drive.status" label="widget.status" />
       </Container>
     );
   }
@@ -37,20 +36,23 @@ export default function Component({ service }) {
   }
 
   const { totalQuota, usage, status } = storage;
+  const totalBytes = totalQuota ?? 0;
   const usedBytes = (usage?.system || 0) + (usage?.myDrives || 0) + (usage?.sharedDrives || 0);
-  const availableBytes = Math.max(0, totalQuota - usedBytes);
-
-  const total = totalQuota > 0 ? t("common.bytes", { value: totalQuota }) : t("common.na");
-  const used = t("common.bytes", { value: usedBytes });
-  const available = t("common.bytes", { value: availableBytes });
-  const statusValue = status === "healthy" ? t("unifi_drive.healthy") : t("unifi_drive.degraded");
+  const availableBytes = Math.max(0, totalBytes - usedBytes);
+  let statusValue = status;
+  if (status === "healthy") statusValue = t("unifi_drive.healthy");
+  else if (status === "degraded") statusValue = t("unifi_drive.degraded");
 
   return (
     <Container service={service}>
-      <Block label="unifi_drive.total" value={total} />
-      <Block label="unifi_drive.used" value={used} />
-      <Block label="unifi_drive.available" value={available} />
-      <Block label="unifi_drive.status" value={statusValue} />
+      <Block field="unifi_drive.total" label="resources.total" value={t("common.bytes", { value: totalBytes })} />
+      <Block field="unifi_drive.used" label="resources.used" value={t("common.bytes", { value: usedBytes })} />
+      <Block
+        field="unifi_drive.available"
+        label="resources.free"
+        value={t("common.bytes", { value: availableBytes })}
+      />
+      <Block field="unifi_drive.status" label="widget.status" value={statusValue} />
     </Container>
   );
 }

--- a/src/widgets/unifi_drive/component.test.jsx
+++ b/src/widgets/unifi_drive/component.test.jsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+
+import { screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "test-utils/render-with-providers";
+
+const { useWidgetAPI } = vi.hoisted(() => ({ useWidgetAPI: vi.fn() }));
+
+vi.mock("utils/proxy/use-widget-api", () => ({ default: useWidgetAPI }));
+
+import Component from "./component";
+
+describe("widgets/unifi_drive/component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders placeholders while loading", () => {
+    useWidgetAPI.mockReturnValue({ data: undefined, error: undefined });
+
+    const service = { widget: { type: "unifi_drive" } };
+    const { container } = renderWithProviders(<Component service={service} />, { settings: { hideErrors: false } });
+
+    expect(container.querySelectorAll(".service-block")).toHaveLength(4);
+    expect(screen.getByText("unifi_drive.total")).toBeInTheDocument();
+    expect(screen.getByText("unifi_drive.used")).toBeInTheDocument();
+    expect(screen.getByText("unifi_drive.available")).toBeInTheDocument();
+    expect(screen.getByText("unifi_drive.status")).toBeInTheDocument();
+  });
+
+  it("renders error when API fails", () => {
+    useWidgetAPI.mockReturnValue({ data: undefined, error: new Error("fail") });
+
+    const service = { widget: { type: "unifi_drive" } };
+    renderWithProviders(<Component service={service} />, { settings: { hideErrors: false } });
+
+    expect(screen.getAllByText("widget.api_error", { exact: false }).length).toBeGreaterThan(0);
+  });
+
+  it("renders no_data when storage data is missing", () => {
+    useWidgetAPI.mockImplementation((widget, endpoint) => {
+      if (endpoint === "v1/systems/storage?type=detail") {
+        return { data: { data: null }, error: undefined };
+      }
+      return { data: undefined, error: undefined };
+    });
+
+    const service = { widget: { type: "unifi_drive" } };
+    renderWithProviders(<Component service={service} />, { settings: { hideErrors: false } });
+
+    expect(screen.getByText("unifi_drive.no_data")).toBeInTheDocument();
+  });
+
+  it("renders storage statistics when data is loaded", () => {
+    useWidgetAPI.mockImplementation((widget, endpoint) => {
+      if (endpoint === "v1/systems/storage?type=detail") {
+        return {
+          data: {
+            data: {
+              totalQuota: 1000000000000,
+              usage: { system: 100000000000, myDrives: 200000000000, sharedDrives: 50000000000 },
+              status: "healthy",
+            },
+          },
+          error: undefined,
+        };
+      }
+      return { data: undefined, error: undefined };
+    });
+
+    const service = { widget: { type: "unifi_drive" } };
+    const { container } = renderWithProviders(<Component service={service} />, { settings: { hideErrors: false } });
+
+    expect(container.querySelectorAll(".service-block")).toHaveLength(4);
+  });
+
+  it("renders degraded status", () => {
+    useWidgetAPI.mockImplementation((widget, endpoint) => {
+      if (endpoint === "v1/systems/storage?type=detail") {
+        return {
+          data: {
+            data: {
+              totalQuota: 1000000000000,
+              usage: { system: 100000000000, myDrives: 200000000000, sharedDrives: 50000000000 },
+              status: "degraded",
+            },
+          },
+          error: undefined,
+        };
+      }
+      return { data: undefined, error: undefined };
+    });
+
+    const service = { widget: { type: "unifi_drive" } };
+    const { container } = renderWithProviders(<Component service={service} />, { settings: { hideErrors: false } });
+
+    expect(container.querySelectorAll(".service-block")).toHaveLength(4);
+  });
+
+  it("handles zero totalQuota gracefully", () => {
+    useWidgetAPI.mockImplementation((widget, endpoint) => {
+      if (endpoint === "v1/systems/storage?type=detail") {
+        return {
+          data: {
+            data: {
+              totalQuota: 0,
+              usage: { system: 0, myDrives: 0, sharedDrives: 0 },
+              status: "healthy",
+            },
+          },
+          error: undefined,
+        };
+      }
+      return { data: undefined, error: undefined };
+    });
+
+    const service = { widget: { type: "unifi_drive" } };
+    const { container } = renderWithProviders(<Component service={service} />, { settings: { hideErrors: false } });
+
+    expect(container.querySelectorAll(".service-block")).toHaveLength(4);
+  });
+});

--- a/src/widgets/unifi_drive/component.test.jsx
+++ b/src/widgets/unifi_drive/component.test.jsx
@@ -4,6 +4,7 @@ import { screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { renderWithProviders } from "test-utils/render-with-providers";
+import { expectBlockValue } from "test-utils/widget-assertions";
 
 const { useWidgetAPI } = vi.hoisted(() => ({ useWidgetAPI: vi.fn() }));
 
@@ -23,10 +24,10 @@ describe("widgets/unifi_drive/component", () => {
     const { container } = renderWithProviders(<Component service={service} />, { settings: { hideErrors: false } });
 
     expect(container.querySelectorAll(".service-block")).toHaveLength(4);
-    expect(screen.getByText("unifi_drive.total")).toBeInTheDocument();
-    expect(screen.getByText("unifi_drive.used")).toBeInTheDocument();
-    expect(screen.getByText("unifi_drive.available")).toBeInTheDocument();
-    expect(screen.getByText("unifi_drive.status")).toBeInTheDocument();
+    expect(screen.getByText("resources.total")).toBeInTheDocument();
+    expect(screen.getByText("resources.used")).toBeInTheDocument();
+    expect(screen.getByText("resources.free")).toBeInTheDocument();
+    expect(screen.getByText("widget.status")).toBeInTheDocument();
   });
 
   it("renders error when API fails", () => {
@@ -39,12 +40,7 @@ describe("widgets/unifi_drive/component", () => {
   });
 
   it("renders no_data when storage data is missing", () => {
-    useWidgetAPI.mockImplementation((widget, endpoint) => {
-      if (endpoint === "storage") {
-        return { data: { data: null }, error: undefined };
-      }
-      return { data: undefined, error: undefined };
-    });
+    useWidgetAPI.mockReturnValue({ data: { data: null }, error: undefined });
 
     const service = { widget: { type: "unifi_drive" } };
     renderWithProviders(<Component service={service} />, { settings: { hideErrors: false } });
@@ -53,71 +49,44 @@ describe("widgets/unifi_drive/component", () => {
   });
 
   it("renders storage statistics when data is loaded", () => {
-    useWidgetAPI.mockImplementation((widget, endpoint) => {
-      if (endpoint === "storage") {
-        return {
-          data: {
-            data: {
-              totalQuota: 1000000000000,
-              usage: { system: 100000000000, myDrives: 200000000000, sharedDrives: 50000000000 },
-              status: "healthy",
-            },
-          },
-          error: undefined,
-        };
-      }
-      return { data: undefined, error: undefined };
+    useWidgetAPI.mockReturnValue({
+      data: {
+        data: {
+          totalQuota: 1000000000000,
+          usage: { system: 100000000000, myDrives: 200000000000, sharedDrives: 50000000000 },
+          status: "healthy",
+        },
+      },
+      error: undefined,
     });
 
     const service = { widget: { type: "unifi_drive" } };
     const { container } = renderWithProviders(<Component service={service} />, { settings: { hideErrors: false } });
 
     expect(container.querySelectorAll(".service-block")).toHaveLength(4);
+    expectBlockValue(container, "resources.total", 1000000000000);
+    expectBlockValue(container, "resources.used", 350000000000);
+    expectBlockValue(container, "resources.free", 650000000000);
+    expectBlockValue(container, "widget.status", "unifi_drive.healthy");
   });
 
   it("renders degraded status", () => {
-    useWidgetAPI.mockImplementation((widget, endpoint) => {
-      if (endpoint === "storage") {
-        return {
-          data: {
-            data: {
-              totalQuota: 1000000000000,
-              usage: { system: 100000000000, myDrives: 200000000000, sharedDrives: 50000000000 },
-              status: "degraded",
-            },
-          },
-          error: undefined,
-        };
-      }
-      return { data: undefined, error: undefined };
+    useWidgetAPI.mockReturnValue({
+      data: {
+        data: {
+          totalQuota: 100,
+          usage: { system: 10, myDrives: 20, sharedDrives: 5 },
+          status: "degraded",
+        },
+      },
+      error: undefined,
     });
 
     const service = { widget: { type: "unifi_drive" } };
     const { container } = renderWithProviders(<Component service={service} />, { settings: { hideErrors: false } });
 
     expect(container.querySelectorAll(".service-block")).toHaveLength(4);
-  });
-
-  it("handles zero totalQuota gracefully", () => {
-    useWidgetAPI.mockImplementation((widget, endpoint) => {
-      if (endpoint === "storage") {
-        return {
-          data: {
-            data: {
-              totalQuota: 0,
-              usage: { system: 0, myDrives: 0, sharedDrives: 0 },
-              status: "healthy",
-            },
-          },
-          error: undefined,
-        };
-      }
-      return { data: undefined, error: undefined };
-    });
-
-    const service = { widget: { type: "unifi_drive" } };
-    const { container } = renderWithProviders(<Component service={service} />, { settings: { hideErrors: false } });
-
-    expect(container.querySelectorAll(".service-block")).toHaveLength(4);
+    expectBlockValue(container, "widget.status", "unifi_drive.degraded");
+    expectBlockValue(container, "resources.free", 65);
   });
 });

--- a/src/widgets/unifi_drive/component.test.jsx
+++ b/src/widgets/unifi_drive/component.test.jsx
@@ -40,7 +40,7 @@ describe("widgets/unifi_drive/component", () => {
 
   it("renders no_data when storage data is missing", () => {
     useWidgetAPI.mockImplementation((widget, endpoint) => {
-      if (endpoint === "v1/systems/storage?type=detail") {
+      if (endpoint === "storage") {
         return { data: { data: null }, error: undefined };
       }
       return { data: undefined, error: undefined };
@@ -54,7 +54,7 @@ describe("widgets/unifi_drive/component", () => {
 
   it("renders storage statistics when data is loaded", () => {
     useWidgetAPI.mockImplementation((widget, endpoint) => {
-      if (endpoint === "v1/systems/storage?type=detail") {
+      if (endpoint === "storage") {
         return {
           data: {
             data: {
@@ -77,7 +77,7 @@ describe("widgets/unifi_drive/component", () => {
 
   it("renders degraded status", () => {
     useWidgetAPI.mockImplementation((widget, endpoint) => {
-      if (endpoint === "v1/systems/storage?type=detail") {
+      if (endpoint === "storage") {
         return {
           data: {
             data: {
@@ -100,7 +100,7 @@ describe("widgets/unifi_drive/component", () => {
 
   it("handles zero totalQuota gracefully", () => {
     useWidgetAPI.mockImplementation((widget, endpoint) => {
-      if (endpoint === "v1/systems/storage?type=detail") {
+      if (endpoint === "storage") {
         return {
           data: {
             data: {

--- a/src/widgets/unifi_drive/proxy.js
+++ b/src/widgets/unifi_drive/proxy.js
@@ -1,0 +1,94 @@
+import cache from "memory-cache";
+
+import getServiceWidget from "utils/config/service-helpers";
+import createLogger from "utils/logger";
+import { formatApiCall } from "utils/proxy/api-helpers";
+import { addCookieToJar, setCookieHeader } from "utils/proxy/cookie-jar";
+import { httpProxy } from "utils/proxy/http";
+import widgets from "widgets/widgets";
+
+const drivePrefix = "/proxy/drive";
+const proxyName = "unifiDriveProxyHandler";
+const prefixCacheKey = `${proxyName}__prefix`;
+const logger = createLogger(proxyName);
+
+async function getWidget(req) {
+  const { group, service, index } = req.query;
+  if (!group || !service) return null;
+
+  const widget = await getServiceWidget(group, service, index);
+  if (!widget) {
+    logger.debug("Invalid or missing widget for service '%s' in group '%s'", service, group);
+    return null;
+  }
+  return widget;
+}
+
+async function login(widget, csrfToken) {
+  const api = widgets?.[widget.type]?.api?.replace("{prefix}", "");
+  const loginUrl = new URL(formatApiCall(api, { endpoint: "auth/login", ...widget }));
+  const headers = { "Content-Type": "application/json" };
+  if (csrfToken) headers["X-CSRF-TOKEN"] = csrfToken;
+
+  return httpProxy(loginUrl, {
+    method: "POST",
+    body: JSON.stringify({ username: widget.username, password: widget.password, remember: true, rememberMe: true }),
+    headers,
+  });
+}
+
+export default async function unifiDriveProxyHandler(req, res) {
+  const widget = await getWidget(req);
+  const { service } = req.query;
+  if (!widget) return res.status(400).json({ error: "Invalid proxy service type" });
+
+  const api = widgets?.[widget.type]?.api;
+  if (!api) return res.status(403).json({ error: "Service does not support API calls" });
+
+  let [status, contentType, data, responseHeaders] = [];
+  let prefix = cache.get(`${prefixCacheKey}.${service}`);
+  let csrfToken;
+
+  if (prefix === null) {
+    [status, contentType, data, responseHeaders] = await httpProxy(widget.url);
+    prefix = drivePrefix;
+    if (responseHeaders?.["x-csrf-token"]) csrfToken = responseHeaders["x-csrf-token"];
+  }
+  cache.put(`${prefixCacheKey}.${service}`, prefix);
+
+  widget.prefix = prefix;
+  const url = new URL(formatApiCall(api, { endpoint: req.query.endpoint, ...widget }));
+  const params = { method: "GET", headers: {} };
+  setCookieHeader(url, params);
+
+  [status, contentType, data, responseHeaders] = await httpProxy(url, params);
+
+  if (status === 401) {
+    logger.debug("UniFi Drive not authenticated, attempting login.");
+    if (responseHeaders?.["x-csrf-token"]) csrfToken = responseHeaders["x-csrf-token"];
+    [status, contentType, data, responseHeaders] = await login(widget, csrfToken);
+
+    if (status !== 200) {
+      logger.error("HTTP %d logging in to UniFi Drive. Data: %s", status, data);
+      return res.status(status).json({ error: { message: `HTTP Error ${status}`, url, data } });
+    }
+
+    const json = JSON.parse(data.toString());
+    if (!(json?.meta?.rc === "ok" || json?.login_time || json?.update_time)) {
+      logger.error("Error logging in to UniFi Drive: Data: %s", data);
+      return res.status(401).end(data);
+    }
+
+    addCookieToJar(url, responseHeaders);
+    setCookieHeader(url, params);
+    [status, contentType, data, responseHeaders] = await httpProxy(url, params);
+  }
+
+  if (status !== 200) {
+    logger.error("HTTP %d from UniFi Drive endpoint %s. Data: %s", status, url.href, data);
+    return res.status(status).json({ error: { message: `HTTP Error ${status}`, url, data } });
+  }
+
+  if (contentType) res.setHeader("Content-Type", contentType);
+  return res.status(status).send(data);
+}

--- a/src/widgets/unifi_drive/proxy.js
+++ b/src/widgets/unifi_drive/proxy.js
@@ -1,18 +1,10 @@
-import cache from "memory-cache";
-
 import getServiceWidget from "utils/config/service-helpers";
-import createLogger from "utils/logger";
-import { formatApiCall } from "utils/proxy/api-helpers";
-import { addCookieToJar, setCookieHeader } from "utils/proxy/cookie-jar";
+import createUnifiProxyHandler from "utils/proxy/handlers/unifi";
 import { httpProxy } from "utils/proxy/http";
-import widgets from "widgets/widgets";
 
 const drivePrefix = "/proxy/drive";
-const proxyName = "unifiDriveProxyHandler";
-const prefixCacheKey = `${proxyName}__prefix`;
-const logger = createLogger(proxyName);
 
-async function getWidget(req) {
+async function getWidget(req, logger) {
   const { group, service, index } = req.query;
   if (!group || !service) return null;
 
@@ -24,71 +16,21 @@ async function getWidget(req) {
   return widget;
 }
 
-async function login(widget, csrfToken) {
-  const api = widgets?.[widget.type]?.api?.replace("{prefix}", "");
-  const loginUrl = new URL(formatApiCall(api, { endpoint: "auth/login", ...widget }));
-  const headers = { "Content-Type": "application/json" };
-  if (csrfToken) headers["X-CSRF-TOKEN"] = csrfToken;
+async function resolveRequestContext({ cachedPrefix, widget }) {
+  if (cachedPrefix !== null) {
+    return { prefix: cachedPrefix };
+  }
 
-  return httpProxy(loginUrl, {
-    method: "POST",
-    body: JSON.stringify({ username: widget.username, password: widget.password, remember: true, rememberMe: true }),
-    headers,
-  });
+  const [, , , responseHeaders] = await httpProxy(widget.url);
+
+  return {
+    prefix: drivePrefix,
+    csrfToken: responseHeaders?.["x-csrf-token"],
+  };
 }
 
-export default async function unifiDriveProxyHandler(req, res) {
-  const widget = await getWidget(req);
-  const { service } = req.query;
-  if (!widget) return res.status(400).json({ error: "Invalid proxy service type" });
-
-  const api = widgets?.[widget.type]?.api;
-  if (!api) return res.status(403).json({ error: "Service does not support API calls" });
-
-  let [status, contentType, data, responseHeaders] = [];
-  let prefix = cache.get(`${prefixCacheKey}.${service}`);
-  let csrfToken;
-
-  if (prefix === null) {
-    [status, contentType, data, responseHeaders] = await httpProxy(widget.url);
-    prefix = drivePrefix;
-    if (responseHeaders?.["x-csrf-token"]) csrfToken = responseHeaders["x-csrf-token"];
-  }
-  cache.put(`${prefixCacheKey}.${service}`, prefix);
-
-  widget.prefix = prefix;
-  const url = new URL(formatApiCall(api, { endpoint: req.query.endpoint, ...widget }));
-  const params = { method: "GET", headers: {} };
-  setCookieHeader(url, params);
-
-  [status, contentType, data, responseHeaders] = await httpProxy(url, params);
-
-  if (status === 401) {
-    logger.debug("UniFi Drive not authenticated, attempting login.");
-    if (responseHeaders?.["x-csrf-token"]) csrfToken = responseHeaders["x-csrf-token"];
-    [status, contentType, data, responseHeaders] = await login(widget, csrfToken);
-
-    if (status !== 200) {
-      logger.error("HTTP %d logging in to UniFi Drive. Data: %s", status, data);
-      return res.status(status).json({ error: { message: `HTTP Error ${status}`, url, data } });
-    }
-
-    const json = JSON.parse(data.toString());
-    if (!(json?.meta?.rc === "ok" || json?.login_time || json?.update_time)) {
-      logger.error("Error logging in to UniFi Drive: Data: %s", data);
-      return res.status(401).end(data);
-    }
-
-    addCookieToJar(url, responseHeaders);
-    setCookieHeader(url, params);
-    [status, contentType, data, responseHeaders] = await httpProxy(url, params);
-  }
-
-  if (status !== 200) {
-    logger.error("HTTP %d from UniFi Drive endpoint %s. Data: %s", status, url.href, data);
-    return res.status(status).json({ error: { message: `HTTP Error ${status}`, url, data } });
-  }
-
-  if (contentType) res.setHeader("Content-Type", contentType);
-  return res.status(status).send(data);
-}
+export default createUnifiProxyHandler({
+  proxyName: "unifiDriveProxyHandler",
+  resolveWidget: getWidget,
+  resolveRequestContext,
+});

--- a/src/widgets/unifi_drive/proxy.test.js
+++ b/src/widgets/unifi_drive/proxy.test.js
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import createMockRes from "test-utils/create-mock-res";
 
-const { httpProxy, getServiceWidget, cache, cookieJar, logger } = vi.hoisted(() => {
+const { httpProxy, getServiceWidget, cache, logger } = vi.hoisted(() => {
   const store = new Map();
   return {
     httpProxy: vi.fn(),
@@ -13,7 +13,6 @@ const { httpProxy, getServiceWidget, cache, cookieJar, logger } = vi.hoisted(() 
       del: vi.fn((k) => store.delete(k)),
       _reset: () => store.clear(),
     },
-    cookieJar: { addCookieToJar: vi.fn(), setCookieHeader: vi.fn() },
     logger: { debug: vi.fn(), error: vi.fn() },
   };
 });
@@ -22,7 +21,6 @@ vi.mock("memory-cache", () => ({ default: cache, ...cache }));
 vi.mock("utils/logger", () => ({ default: () => logger }));
 vi.mock("utils/config/service-helpers", () => ({ default: getServiceWidget }));
 vi.mock("utils/proxy/http", () => ({ httpProxy }));
-vi.mock("utils/proxy/cookie-jar", () => cookieJar);
 vi.mock("widgets/widgets", () => ({
   default: { unifi_drive: { api: "{url}{prefix}/api/{endpoint}" } },
 }));
@@ -50,10 +48,7 @@ describe("widgets/unifi_drive/proxy", () => {
   it("returns 403 when widget type has no API config", async () => {
     getServiceWidget.mockResolvedValue({ ...widgetConfig, type: "unknown" });
     const res = createMockRes();
-    await unifiDriveProxyHandler(
-      { query: { group: "g", service: "s", endpoint: "v1/systems/storage?type=detail" } },
-      res,
-    );
+    await unifiDriveProxyHandler({ query: { group: "g", service: "s", endpoint: "storage" } }, res);
     expect(res.statusCode).toBe(403);
   });
 
@@ -64,88 +59,12 @@ describe("widgets/unifi_drive/proxy", () => {
       .mockResolvedValueOnce([200, "application/json", Buffer.from('{"data":{}}'), {}]);
 
     const res = createMockRes();
-    await unifiDriveProxyHandler(
-      { query: { group: "g", service: "s", endpoint: "v1/systems/storage?type=detail" } },
-      res,
-    );
+    await unifiDriveProxyHandler({ query: { group: "g", service: "s", endpoint: "storage" } }, res);
 
+    expect(httpProxy.mock.calls[0][0]).toBe("http://unifi");
     expect(httpProxy.mock.calls[1][0].toString()).toContain("/proxy/drive/api/");
+    expect(cache.put).toHaveBeenCalledWith("unifiDriveProxyHandler__prefix.s", "/proxy/drive");
     expect(res.statusCode).toBe(200);
-  });
-
-  it("logs in on 401 and retries", async () => {
-    getServiceWidget.mockResolvedValue({ ...widgetConfig });
-    httpProxy
-      .mockResolvedValueOnce([200, "text/html", Buffer.from(""), { "x-csrf-token": "tok" }])
-      .mockResolvedValueOnce([401, "application/json", Buffer.from(""), {}])
-      .mockResolvedValueOnce([
-        200,
-        "application/json",
-        Buffer.from(JSON.stringify({ meta: { rc: "ok" } })),
-        { "set-cookie": ["sid=1"] },
-      ])
-      .mockResolvedValueOnce([200, "application/json", Buffer.from('{"data":{}}'), {}]);
-
-    const res = createMockRes();
-    await unifiDriveProxyHandler(
-      { query: { group: "g", service: "s", endpoint: "v1/systems/storage?type=detail" } },
-      res,
-    );
-
-    expect(httpProxy).toHaveBeenCalledTimes(4);
-    expect(cookieJar.addCookieToJar).toHaveBeenCalled();
-    expect(res.statusCode).toBe(200);
-  });
-
-  it("returns error when login fails", async () => {
-    getServiceWidget.mockResolvedValue({ ...widgetConfig });
-    httpProxy
-      .mockResolvedValueOnce([200, "text/html", Buffer.from(""), {}])
-      .mockResolvedValueOnce([401, "application/json", Buffer.from(""), {}])
-      .mockResolvedValueOnce([403, "application/json", Buffer.from("forbidden"), {}]);
-
-    const res = createMockRes();
-    await unifiDriveProxyHandler(
-      { query: { group: "g", service: "s", endpoint: "v1/systems/storage?type=detail" } },
-      res,
-    );
-    expect(res.statusCode).toBe(403);
-  });
-
-  it("returns 401 when login response is invalid", async () => {
-    getServiceWidget.mockResolvedValue({ ...widgetConfig });
-    httpProxy
-      .mockResolvedValueOnce([200, "text/html", Buffer.from(""), {}])
-      .mockResolvedValueOnce([401, "application/json", Buffer.from(""), {}])
-      .mockResolvedValueOnce([200, "application/json", Buffer.from(JSON.stringify({ error: "bad" })), {}]);
-
-    const res = createMockRes();
-    await unifiDriveProxyHandler(
-      { query: { group: "g", service: "s", endpoint: "v1/systems/storage?type=detail" } },
-      res,
-    );
-    expect(res.statusCode).toBe(401);
-  });
-
-  it("returns error when retry after login gets non-200", async () => {
-    getServiceWidget.mockResolvedValue({ ...widgetConfig });
-    httpProxy
-      .mockResolvedValueOnce([200, "text/html", Buffer.from(""), {}])
-      .mockResolvedValueOnce([401, "application/json", Buffer.from(""), {}])
-      .mockResolvedValueOnce([
-        200,
-        "application/json",
-        Buffer.from(JSON.stringify({ login_time: 1 })),
-        { "set-cookie": ["sid=1"] },
-      ])
-      .mockResolvedValueOnce([500, "application/json", Buffer.from("error"), {}]);
-
-    const res = createMockRes();
-    await unifiDriveProxyHandler(
-      { query: { group: "g", service: "s", endpoint: "v1/systems/storage?type=detail" } },
-      res,
-    );
-    expect(res.statusCode).toBe(500);
   });
 
   it("skips prefix detection when cached", async () => {
@@ -154,12 +73,10 @@ describe("widgets/unifi_drive/proxy", () => {
     httpProxy.mockResolvedValueOnce([200, "application/json", Buffer.from('{"data":{}}'), {}]);
 
     const res = createMockRes();
-    await unifiDriveProxyHandler(
-      { query: { group: "g", service: "s", endpoint: "v1/systems/storage?type=detail" } },
-      res,
-    );
+    await unifiDriveProxyHandler({ query: { group: "g", service: "s", endpoint: "storage" } }, res);
 
     expect(httpProxy).toHaveBeenCalledTimes(1);
+    expect(httpProxy.mock.calls[0][0].toString()).toContain("/proxy/drive/api/");
     expect(res.statusCode).toBe(200);
   });
 });

--- a/src/widgets/unifi_drive/proxy.test.js
+++ b/src/widgets/unifi_drive/proxy.test.js
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import createMockRes from "test-utils/create-mock-res";
+
+const { httpProxy, getServiceWidget, cache, cookieJar, logger } = vi.hoisted(() => {
+  const store = new Map();
+  return {
+    httpProxy: vi.fn(),
+    getServiceWidget: vi.fn(),
+    cache: {
+      get: vi.fn((k) => (store.has(k) ? store.get(k) : null)),
+      put: vi.fn((k, v) => store.set(k, v)),
+      del: vi.fn((k) => store.delete(k)),
+      _reset: () => store.clear(),
+    },
+    cookieJar: { addCookieToJar: vi.fn(), setCookieHeader: vi.fn() },
+    logger: { debug: vi.fn(), error: vi.fn() },
+  };
+});
+
+vi.mock("memory-cache", () => ({ default: cache, ...cache }));
+vi.mock("utils/logger", () => ({ default: () => logger }));
+vi.mock("utils/config/service-helpers", () => ({ default: getServiceWidget }));
+vi.mock("utils/proxy/http", () => ({ httpProxy }));
+vi.mock("utils/proxy/cookie-jar", () => cookieJar);
+vi.mock("widgets/widgets", () => ({
+  default: { unifi_drive: { api: "{url}{prefix}/api/{endpoint}" } },
+}));
+
+import unifiDriveProxyHandler from "./proxy";
+
+const widgetConfig = { type: "unifi_drive", url: "http://unifi", username: "u", password: "p" };
+
+describe("widgets/unifi_drive/proxy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cache._reset();
+  });
+
+  it("returns 400 when widget config is missing", async () => {
+    getServiceWidget.mockResolvedValue(null);
+    const res = createMockRes();
+    await unifiDriveProxyHandler(
+      { query: { group: "g", service: "s", endpoint: "v1/systems/storage?type=detail" } },
+      res,
+    );
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 403 when widget type has no API config", async () => {
+    getServiceWidget.mockResolvedValue({ ...widgetConfig, type: "unknown" });
+    const res = createMockRes();
+    await unifiDriveProxyHandler(
+      { query: { group: "g", service: "s", endpoint: "v1/systems/storage?type=detail" } },
+      res,
+    );
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("uses /proxy/drive prefix and returns data on success", async () => {
+    getServiceWidget.mockResolvedValue({ ...widgetConfig });
+    httpProxy
+      .mockResolvedValueOnce([200, "text/html", Buffer.from(""), {}])
+      .mockResolvedValueOnce([200, "application/json", Buffer.from('{"data":{}}'), {}]);
+
+    const res = createMockRes();
+    await unifiDriveProxyHandler(
+      { query: { group: "g", service: "s", endpoint: "v1/systems/storage?type=detail" } },
+      res,
+    );
+
+    expect(httpProxy.mock.calls[1][0].toString()).toContain("/proxy/drive/api/");
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("logs in on 401 and retries", async () => {
+    getServiceWidget.mockResolvedValue({ ...widgetConfig });
+    httpProxy
+      .mockResolvedValueOnce([200, "text/html", Buffer.from(""), { "x-csrf-token": "tok" }])
+      .mockResolvedValueOnce([401, "application/json", Buffer.from(""), {}])
+      .mockResolvedValueOnce([
+        200,
+        "application/json",
+        Buffer.from(JSON.stringify({ meta: { rc: "ok" } })),
+        { "set-cookie": ["sid=1"] },
+      ])
+      .mockResolvedValueOnce([200, "application/json", Buffer.from('{"data":{}}'), {}]);
+
+    const res = createMockRes();
+    await unifiDriveProxyHandler(
+      { query: { group: "g", service: "s", endpoint: "v1/systems/storage?type=detail" } },
+      res,
+    );
+
+    expect(httpProxy).toHaveBeenCalledTimes(4);
+    expect(cookieJar.addCookieToJar).toHaveBeenCalled();
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("returns error when login fails", async () => {
+    getServiceWidget.mockResolvedValue({ ...widgetConfig });
+    httpProxy
+      .mockResolvedValueOnce([200, "text/html", Buffer.from(""), {}])
+      .mockResolvedValueOnce([401, "application/json", Buffer.from(""), {}])
+      .mockResolvedValueOnce([403, "application/json", Buffer.from("forbidden"), {}]);
+
+    const res = createMockRes();
+    await unifiDriveProxyHandler(
+      { query: { group: "g", service: "s", endpoint: "v1/systems/storage?type=detail" } },
+      res,
+    );
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("returns 401 when login response is invalid", async () => {
+    getServiceWidget.mockResolvedValue({ ...widgetConfig });
+    httpProxy
+      .mockResolvedValueOnce([200, "text/html", Buffer.from(""), {}])
+      .mockResolvedValueOnce([401, "application/json", Buffer.from(""), {}])
+      .mockResolvedValueOnce([200, "application/json", Buffer.from(JSON.stringify({ error: "bad" })), {}]);
+
+    const res = createMockRes();
+    await unifiDriveProxyHandler(
+      { query: { group: "g", service: "s", endpoint: "v1/systems/storage?type=detail" } },
+      res,
+    );
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns error when retry after login gets non-200", async () => {
+    getServiceWidget.mockResolvedValue({ ...widgetConfig });
+    httpProxy
+      .mockResolvedValueOnce([200, "text/html", Buffer.from(""), {}])
+      .mockResolvedValueOnce([401, "application/json", Buffer.from(""), {}])
+      .mockResolvedValueOnce([
+        200,
+        "application/json",
+        Buffer.from(JSON.stringify({ login_time: 1 })),
+        { "set-cookie": ["sid=1"] },
+      ])
+      .mockResolvedValueOnce([500, "application/json", Buffer.from("error"), {}]);
+
+    const res = createMockRes();
+    await unifiDriveProxyHandler(
+      { query: { group: "g", service: "s", endpoint: "v1/systems/storage?type=detail" } },
+      res,
+    );
+    expect(res.statusCode).toBe(500);
+  });
+
+  it("skips prefix detection when cached", async () => {
+    getServiceWidget.mockResolvedValue({ ...widgetConfig });
+    cache.put("unifiDriveProxyHandler__prefix.s", "/proxy/drive");
+    httpProxy.mockResolvedValueOnce([200, "application/json", Buffer.from('{"data":{}}'), {}]);
+
+    const res = createMockRes();
+    await unifiDriveProxyHandler(
+      { query: { group: "g", service: "s", endpoint: "v1/systems/storage?type=detail" } },
+      res,
+    );
+
+    expect(httpProxy).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(200);
+  });
+});

--- a/src/widgets/unifi_drive/widget.js
+++ b/src/widgets/unifi_drive/widget.js
@@ -1,0 +1,14 @@
+import unifiDriveProxyHandler from "./proxy";
+
+const widget = {
+  api: "{url}{prefix}/api/{endpoint}",
+  proxyHandler: unifiDriveProxyHandler,
+
+  mappings: {
+    "v1/systems/storage?type=detail": {
+      endpoint: "v1/systems/storage?type=detail",
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/unifi_drive/widget.js
+++ b/src/widgets/unifi_drive/widget.js
@@ -5,7 +5,7 @@ const widget = {
   proxyHandler: unifiDriveProxyHandler,
 
   mappings: {
-    "v1/systems/storage?type=detail": {
+    storage: {
       endpoint: "v1/systems/storage?type=detail",
     },
   },

--- a/src/widgets/unifi_drive/widget.test.js
+++ b/src/widgets/unifi_drive/widget.test.js
@@ -1,0 +1,11 @@
+import { describe, it } from "vitest";
+
+import { expectWidgetConfigShape } from "test-utils/widget-config";
+
+import widget from "./widget";
+
+describe("unifi_drive widget config", () => {
+  it("exports a valid widget config", () => {
+    expectWidgetConfigShape(widget);
+  });
+});

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -137,6 +137,7 @@ import trilium from "./trilium/widget";
 import truenas from "./truenas/widget";
 import tubearchivist from "./tubearchivist/widget";
 import unifi from "./unifi/widget";
+import unifi_drive from "./unifi_drive/widget";
 import unmanic from "./unmanic/widget";
 import unraid from "./unraid/widget";
 import uptimekuma from "./uptimekuma/widget";
@@ -296,6 +297,7 @@ const widgets = {
   truenas,
   unifi,
   unifi_console: unifi,
+  unifi_drive,
   unmanic,
   unraid,
   uptimekuma,


### PR DESCRIPTION
## Proposed change

Adds a new **service widget** for [UniFi Drive (UNAS)](https://ui.com/integrations/network-storage) devices. This enables Homepage users to monitor storage statistics from their UniFi NAS directly on their dashboard.

Related discussion: #5960

### Features

- **Storage statistics**: Total capacity, used space, available space, and health status

### Configuration example

```yaml
widget:
  type: unifi_drive
  url: https://unifi.host.or.ip
  username: your_username
  password: your_password
```

### API endpoint used

- `GET /proxy/drive/api/v1/systems/storage?type=detail` — overall storage stats

### Example API response

```json
{
  "data": {
    "totalQuota": 2000000000000,
    "usage": {
      "system": 50000000000,
      "myDrives": 300000000000,
      "sharedDrives": 150000000000
    },
    "status": "healthy"
  }
}
```

### AI disclosure

Claude (Anthropic) was used to assist with test writing, proxy handler patterns, and PR preparation. All code was reviewed and tested by the author.

## Type of change

- [x] New service widget

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] In the description above I have disclosed the use of AI tools in the coding of this PR.