### PR TITLE
feat: add UGREEN NAS widget

### DIFF
--- a/docs/widgets/services/ugreen.md
+++ b/docs/widgets/services/ugreen.md
@@ -1,0 +1,21 @@
+---
+title: UGREEN NAS
+description: UGREEN NAS Widget Configuration
+---
+
+Learn more about [UGREEN NAS](https://nas.ugreen.com/).
+
+The UGREEN NAS widget provides system monitoring through the UGOS built-in API. Authentication uses the same credentials as the UGOS web interface.
+
+Allowed fields: `["cpu", "mem", "uptime", "cpuTemp", "netRx", "netTx", "fanSpeed", "diskRead", "diskWrite"]`.
+
+Up to 4 fields can be displayed at a time. The default fields are `cpu`, `mem`, `uptime`, and `cpuTemp`.
+
+```yaml
+widget:
+  type: ugreen
+  url: http://ugreen.host.or.ip:9999
+  username: admin
+  password: yourpassword
+  fields: ["cpu", "mem", "uptime", "cpuTemp"] # optional, default shown
+```

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -585,6 +585,17 @@
         "uptime": "Uptime",
         "alerts": "Alerts"
     },
+    "ugreen": {
+        "cpu": "CPU",
+        "mem": "MEM",
+        "uptime": "Uptime",
+        "cpuTemp": "CPU Temp",
+        "netRx": "Net Down",
+        "netTx": "Net Up",
+        "fanSpeed": "Fan",
+        "diskRead": "Disk Read",
+        "diskWrite": "Disk Write"
+    },
     "pyload": {
         "speed": "Speed",
         "active": "Active",

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -146,6 +146,7 @@ const components = {
   trilium: dynamic(() => import("./trilium/component")),
   tubearchivist: dynamic(() => import("./tubearchivist/component")),
   truenas: dynamic(() => import("./truenas/component")),
+  ugreen: dynamic(() => import("./ugreen/component")),
   unifi: dynamic(() => import("./unifi/component")),
   unifi_drive: dynamic(() => import("./unifi_drive/component")),
   unmanic: dynamic(() => import("./unmanic/component")),

--- a/src/widgets/ugreen/component.jsx
+++ b/src/widgets/ugreen/component.jsx
@@ -1,0 +1,58 @@
+import Block from "components/services/widget/block";
+import Container from "components/services/widget/container";
+import { useTranslation } from "next-i18next";
+
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+const DEFAULT_FIELDS = ["cpu", "mem", "uptime", "cpuTemp"];
+const MAX_ALLOWED_FIELDS = 4;
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+
+  const { widget } = service;
+
+  if (!widget.fields?.length) {
+    widget.fields = DEFAULT_FIELDS;
+  } else if (widget.fields.length > MAX_ALLOWED_FIELDS) {
+    widget.fields = widget.fields.slice(0, MAX_ALLOWED_FIELDS);
+  }
+
+  const { data: statsData, error: statsError } = useWidgetAPI(widget, "stats");
+  const { data: statusData, error: statusError } = useWidgetAPI(widget, "status");
+
+  if (statsError || statusError) {
+    const finalError = statsError ?? statusError;
+    return <Container service={service} error={finalError} />;
+  }
+
+  if (!statsData || !statusData) {
+    return (
+      <Container service={service}>
+        <Block label="ugreen.cpu" />
+        <Block label="ugreen.mem" />
+        <Block label="ugreen.uptime" />
+        <Block label="ugreen.cpuTemp" />
+        <Block label="ugreen.netRx" />
+        <Block label="ugreen.netTx" />
+        <Block label="ugreen.fanSpeed" />
+        <Block label="ugreen.diskRead" />
+        <Block label="ugreen.diskWrite" />
+      </Container>
+    );
+  }
+
+  return (
+    <Container service={service}>
+      <Block label="ugreen.cpu" value={t("common.percent", { value: statsData.cpu })} />
+      <Block label="ugreen.mem" value={t("common.percent", { value: statsData.mem })} />
+      <Block label="ugreen.uptime" value={t("common.duration", { value: statusData.uptime })} />
+      <Block label="ugreen.cpuTemp" value={`${t("common.number", { value: statsData.cpuTemp })} °C`} />
+      <Block label="ugreen.netRx" value={t("common.byterate", { value: statsData.netRx })} />
+      <Block label="ugreen.netTx" value={t("common.byterate", { value: statsData.netTx })} />
+      <Block label="ugreen.fanSpeed" value={`${t("common.number", { value: statsData.cpuFan })} RPM`} />
+      <Block label="ugreen.diskRead" value={t("common.byterate", { value: statsData.diskRead })} />
+      <Block label="ugreen.diskWrite" value={t("common.byterate", { value: statsData.diskWrite })} />
+    </Container>
+  );
+}

--- a/src/widgets/ugreen/component.test.jsx
+++ b/src/widgets/ugreen/component.test.jsx
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+
+import { screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "test-utils/render-with-providers";
+import { expectBlockValue } from "test-utils/widget-assertions";
+
+const { useWidgetAPI } = vi.hoisted(() => ({ useWidgetAPI: vi.fn() }));
+
+vi.mock("utils/proxy/use-widget-api", () => ({ default: useWidgetAPI }));
+
+import Component from "./component";
+
+describe("widgets/ugreen/component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders placeholders while loading with default fields", () => {
+    useWidgetAPI.mockReturnValue({ data: undefined, error: undefined });
+
+    const service = { widget: { type: "ugreen" } };
+    const { container } = renderWithProviders(<Component service={service} />, { settings: { hideErrors: false } });
+
+    expect(service.widget.fields).toEqual(["cpu", "mem", "uptime", "cpuTemp"]);
+    expect(container.querySelectorAll(".service-block")).toHaveLength(4);
+    expect(screen.getByText("ugreen.cpu")).toBeInTheDocument();
+    expect(screen.getByText("ugreen.mem")).toBeInTheDocument();
+    expect(screen.getByText("ugreen.uptime")).toBeInTheDocument();
+    expect(screen.getByText("ugreen.cpuTemp")).toBeInTheDocument();
+  });
+
+  it("limits fields to MAX_ALLOWED_FIELDS", () => {
+    useWidgetAPI.mockReturnValue({ data: undefined, error: undefined });
+
+    const service = {
+      widget: { type: "ugreen", fields: ["cpu", "mem", "uptime", "cpuTemp", "netRx"] },
+    };
+    renderWithProviders(<Component service={service} />, { settings: { hideErrors: false } });
+
+    expect(service.widget.fields).toEqual(["cpu", "mem", "uptime", "cpuTemp"]);
+  });
+
+  it("renders stats and status data when loaded", () => {
+    useWidgetAPI.mockImplementation((_widget, endpoint) => {
+      if (endpoint === "stats") {
+        return {
+          data: {
+            cpu: 25.5,
+            mem: 60.2,
+            cpuTemp: 45,
+            netRx: 1024000,
+            netTx: 512000,
+            cpuFan: 1200,
+            diskRead: 2048000,
+            diskWrite: 1024000,
+          },
+          error: undefined,
+        };
+      }
+      if (endpoint === "status") {
+        return {
+          data: { uptime: 86400, serverStatus: 2, devName: "UGreen Tempest" },
+          error: undefined,
+        };
+      }
+      return { data: undefined, error: undefined };
+    });
+
+    const service = { widget: { type: "ugreen" } };
+    const { container } = renderWithProviders(<Component service={service} />, { settings: { hideErrors: false } });
+
+    expectBlockValue(container, "ugreen.cpu", 25.5);
+    expectBlockValue(container, "ugreen.mem", 60.2);
+    expectBlockValue(container, "ugreen.uptime", 86400);
+    expectBlockValue(container, "ugreen.cpuTemp", 45);
+  });
+
+  it("renders custom fields", () => {
+    useWidgetAPI.mockImplementation((_widget, endpoint) => {
+      if (endpoint === "stats") {
+        return {
+          data: { cpu: 10, mem: 20, cpuTemp: 40, netRx: 1000, netTx: 500, cpuFan: 1200, diskRead: 0, diskWrite: 0 },
+          error: undefined,
+        };
+      }
+      if (endpoint === "status") {
+        return { data: { uptime: 3600 }, error: undefined };
+      }
+      return { data: undefined, error: undefined };
+    });
+
+    const service = { widget: { type: "ugreen", fields: ["cpu", "netRx", "netTx", "fanSpeed"] } };
+    const { container } = renderWithProviders(<Component service={service} />, { settings: { hideErrors: false } });
+
+    expect(container.querySelectorAll(".service-block")).toHaveLength(4);
+  });
+
+  it("renders error state", () => {
+    useWidgetAPI.mockImplementation((_widget, endpoint) => {
+      if (endpoint === "stats") {
+        return { data: undefined, error: { message: "Connection refused" } };
+      }
+      return { data: undefined, error: undefined };
+    });
+
+    renderWithProviders(<Component service={{ widget: { type: "ugreen" } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expect(screen.getByText("Connection refused")).toBeInTheDocument();
+  });
+});

--- a/src/widgets/ugreen/proxy.js
+++ b/src/widgets/ugreen/proxy.js
@@ -1,0 +1,193 @@
+import crypto from "crypto";
+
+import cache from "memory-cache";
+
+import getServiceWidget from "utils/config/service-helpers";
+import createLogger from "utils/logger";
+import { formatApiCall } from "utils/proxy/api-helpers";
+import { httpProxy } from "utils/proxy/http";
+import widgets from "widgets/widgets";
+
+const proxyName = "ugreenProxyHandler";
+const tokenCacheKey = `${proxyName}__token`;
+const logger = createLogger(proxyName);
+
+async function login(widget, service) {
+  const { url, username, password } = widget;
+
+  // Step 1: Get RSA public key
+  const checkUrl = `${url}/ugreen/v1/verify/check?token=`;
+  const checkResponse = await httpProxy(checkUrl, {
+    method: "POST",
+    body: JSON.stringify({ username }),
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+
+  const checkStatus = checkResponse[0];
+  const checkHeaders = checkResponse[3];
+
+  if (checkStatus !== 200) {
+    logger.error("Failed to get RSA public key from UGREEN NAS, status %d", checkStatus);
+    return [checkStatus, null];
+  }
+
+  const rsaToken = checkHeaders?.["x-rsa-token"];
+  if (!rsaToken) {
+    logger.error("No x-rsa-token header in UGREEN verify/check response");
+    return [500, null];
+  }
+
+  // Step 2: Encrypt password with RSA public key
+  let encryptedPassword;
+  try {
+    let keyPem = Buffer.from(rsaToken, "base64").toString("utf-8");
+    // UGOS sends mislabeled PEM: header says PKCS#1 but data is SPKI
+    keyPem = keyPem.replace("BEGIN RSA PUBLIC KEY", "BEGIN PUBLIC KEY").replace("END RSA PUBLIC KEY", "END PUBLIC KEY");
+    const publicKey = crypto.createPublicKey({ key: keyPem, format: "pem" });
+    encryptedPassword = crypto.publicEncrypt({ key: publicKey, padding: crypto.constants.RSA_PKCS1_PADDING }, Buffer.from(password)).toString("base64");
+  } catch (e) {
+    logger.error("Failed to encrypt password for UGREEN NAS: %s", e.message);
+    return [500, null];
+  }
+
+  // Step 3: Login with encrypted password
+  const loginUrl = `${url}/ugreen/v1/verify/login`;
+  const loginResponse = await httpProxy(loginUrl, {
+    method: "POST",
+    body: JSON.stringify({
+      is_simple: true,
+      keepalive: true,
+      otp: false,
+      username,
+      password: encryptedPassword,
+    }),
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+
+  const loginStatus = loginResponse[0];
+  let loginData;
+  try {
+    loginData = JSON.parse(Buffer.from(loginResponse[2]).toString());
+  } catch {
+    logger.error("Failed to parse UGREEN login response");
+    return [loginStatus, null];
+  }
+
+  if (loginStatus !== 200 || loginData.code !== 200) {
+    logger.error("UGREEN login failed with code %d", loginData.code ?? loginStatus);
+    return [loginStatus === 200 ? 401 : loginStatus, null];
+  }
+
+  const token = loginData.data?.token;
+  if (token) {
+    cache.put(`${tokenCacheKey}.${service}`, token);
+  }
+
+  return [200, token];
+}
+
+export default async function ugreenProxyHandler(req, res, map) {
+  const { group, service, endpoint, index } = req.query;
+
+  if (!group || !service) {
+    return res.status(400).json({ error: "Invalid proxy service type" });
+  }
+
+  const widget = await getServiceWidget(group, service, index);
+
+  if (!widget) {
+    return res.status(400).json({ error: "Invalid proxy service type" });
+  }
+
+  if (!widgets?.[widget.type]?.api) {
+    return res.status(403).json({ error: "Service does not support API calls" });
+  }
+
+  const url = new URL(formatApiCall(widgets[widget.type].api, { endpoint, ...widget }));
+
+  let status;
+  let data;
+
+  // Check cache for existing token
+  let token = cache.get(`${tokenCacheKey}.${service}`);
+  if (!token) {
+    [status, token] = await login(widget, service);
+    if (status !== 200) {
+      return res.status(status).json({ error: "Failed to authenticate with UGREEN NAS" });
+    }
+  }
+
+  // Append token to URL
+  url.searchParams.set("token", token);
+
+  [status, , data] = await httpProxy(url, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+
+  // Check for token expiry (UGOS returns code 1024)
+  if (status === 200) {
+    try {
+      const json = JSON.parse(Buffer.from(data).toString());
+      if (json.code === 1024) {
+        logger.debug("UGREEN token expired, re-authenticating");
+        cache.del(`${tokenCacheKey}.${service}`);
+        [status, token] = await login(widget, service);
+        if (status !== 200) {
+          return res.status(status).json({ error: "Failed to re-authenticate with UGREEN NAS" });
+        }
+
+        url.searchParams.set("token", token);
+        [status, , data] = await httpProxy(url, {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+          },
+        });
+      }
+    } catch {
+      // response wasn't JSON, pass through
+    }
+  }
+
+  // Handle HTTP-level auth failures
+  if ([401, 403].includes(status)) {
+    logger.debug("HTTP %d from UGREEN, re-authenticating", status);
+    cache.del(`${tokenCacheKey}.${service}`);
+    [status, token] = await login(widget, service);
+    if (status !== 200) {
+      return res.status(status).json({ error: "Failed to re-authenticate with UGREEN NAS" });
+    }
+
+    url.searchParams.set("token", token);
+    [status, , data] = await httpProxy(url, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+
+  if (status !== 200) {
+    logger.debug("HTTP %d from UGREEN API endpoint", status);
+    return res.status(status).send(data);
+  }
+
+  let responseData = data;
+  if (map) {
+    try {
+      responseData = JSON.parse(Buffer.from(data).toString());
+      responseData = map(responseData);
+    } catch {
+      // pass through raw data if parsing fails
+    }
+  }
+
+  return res.status(200).json(responseData);
+}

--- a/src/widgets/ugreen/proxy.test.js
+++ b/src/widgets/ugreen/proxy.test.js
@@ -1,0 +1,202 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import createMockRes from "test-utils/create-mock-res";
+
+const { httpProxy, getServiceWidget, cache, logger } = vi.hoisted(() => {
+  const store = new Map();
+
+  return {
+    httpProxy: vi.fn(),
+    getServiceWidget: vi.fn(),
+    cache: {
+      get: vi.fn((k) => store.get(k)),
+      put: vi.fn((k, v) => store.set(k, v)),
+      del: vi.fn((k) => store.delete(k)),
+      _reset: () => store.clear(),
+    },
+    logger: {
+      debug: vi.fn(),
+      error: vi.fn(),
+    },
+  };
+});
+
+vi.mock("utils/logger", () => ({
+  default: () => logger,
+}));
+
+vi.mock("utils/config/service-helpers", () => ({
+  default: getServiceWidget,
+}));
+
+vi.mock("utils/proxy/http", () => ({
+  httpProxy,
+}));
+
+vi.mock("memory-cache", () => ({
+  default: cache,
+  ...cache,
+}));
+
+vi.mock("widgets/widgets", () => ({
+  default: {
+    ugreen: {
+      api: "{url}/{endpoint}",
+      mappings: {
+        stats: { endpoint: "ugreen/v1/taskmgr/stat/get_all" },
+        status: { endpoint: "ugreen/v1/desktop/components/data?id=desktop.component.SystemStatus" },
+        storage: { endpoint: "ugreen/v1/storage/pool/list" },
+      },
+    },
+  },
+}));
+
+// Mock crypto for RSA operations
+vi.mock("crypto", () => ({
+  default: {
+    createPublicKey: vi.fn(() => "mock-public-key"),
+    publicEncrypt: vi.fn(() => Buffer.from("encrypted-password")),
+    constants: { RSA_PKCS1_PADDING: 1 },
+  },
+}));
+
+import ugreenProxyHandler from "./proxy";
+
+describe("widgets/ugreen/proxy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cache._reset();
+  });
+
+  it("returns 400 when group or service is missing", async () => {
+    const req = { query: {} };
+    const res = createMockRes();
+
+    await ugreenProxyHandler(req, res);
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("performs RSA login flow and uses token for API requests", async () => {
+    getServiceWidget.mockResolvedValue({
+      type: "ugreen",
+      url: "http://ugreen",
+      username: "admin",
+      password: "secret",
+    });
+
+    httpProxy
+      // Step 1: verify/check returns RSA key
+      .mockResolvedValueOnce([
+        200,
+        "application/json",
+        Buffer.from(JSON.stringify({ code: 200 })),
+        { "x-rsa-token": Buffer.from("mock-rsa-key").toString("base64") },
+      ])
+      // Step 2: verify/login returns token
+      .mockResolvedValueOnce([
+        200,
+        "application/json",
+        Buffer.from(JSON.stringify({ code: 200, data: { token: "tok123" } })),
+      ])
+      // Step 3: actual API call
+      .mockResolvedValueOnce([
+        200,
+        "application/json",
+        Buffer.from(JSON.stringify({ code: 200, data: { overview: {} } })),
+      ]);
+
+    const req = {
+      query: { group: "g", service: "svc", endpoint: "ugreen/v1/taskmgr/stat/get_all", index: "0" },
+    };
+    const res = createMockRes();
+
+    await ugreenProxyHandler(req, res);
+
+    expect(httpProxy).toHaveBeenCalledTimes(3);
+    // verify/check
+    expect(httpProxy.mock.calls[0][0]).toBe("http://ugreen/ugreen/v1/verify/check?token=");
+    // verify/login
+    expect(httpProxy.mock.calls[1][0]).toBe("http://ugreen/ugreen/v1/verify/login");
+    // API call with token
+    expect(httpProxy.mock.calls[2][0].toString()).toContain("token=tok123");
+    expect(res.json).toHaveBeenCalled();
+  });
+
+  it("uses cached token and skips login", async () => {
+    cache.put("ugreenProxyHandler__token.svc", "cached-token");
+
+    getServiceWidget.mockResolvedValue({
+      type: "ugreen",
+      url: "http://ugreen",
+      username: "admin",
+      password: "secret",
+    });
+
+    httpProxy.mockResolvedValueOnce([
+      200,
+      "application/json",
+      Buffer.from(JSON.stringify({ code: 200, data: {} })),
+    ]);
+
+    const req = {
+      query: { group: "g", service: "svc", endpoint: "ugreen/v1/taskmgr/stat/get_all", index: "0" },
+    };
+    const res = createMockRes();
+
+    await ugreenProxyHandler(req, res);
+
+    // Only the API call, no login
+    expect(httpProxy).toHaveBeenCalledTimes(1);
+    expect(httpProxy.mock.calls[0][0].toString()).toContain("token=cached-token");
+  });
+
+  it("re-authenticates when UGOS returns code 1024 (token expired)", async () => {
+    cache.put("ugreenProxyHandler__token.svc", "expired-token");
+
+    getServiceWidget.mockResolvedValue({
+      type: "ugreen",
+      url: "http://ugreen",
+      username: "admin",
+      password: "secret",
+    });
+
+    httpProxy
+      // First API call returns code 1024
+      .mockResolvedValueOnce([
+        200,
+        "application/json",
+        Buffer.from(JSON.stringify({ code: 1024 })),
+      ])
+      // Re-auth: verify/check
+      .mockResolvedValueOnce([
+        200,
+        "application/json",
+        Buffer.from(JSON.stringify({ code: 200 })),
+        { "x-rsa-token": Buffer.from("mock-rsa-key").toString("base64") },
+      ])
+      // Re-auth: verify/login
+      .mockResolvedValueOnce([
+        200,
+        "application/json",
+        Buffer.from(JSON.stringify({ code: 200, data: { token: "new-token" } })),
+      ])
+      // Retry API call
+      .mockResolvedValueOnce([
+        200,
+        "application/json",
+        Buffer.from(JSON.stringify({ code: 200, data: { overview: {} } })),
+      ]);
+
+    const req = {
+      query: { group: "g", service: "svc", endpoint: "ugreen/v1/taskmgr/stat/get_all", index: "0" },
+    };
+    const res = createMockRes();
+
+    await ugreenProxyHandler(req, res);
+
+    expect(httpProxy).toHaveBeenCalledTimes(4);
+    expect(cache.del).toHaveBeenCalledWith("ugreenProxyHandler__token.svc");
+    expect(res.json).toHaveBeenCalled();
+  });
+});

--- a/src/widgets/ugreen/widget.js
+++ b/src/widgets/ugreen/widget.js
@@ -1,0 +1,52 @@
+import ugreenProxyHandler from "./proxy";
+
+const widget = {
+  api: "{url}/{endpoint}",
+  proxyHandler: ugreenProxyHandler,
+
+  mappings: {
+    stats: {
+      endpoint: "ugreen/v1/taskmgr/stat/get_all",
+      map: (data) => ({
+        cpu: data.data?.overview?.cpu?.[0]?.used_percent,
+        cpuTemp: data.data?.overview?.cpu?.[0]?.temp,
+        mem: data.data?.overview?.mem?.[0]?.used_percent,
+        netRx: data.data?.net?.series?.[0]?.recv_rate,
+        netTx: data.data?.net?.series?.[0]?.send_rate,
+        diskRead: data.data?.disk?.series?.[0]?.read_rate,
+        diskWrite: data.data?.disk?.series?.[0]?.write_rate,
+        cpuFan: data.data?.overview?.cpu_fan?.[0]?.speed,
+        deviceFans: data.data?.overview?.device_fan,
+        diskTemps: data.data?.disk?.series?.slice(1)?.map((d) => ({
+          name: d.name,
+          temp: d.temperature,
+        })),
+      }),
+    },
+    status: {
+      endpoint: "ugreen/v1/desktop/components/data?id=desktop.component.SystemStatus",
+      map: (data) => ({
+        uptime: data.data?.total_run_time,
+        serverStatus: data.data?.server_status,
+        devName: data.data?.dev_name,
+      }),
+    },
+    storage: {
+      endpoint: "ugreen/v1/storage/pool/list",
+      map: (data) => {
+        const pools = data.data?.result ?? [];
+        return pools.map((pool) => ({
+          name: pool.name,
+          label: pool.label,
+          level: pool.level,
+          status: pool.status,
+          total: pool.total,
+          used: pool.used,
+          free: pool.free,
+        }));
+      },
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/ugreen/widget.test.js
+++ b/src/widgets/ugreen/widget.test.js
@@ -1,0 +1,11 @@
+import { describe, it } from "vitest";
+
+import { expectWidgetConfigShape } from "test-utils/widget-config";
+
+import widget from "./widget";
+
+describe("ugreen widget config", () => {
+  it("exports a valid widget config", () => {
+    expectWidgetConfigShape(widget);
+  });
+});

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -136,6 +136,7 @@ import transmission from "./transmission/widget";
 import trilium from "./trilium/widget";
 import truenas from "./truenas/widget";
 import tubearchivist from "./tubearchivist/widget";
+import ugreen from "./ugreen/widget";
 import unifi from "./unifi/widget";
 import unifi_drive from "./unifi_drive/widget";
 import unmanic from "./unmanic/widget";
@@ -295,6 +296,7 @@ const widgets = {
   trilium,
   tubearchivist,
   truenas,
+  ugreen,
   unifi,
   unifi_console: unifi,
   unifi_drive,


### PR DESCRIPTION
## Summary
- Adds a native widget for UGREEN NAS devices (UGOS API)
- RSA-encrypted authentication flow against the NAS directly — no Home Assistant required
- Supports 9 configurable fields: `cpu`, `mem`, `uptime`, `cpuTemp`, `netRx`, `netTx`, `fanSpeed`, `diskRead`, `diskWrite`
- Includes proxy handler, widget definition, React component, tests, translations, and docs

Resolves #6451

## Configuration

```yaml
widget:
  type: ugreen
  url: http://ugreen.host.or.ip:9999
  username: admin
  password: yourpassword
  fields: ["cpu", "mem", "uptime", "cpuTemp"] # optional, up to 4
```

## Test plan
- [x] Tested all 9 fields against a live UGREEN DXP480T Plus running UGOS 1.12.1
- [x] Verified RSA login flow, token caching, and token expiry re-auth
- [x] All unit tests pass (10/10 — widget, proxy, component)
- [x] Field filtering via `widget.fields` works correctly (max 4)
- [ ] Needs testing on other UGREEN models