### PR TITLE
Feature: add Remnawave widget

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -285,6 +285,12 @@
         "queued": "Queued",
         "books": "Books"
     },
+    "remnawave": {
+        "onlineNow": "Online Now",
+        "nodesOnline": "Nodes Online",
+        "bandwidthToday": "BW Today",
+        "bandwidthSevenDays": "BW 7 Days"
+    },
     "bazarr": {
         "missingEpisodes": "Missing Episodes",
         "missingMovies": "Missing Movies"

--- a/src/utils/proxy/handlers/credentialed.js
+++ b/src/utils/proxy/handlers/credentialed.js
@@ -62,6 +62,7 @@ export default async function credentialedProxyHandler(req, res, map) {
           "mealie",
           "netalertx",
           "pangolin",
+          "remnawave",
           "tailscale",
           "tandoor",
           "tracearr",

--- a/src/widgets/remnawave/component.jsx
+++ b/src/widgets/remnawave/component.jsx
@@ -1,0 +1,42 @@
+import Block from "components/services/widget/block";
+import Container from "components/services/widget/container";
+import { useTranslation } from "next-i18next";
+
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+  const { widget } = service;
+
+  const { data: statsData, error: statsError } = useWidgetAPI(widget, "stats");
+  const { data: bandwidthData, error: bandwidthError } = useWidgetAPI(widget, "stats/bandwidth");
+
+  if (statsError || bandwidthError) {
+    return <Container service={service} error={statsError || bandwidthError} />;
+  }
+
+  if (!statsData || !bandwidthData) {
+    return (
+      <Container service={service}>
+        <Block label="remnawave.onlineNow" />
+        <Block label="remnawave.nodesOnline" />
+        <Block label="remnawave.bandwidthToday" />
+        <Block label="remnawave.bandwidthSevenDays" />
+      </Container>
+    );
+  }
+
+  const onlineNow = statsData.response?.onlineStats?.onlineNow ?? 0;
+  const nodesOnline = statsData.response?.nodes?.totalOnline ?? 0;
+  const bandwidthToday = parseInt(bandwidthData.response?.bandwidthLastTwoDays?.current ?? "0", 10);
+  const bandwidthSevenDays = parseInt(bandwidthData.response?.bandwidthLastSevenDays?.current ?? "0", 10);
+
+  return (
+    <Container service={service}>
+      <Block label="remnawave.onlineNow" value={t("common.number", { value: onlineNow })} />
+      <Block label="remnawave.nodesOnline" value={t("common.number", { value: nodesOnline })} />
+      <Block label="remnawave.bandwidthToday" value={t("common.bytes", { value: bandwidthToday })} />
+      <Block label="remnawave.bandwidthSevenDays" value={t("common.bytes", { value: bandwidthSevenDays })} />
+    </Container>
+  );
+}

--- a/src/widgets/remnawave/component.test.jsx
+++ b/src/widgets/remnawave/component.test.jsx
@@ -39,6 +39,57 @@ describe("widgets/remnawave/component", () => {
     expect(screen.getByText(/boom/)).toBeInTheDocument();
   });
 
+  it("renders error when only bandwidth endpoint fails", () => {
+    useWidgetAPI.mockImplementation((_widget, endpoint) => {
+      if (endpoint === "stats") {
+        return { data: { response: {} }, error: undefined };
+      }
+      return { data: undefined, error: { message: "bandwidth failed" } };
+    });
+
+    const service = { widget: { type: "remnawave" } };
+    renderWithProviders(<Component service={service} />, { settings: { hideErrors: false } });
+
+    expect(screen.getByText(/widget\.api_error\s+widget\.information/)).toBeInTheDocument();
+    expect(screen.getByText(/bandwidth failed/)).toBeInTheDocument();
+  });
+
+  it("renders placeholders when stats loads but bandwidth is still loading", () => {
+    useWidgetAPI.mockImplementation((_widget, endpoint) => {
+      if (endpoint === "stats") {
+        return { data: { response: {} }, error: undefined };
+      }
+      return { data: undefined, error: undefined };
+    });
+
+    const service = { widget: { type: "remnawave" } };
+    const { container } = renderWithProviders(<Component service={service} />, { settings: { hideErrors: false } });
+
+    expect(container.querySelectorAll(".service-block")).toHaveLength(4);
+    expect(screen.getByText("remnawave.onlineNow")).toBeInTheDocument();
+  });
+
+  it("falls back to zero when response fields are missing", () => {
+    useWidgetAPI.mockImplementation((_widget, endpoint) => {
+      if (endpoint === "stats") {
+        return { data: { response: {} }, error: undefined };
+      }
+      if (endpoint === "stats/bandwidth") {
+        return { data: { response: {} }, error: undefined };
+      }
+      return { data: undefined, error: undefined };
+    });
+
+    const { container } = renderWithProviders(<Component service={{ widget: { type: "remnawave" } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expectBlockValue(container, "remnawave.onlineNow", 0);
+    expectBlockValue(container, "remnawave.nodesOnline", 0);
+    expectBlockValue(container, "remnawave.bandwidthToday", 0);
+    expectBlockValue(container, "remnawave.bandwidthSevenDays", 0);
+  });
+
   it("renders stats and bandwidth data", () => {
     useWidgetAPI.mockImplementation((_widget, endpoint) => {
       if (endpoint === "stats") {

--- a/src/widgets/remnawave/component.test.jsx
+++ b/src/widgets/remnawave/component.test.jsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+
+import { screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "test-utils/render-with-providers";
+import { expectBlockValue } from "test-utils/widget-assertions";
+
+const { useWidgetAPI } = vi.hoisted(() => ({ useWidgetAPI: vi.fn() }));
+vi.mock("utils/proxy/use-widget-api", () => ({ default: useWidgetAPI }));
+
+import Component from "./component";
+
+describe("widgets/remnawave/component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders placeholders while loading", () => {
+    useWidgetAPI.mockReturnValue({ data: undefined, error: undefined });
+
+    const service = { widget: { type: "remnawave" } };
+    const { container } = renderWithProviders(<Component service={service} />, { settings: { hideErrors: false } });
+
+    expect(container.querySelectorAll(".service-block")).toHaveLength(4);
+    expect(screen.getByText("remnawave.onlineNow")).toBeInTheDocument();
+    expect(screen.getByText("remnawave.nodesOnline")).toBeInTheDocument();
+    expect(screen.getByText("remnawave.bandwidthToday")).toBeInTheDocument();
+    expect(screen.getByText("remnawave.bandwidthSevenDays")).toBeInTheDocument();
+  });
+
+  it("renders error state", () => {
+    useWidgetAPI.mockReturnValue({ data: undefined, error: { message: "boom" } });
+
+    const service = { widget: { type: "remnawave" } };
+    renderWithProviders(<Component service={service} />, { settings: { hideErrors: false } });
+
+    expect(screen.getByText(/widget\.api_error\s+widget\.information/)).toBeInTheDocument();
+    expect(screen.getByText(/boom/)).toBeInTheDocument();
+  });
+
+  it("renders stats and bandwidth data", () => {
+    useWidgetAPI.mockImplementation((_widget, endpoint) => {
+      if (endpoint === "stats") {
+        return {
+          data: {
+            response: {
+              onlineStats: { onlineNow: 42 },
+              nodes: { totalOnline: 5 },
+            },
+          },
+          error: undefined,
+        };
+      }
+
+      if (endpoint === "stats/bandwidth") {
+        return {
+          data: {
+            response: {
+              bandwidthLastTwoDays: { current: "1073741824" },
+              bandwidthLastSevenDays: { current: "10737418240" },
+            },
+          },
+          error: undefined,
+        };
+      }
+
+      return { data: undefined, error: undefined };
+    });
+
+    const { container } = renderWithProviders(<Component service={{ widget: { type: "remnawave" } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expectBlockValue(container, "remnawave.onlineNow", 42);
+    expectBlockValue(container, "remnawave.nodesOnline", 5);
+    expectBlockValue(container, "remnawave.bandwidthToday", 1073741824);
+    expectBlockValue(container, "remnawave.bandwidthSevenDays", 10737418240);
+  });
+});

--- a/src/widgets/remnawave/widget.js
+++ b/src/widgets/remnawave/widget.js
@@ -1,0 +1,17 @@
+import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
+
+const widget = {
+  api: "{url}/api/system/{endpoint}",
+  proxyHandler: credentialedProxyHandler,
+
+  mappings: {
+    stats: {
+      endpoint: "stats",
+    },
+    "stats/bandwidth": {
+      endpoint: "stats/bandwidth",
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/remnawave/widget.test.js
+++ b/src/widgets/remnawave/widget.test.js
@@ -1,0 +1,11 @@
+import { describe, it } from "vitest";
+
+import { expectWidgetConfigShape } from "test-utils/widget-config";
+
+import widget from "./widget";
+
+describe("remnawave widget config", () => {
+  it("exports a valid widget config", () => {
+    expectWidgetConfigShape(widget);
+  });
+});

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -110,6 +110,7 @@ import qbittorrent from "./qbittorrent/widget";
 import qnap from "./qnap/widget";
 import radarr from "./radarr/widget";
 import readarr from "./readarr/widget";
+import remnawave from "./remnawave/widget";
 import romm from "./romm/widget";
 import rutorrent from "./rutorrent/widget";
 import sabnzbd from "./sabnzbd/widget";
@@ -269,6 +270,7 @@ const widgets = {
   qnap,
   radarr,
   readarr,
+  remnawave,
   romm,
   rutorrent,
   sabnzbd,


### PR DESCRIPTION
## Summary

Add a new widget for [Remnawave](https://github.com/remnawave/panel), a modern proxy management panel built on Xray-core. Remnawave manages VPN/proxy users, nodes, traffic limits, and subscriptions. This widget surfaces key operational stats directly in the Homepage dashboard.

The widget displays four metrics:
- **Online Now** — currently connected users
- **Nodes Online** — active proxy nodes
- **BW Today** — bandwidth consumed today (auto-formatted)
- **BW 7 Days** — bandwidth consumed over the last 7 days (auto-formatted)

## Changes

### New files

| File | Purpose |
|------|---------|
| `src/widgets/remnawave/widget.js` | Widget definition with two API endpoint mappings (`stats` and `stats/bandwidth`). Uses the credentialed proxy handler for Bearer token auth. API template: `{url}/api/system/{endpoint}`. |
| `src/widgets/remnawave/component.jsx` | React component that renders the four stat blocks. Reads from `response.onlineStats.onlineNow`, `response.nodes.totalOnline`, `response.bandwidthLastTwoDays.current`, and `response.bandwidthLastSevenDays.current`. Bandwidth values are passed through the byte-formatting utility. |
| `src/widgets/remnawave/widget.test.js` | Validates the widget configuration shape (endpoints, proxy handler, API URL template). |
| `src/widgets/remnawave/component.test.jsx` | Component tests covering loading, error, and successful data rendering states. |

### Modified files

| File | Change |
|------|--------|
| `src/widgets/widgets.js` | Added `remnawave` import and registry entry, inserted alphabetically between `readarr` and `romm`. |
| `src/utils/proxy/handlers/credentialed.js` | Added `"remnawave"` to the Bearer token authentication list, inserted alphabetically between `pangolin` and `tailscale`. |
| `public/locales/en/common.json` | Added translation keys under `remnawave`: `onlineNow`, `nodesOnline`, `bandwidthToday`, `bandwidthSevenDays`. |

## Configuration

Users create an API token in the Remnawave panel UI and provide it as `key` in `services.yaml`:

```yaml
- Remnawave:
    icon: remnawave.png
    href: https://panel.example.com
    widget:
      type: remnawave
      url: https://panel.example.com
      key: your-api-token
```

## API Endpoints

| Endpoint | Method | Returns |
|----------|--------|---------|
| `/api/system/stats` | GET | Online user count, nodes online count |
| `/api/system/stats/bandwidth` | GET | Bandwidth comparison data (today, 7 days, 30 days, etc.) |

Both endpoints require a Bearer token in the `Authorization` header. The credentialed proxy handler manages this automatically when the user provides `key` in their widget config.

## Screenshots

<!-- Add screenshots of the widget in light and dark mode here -->

## Test Plan

- [ ] Verify the widget renders all four stat blocks with correct labels and values when the Remnawave API returns valid data
- [ ] Verify the widget displays the loading skeleton while API requests are in flight
- [ ] Verify the widget handles API errors gracefully (shows error state, does not crash)
- [ ] Verify bandwidth values are formatted correctly (bytes, KB, MB, GB as appropriate)
- [ ] Verify the widget works with a real Remnawave instance using a valid API token
- [ ] Verify the widget appears in the correct alphabetical position in the widget registry
- [ ] Verify Bearer token authentication is sent correctly via the credentialed proxy handler
- [ ] Run `npm test` — all new and existing tests pass
- [ ] Run `npm run lint` — no lint errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)