### PR TITLE
Feature: shelfmark widget

### DIFF
--- a/docs/widgets/services/index.md
+++ b/docs/widgets/services/index.md
@@ -125,6 +125,7 @@ You can also find a list of all available service widgets in the sidebar navigat
 - [ruTorrent](rutorrent.md)
 - [SABnzbd](sabnzbd.md)
 - [Scrutiny](scrutiny.md)
+- [Shelfmark](shelfmark.md)
 - [Slskd](slskd.md)
 - [Sonarr](sonarr.md)
 - [Speedtest Tracker](speedtest-tracker.md)

--- a/docs/widgets/services/shelfmark.md
+++ b/docs/widgets/services/shelfmark.md
@@ -1,0 +1,21 @@
+---
+title: Shelfmark
+description: Shelfmark Widget Configuration
+---
+
+Learn more about [Shelfmark](https://github.com/calibrain/shelfmark).
+
+Authenticates against `{url}/api/auth/login` with `username` and `password`, then reads `{url}/api/status`.
+
+The widget displays item counts per status key from `/api/status`.
+Default fields are `requested`, `downloading`, `complete`, and `error`.
+
+```yaml
+widget:
+  type: shelfmark
+  url: https://shelfmark.example.com
+  username: username
+  password: password
+  # optional, max 4 fields:
+  # fields: ["requested", "available", "cancelled", "complete", "done", "downloading", "error", "locating", "queued", "resolving"]
+```

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -816,6 +816,18 @@
         "reading": "Reading",
         "finished": "Finished"
     },
+    "shelfmark": {
+        "requested": "Angefragt",
+        "available": "Verfuegbar",
+        "cancelled": "Abgebrochen",
+        "complete": "Fertig",
+        "done": "Erledigt",
+        "downloading": "Laedt",
+        "error": "Fehler",
+        "locating": "Suche",
+        "queued": "Warteschlange",
+        "resolving": "Aufloesen"
+    },
     "jdownloader": {
         "downloadCount": "Warteschlange",
         "downloadBytesRemaining": "Verbleibend",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -816,6 +816,18 @@
         "reading": "Reading",
         "finished": "Finished"
     },
