### PR TITLE
Documentation: fix kubernetes config examples

### DIFF
--- a/kubernetes.md
+++ b/kubernetes.md
@@ -20,13 +20,13 @@ helm install my-release jameswynn/homepage
 Set the `mode` in the `kubernetes.yaml` to `cluster`.
 
 ```yaml
-mode: default
+mode: cluster
 ```
 
-To enable Kubernetes gateway-api compatibility, set `route` to `gateway`.
+To enable Kubernetes gateway-api compatibility, set `gateway` to `true`.
 
 ```yaml
-route: gateway
+gateway: true
 ```
 
 ## Widgets


### PR DESCRIPTION
## Summary

Fix incorrect Kubernetes configuration examples in :

- change  to 
- change  to 

## Why

The surrounding text says to set cluster mode and enable gateway compatibility, but the examples showed different values. This updates the examples to match the documented behavior.
