### PR TITLE
Fix: fix compatibility with flood changes

### DIFF
--- a/src/widgets/flood/proxy.js
+++ b/src/widgets/flood/proxy.js
@@ -12,7 +12,7 @@ async function login(widget) {
   const loginParams = {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: null,
+    body: "{}",
   };
 
   if (widget.username && widget.password) {

--- a/src/widgets/flood/proxy.test.js
+++ b/src/widgets/flood/proxy.test.js
@@ -45,7 +45,7 @@ describe("widgets/flood/proxy", () => {
     expect(httpProxy).toHaveBeenCalledTimes(3);
     expect(httpProxy.mock.calls[0][0].toString()).toBe("http://flood/api/stats");
     expect(httpProxy.mock.calls[1][0]).toBe("http://flood/api/auth/authenticate");
-    expect(httpProxy.mock.calls[1][1].body).toBeNull();
+    expect(httpProxy.mock.calls[1][1].body).toBe("{}");
     expect(httpProxy.mock.calls[2][0].toString()).toBe("http://flood/api/stats");
     expect(res.statusCode).toBe(200);
     expect(res.body).toEqual(Buffer.from("data"));


### PR DESCRIPTION
<!--
==== STOP ====================
======== STOP ================
============ STOP ============
================ STOP ========
==================== STOP ====

⚠️ Before opening this pull request please review the guidelines in the checklist below.

If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.
-->

## Proposed change

Fixes flood widget to work without credentials by using proper value empty `body` . In new versions of flood fastify+zod validation is used. Therefore `body: null` in combination of request header `content-type: application/json` is invalid, since null is not proper JSON.

For more info see `FST_ERR_CTP_EMPTY_JSON_BODY` (in case of `null` in body) and `FST_ERR_VALIDATION` (in case of `""`) fastify errors.

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

Closes # (issue)

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [ ] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] In the description above I have disclosed the use of AI tools in the coding of this PR.