+    "shelfmark": {
+        "requested": "Requested",
+        "available": "Available",
+        "cancelled": "Cancelled",
+        "complete": "Complete",
+        "done": "Done",
+        "downloading": "Downloading",
+        "error": "Error",
+        "locating": "Locating",
+        "queued": "Queued",
+        "resolving": "Resolving"
+    },
     "jdownloader": {
         "downloadCount": "Queue",
         "downloadBytesRemaining": "Remaining",

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -125,6 +125,7 @@ const components = {
   sabnzbd: dynamic(() => import("./sabnzbd/component")),
   scrutiny: dynamic(() => import("./scrutiny/component")),
   seerr: dynamic(() => import("./seerr/component")),
+  shelfmark: dynamic(() => import("./shelfmark/component")),
   slskd: dynamic(() => import("./slskd/component")),
   sonarr: dynamic(() => import("./sonarr/component")),
   sparkyfitness: dynamic(() => import("./sparkyfitness/component")),

--- a/src/widgets/shelfmark/component.jsx
+++ b/src/widgets/shelfmark/component.jsx
@@ -1,0 +1,90 @@
+import Block from "components/services/widget/block";
+import Container from "components/services/widget/container";
+import { useTranslation } from "next-i18next";
+
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export const shelfmarkDefaultFields = [
+  "requested",
+  "downloading",
+  "complete",
+  "error",
+];
+const MAX_ALLOWED_FIELDS = 4;
+const shelfmarkFieldPriority = [
+  "requested",
+  "available",
+  "downloading",
+  "complete",
+  "error",
+  "cancelled",
+  "done",
+  "locating",
+  "queued",
+  "resolving",
+];
+
+function getAutoFields(statusCounts) {
+  const availableFields = Object.keys(statusCounts ?? {});
+  const prioritized = shelfmarkFieldPriority.filter((field) => availableFields.includes(field));
+  const remainder = availableFields.filter((field) => !prioritized.includes(field));
+  const merged = [...prioritized, ...remainder];
+
+  if (merged.length === 0) {
+    return shelfmarkDefaultFields;
+  }
+
+  return merged.slice(0, MAX_ALLOWED_FIELDS);
+}
+
+function normalizeFields(widget, statusCounts) {
+  if (!widget.fields || widget.fields.length === 0) {
+    widget.fields = getAutoFields(statusCounts);
+  } else {
+    widget.fields = widget.fields
+      .filter((field) => shelfmarkFieldPriority.includes(field))
+      .slice(0, MAX_ALLOWED_FIELDS);
+    if (widget.fields.length === 0) {
+      widget.fields = shelfmarkDefaultFields;
+    }
+  }
+
+  return widget.fields;
+}
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+  const { widget } = service;
+
+  const { data: shelfmarkData, error: shelfmarkError } = useWidgetAPI(widget);
+
+  if (shelfmarkError) {
+    return <Container service={service} error={shelfmarkError} />;
+  }
+
+  const statusCounts = shelfmarkData?.statuses ?? {};
+  const fields = normalizeFields(widget, statusCounts);
+
+  if (!shelfmarkData) {
+    return (
+      <Container service={service}>
+        {fields.map((field) => (
+          <Block key={field} field={`shelfmark.${field}`} label={`shelfmark.${field}`} />
+        ))}
+      </Container>
+    );
+  }
+
+  return (
+    <Container service={service}>
+      {fields.map((field) => (
+        <Block
+          key={field}
+          field={`shelfmark.${field}`}
+          label={`shelfmark.${field}`}
+          value={t("common.number", { value: statusCounts[field] ?? 0 })}
+        />
+      ))}
+    </Container>
+  );
+}

--- a/src/widgets/shelfmark/component.test.jsx
+++ b/src/widgets/shelfmark/component.test.jsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+
+import { screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "test-utils/render-with-providers";
+import { expectBlockValue } from "test-utils/widget-assertions";
+
+const { useWidgetAPI } = vi.hoisted(() => ({
+  useWidgetAPI: vi.fn(),
+}));
+
+vi.mock("utils/proxy/use-widget-api", () => ({
+  default: useWidgetAPI,
+}));
+
+import Component, { shelfmarkDefaultFields } from "./component";
+
+describe("widgets/shelfmark/component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("defaults fields while loading", () => {
+    useWidgetAPI.mockReturnValue({ data: undefined, error: undefined });
+
+    const service = { widget: { type: "shelfmark" } };
+    const { container } = renderWithProviders(<Component service={service} />, { settings: { hideErrors: false } });
+
+    expect(service.widget.fields).toEqual(shelfmarkDefaultFields);
+    expect(container.querySelectorAll(".service-block")).toHaveLength(4);
+    expect(screen.getByText("shelfmark.requested")).toBeInTheDocument();
+    expect(screen.getByText("shelfmark.downloading")).toBeInTheDocument();
+    expect(screen.getByText("shelfmark.complete")).toBeInTheDocument();
+    expect(screen.getByText("shelfmark.error")).toBeInTheDocument();
+  });
+
+  it("auto-selects prioritized status keys from status data", () => {
+    useWidgetAPI.mockReturnValue({
+      data: {
+        statuses: {
+          queued: 4,
+          available: 2,
+          done: 3,
+          error: 1,
+          resolving: 5,
+        },
+      },
+      error: undefined,
+    });
+
+    const service = { widget: { type: "shelfmark" } };
+    const { container } = renderWithProviders(<Component service={service} />, { settings: { hideErrors: false } });
+
+    expect(service.widget.fields).toEqual(["available", "error", "done", "queued"]);
+    expect(container.querySelectorAll(".service-block")).toHaveLength(4);
+    expectBlockValue(container, "shelfmark.available", 2);
+    expectBlockValue(container, "shelfmark.error", 1);
+    expectBlockValue(container, "shelfmark.done", 3);
+    expectBlockValue(container, "shelfmark.queued", 4);
+  });
+});

--- a/src/widgets/shelfmark/proxy.js
+++ b/src/widgets/shelfmark/proxy.js
@@ -1,0 +1,182 @@
+import cache from "memory-cache";
+
+import getServiceWidget from "utils/config/service-helpers";
+import createLogger from "utils/logger";
+import { formatApiCall } from "utils/proxy/api-helpers";
+import { httpProxy } from "utils/proxy/http";
+import widgets from "widgets/widgets";
+
+const proxyName = "shelfmarkProxyHandler";
+const sessionTokenCacheKey = `${proxyName}__sessionToken`;
+const logger = createLogger(proxyName);
+const allowedStatusKeys = new Set([
+  "requested",
+  "available",
+  "downloading",
+  "complete",
+  "error",
+  "cancelled",
+  "done",
+  "locating",
+  "queued",
+  "resolving",
+]);
+
+function extractAccessToken(payload) {
+  if (!payload || typeof payload !== "object") return null;
+
+  return payload.accessToken ?? payload.access_token ?? payload.token ?? payload.jwt ?? payload.id_token ?? null;
+}
+
+async function login(widget, service) {
+  if (!widget.username || !widget.password) {
+    logger.debug("Missing credentials for Shelfmark service '%s'", service);
+    return { accessToken: false };
+  }
+
+  const loginURL = widgets?.[widget.type]?.loginURL;
+  const loginUrl = new URL(formatApiCall(loginURL, widget));
+
+  const [status, , data] = await httpProxy(loginUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      accept: "application/json",
+    },
+    body: JSON.stringify({
+      username: widget.username,
+      password: widget.password,
+    }),
+  });
+
+  if (status !== 200) {
+    logger.debug("Shelfmark login failed for service '%s' with status %d", service, status);
+    return { accessToken: false };
+  }
+
+  try {
+    const accessToken = extractAccessToken(JSON.parse(data.toString()));
+
+    if (accessToken) {
+      cache.put(`${sessionTokenCacheKey}.${service}`, accessToken, 60 * 60 * 1000 - 60 * 1000);
+      return { accessToken };
+    }
+  } catch (e) {
+    logger.error("Unable to parse Shelfmark login response: %s", e);
+  }
+
+  // Some backends rely purely on session cookies from login.
+  return { accessToken: true };
+}
+
+async function apiCall(widget, endpoint, service) {
+  const cacheKey = `${sessionTokenCacheKey}.${service}`;
+  let accessToken = cache.get(cacheKey);
+
+  if (!accessToken) {
+    ({ accessToken } = await login(widget, service));
+  }
+
+  if (!accessToken) {
+    return { status: 401, data: null };
+  }
+
+  const headers = {
+    accept: "application/json",
+  };
+
+  if (typeof accessToken === "string") {
+    headers.Authorization = `Bearer ${accessToken}`;
+  }
+
+  const url = new URL(formatApiCall(widgets[widget.type].api, { ...widget, endpoint }));
+  let [status, , data] = await httpProxy(url, {
+    method: "GET",
+    headers,
+  });
+
+  if (status === 401 || status === 403) {
+    logger.debug("Shelfmark API rejected the request, attempting to obtain a new session token");
+    const refreshedToken = (await login(widget, service)).accessToken;
+    if (!refreshedToken) {
+      return { status, data: null };
+    }
+
+    if (typeof refreshedToken === "string") {
+      headers.Authorization = `Bearer ${refreshedToken}`;
+    } else {
+      delete headers.Authorization;
+    }
+
+    [status, , data] = await httpProxy(url, {
+      method: "GET",
+      headers,
+    });
+  }
+
+  if (status !== 200) {
+    logger.error("Error getting data from Shelfmark: %s status %d. Data: %s", url, status, data);
+    return { status, data: null };
+  }
+
+  try {
+    return { status, data: JSON.parse(data.toString()) };
+  } catch (e) {
+    logger.error("Error parsing Shelfmark response: %s", e);
+  }
+
+  return { status, data: null };
+}
+
+function summarizeStatusEntries(payload) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(payload)
+      .filter(([key, value]) => allowedStatusKeys.has(key) && value && typeof value === "object")
+      .map(([key, value]) => {
+        if (Array.isArray(value)) {
+          return [key, value.length];
+        }
+        return [key, Object.keys(value).length];
+      }),
+  );
+}
+
+export default async function shelfmarkProxyHandler(req, res) {
+  const { group, service, index } = req.query;
+
+  if (!group || !service) {
+    logger.debug("Invalid or missing service '%s' or group '%s'", service, group);
+    return res.status(400).json({ error: "Invalid proxy service type" });
+  }
+
+  const widget = await getServiceWidget(group, service, index);
+
+  if (!widget) {
+    logger.debug("Invalid or missing widget for service '%s' in group '%s'", service, group);
+    return res.status(400).json({ error: "Invalid proxy service type" });
+  }
+
+  if (!widget.username || !widget.password) {
+    logger.debug("Missing credentials for Shelfmark widget in service '%s'", service);
+    return res.status(400).json({ error: "Missing Shelfmark credentials" });
+  }
+
+  if (!widget.url) {
+    logger.debug("Missing URL for Shelfmark widget in service '%s'", service);
+    return res.status(400).json({ error: "Missing Shelfmark URL" });
+  }
+
+  const { data, status } = await apiCall(widget, "status", service);
+
+  if (status !== 200 || !data || typeof data !== "object") {
+    return res.status(status || 500).send(data || { error: "Error fetching status" });
+  }
+
+  return res.status(200).send({
+    statuses: summarizeStatusEntries(data),
+  });
+}

--- a/src/widgets/shelfmark/proxy.test.js
+++ b/src/widgets/shelfmark/proxy.test.js
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import createMockRes from "test-utils/create-mock-res";
+
+const { httpProxy, getServiceWidget, cache, logger } = vi.hoisted(() => {
+  const store = new Map();
+
+  return {
+    httpProxy: vi.fn(),
+    getServiceWidget: vi.fn(),
+    cache: {
+      get: vi.fn((k) => store.get(k)),
+      put: vi.fn((k, v) => store.set(k, v)),
+      del: vi.fn((k) => store.delete(k)),
+      _reset: () => store.clear(),
+    },
+    logger: {
+      debug: vi.fn(),
+      error: vi.fn(),
+    },
+  };
+});
+
+vi.mock("utils/logger", () => ({
+  default: () => logger,
+}));
+
+vi.mock("utils/config/service-helpers", () => ({
+  default: getServiceWidget,
+}));
+
+vi.mock("utils/proxy/http", () => ({
+  httpProxy,
+}));
+
+vi.mock("memory-cache", () => ({
+  default: cache,
+  ...cache,
+}));
+
+vi.mock("widgets/widgets", () => ({
+  default: {
+    shelfmark: {
+      api: "{url}/api/{endpoint}",
+      loginURL: "{url}/api/auth/login",
+    },
+  },
+}));
+
+import shelfmarkProxyHandler from "./proxy";
+
+describe("widgets/shelfmark/proxy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cache._reset();
+  });
+
+  it("returns 400 when Shelfmark credentials are missing", async () => {
+    getServiceWidget.mockResolvedValue({ type: "shelfmark", url: "https://shelfmark.example.com" });
+
+    const req = { query: { group: "g", service: "svc", index: "0" } };
+    const res = createMockRes();
+
+    await shelfmarkProxyHandler(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: "Missing Shelfmark credentials" });
+  });
+
+  it("returns 400 when Shelfmark URL is missing", async () => {
+    getServiceWidget.mockResolvedValue({
+      type: "shelfmark",
+      username: "u",
+      password: "p",
+    });
+
+    const req = { query: { group: "g", service: "svc", index: "0" } };
+    const res = createMockRes();
+
+    await shelfmarkProxyHandler(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: "Missing Shelfmark URL" });
+  });
+
+  it("logs in and summarizes status object lengths from /status", async () => {
+    getServiceWidget.mockResolvedValue({
+      type: "shelfmark",
+      url: "https://shelfmark.example.com",
+      username: "u",
+      password: "p",
+    });
+
+    httpProxy
+      .mockResolvedValueOnce([200, "application/json", Buffer.from(JSON.stringify({ accessToken: "tok" }))])
+      .mockResolvedValueOnce([
+        200,
+        "application/json",
+        Buffer.from(
+          JSON.stringify({
+            available: { a: { id: 1 }, b: { id: 2 } },
+            cancelled: {},
+            complete: { c: { id: 3 } },
+            done: { d: { id: 4 }, e: { id: 5 }, f: { id: 6 } },
+            queued: [{ id: 7 }, { id: 8 }],
+            meta: { healthy: true },
+          }),
+        ),
+      ]);
+
+    const req = { query: { group: "g", service: "svc", index: "0" } };
+    const res = createMockRes();
+
+    await shelfmarkProxyHandler(req, res);
+
+    expect(httpProxy).toHaveBeenCalledTimes(2);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      statuses: {
+        available: 2,
+        cancelled: 0,
+        complete: 1,
+        done: 3,
+        queued: 2,
+      },
+    });
+  });
+});

--- a/src/widgets/shelfmark/widget.js
+++ b/src/widgets/shelfmark/widget.js
@@ -1,0 +1,9 @@
+import shelfmarkProxyHandler from "./proxy";
+
+const widget = {
+  api: "{url}/api/{endpoint}",
+  loginURL: "{url}/api/auth/login",
+  proxyHandler: shelfmarkProxyHandler,
+};
+
+export default widget;

--- a/src/widgets/shelfmark/widget.test.js
+++ b/src/widgets/shelfmark/widget.test.js
@@ -1,0 +1,11 @@
+import { describe, it } from "vitest";
+
+import { expectWidgetConfigShape } from "test-utils/widget-config";
+
+import widget from "./widget";
+
+describe("shelfmark widget config", () => {
+  it("exports a valid widget config", () => {
+    expectWidgetConfigShape(widget);
+  });
+});

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -115,6 +115,7 @@ import rutorrent from "./rutorrent/widget";
 import sabnzbd from "./sabnzbd/widget";
 import scrutiny from "./scrutiny/widget";
 import seerr from "./seerr/widget";
+import shelfmark from "./shelfmark/widget";
 import slskd from "./slskd/widget";
 import sonarr from "./sonarr/widget";
 import sparkyfitness from "./sparkyfitness/widget";
@@ -273,6 +274,7 @@ const widgets = {
   sabnzbd,
   scrutiny,
   seerr,
+  shelfmark,
   slskd,
   sonarr,
   sparkyfitness,


### PR DESCRIPTION
Closes #6404 (discussion)

## Type of change

Adds a new service Widget for [Shelfmark](https://github.com/calibrain/shelfmark). With this you can view the status of downloaded e-books and audiobooks directly on homepage.

It uses the included `/status` Endpoint via authentication at the `/auth/login` Endpoint.

## Config Example:

```yaml
widget:
  type: shelfmark
  url: https://shelfmark.example.com
  username: username
  password: password
  # optional, max 4 fields:
  # fields: ["requested", "available", "cancelled", "complete", "done", "downloading", "error", "locating", "queued", "resolving"]
```


<!--
What type of change does your PR introduce to Homepage?
-->

- [x] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] In the description above I have disclosed the use of AI tools in the coding of this PR.
