### PR TITLE
Update Watchtower documentation with maintenance note

### DIFF
--- a/docs/widgets/services/watchtower.md
+++ b/docs/widgets/services/watchtower.md
@@ -15,4 +15,4 @@ widget:
   url: http://your-ip-address:8080
   key: demotoken
 ```
-_*Watchtower is no longer maintained, you can read more about it [here](https://github.com/containrrr/watchtower/discussions/2135)_
+_Watchtower is no longer maintained, you can read more about it [here](https://github.com/containrrr/watchtower/discussions/2135)_

--- a/docs/widgets/services/watchtower.md
+++ b/docs/widgets/services/watchtower.md
@@ -3,7 +3,7 @@ title: Watchtower
 description: Watchtower Widget Configuration
 ---
 
-Learn more about [Watchtower](https://github.com/containrrr/watchtower).*
+Learn more about [Watchtower](https://github.com/containrrr/watchtower).
 
 To use this widget, Watchtower needs to be configured to [enable metrics](https://containrrr.dev/watchtower/metrics/).
 
@@ -15,4 +15,4 @@ widget:
   url: http://your-ip-address:8080
   key: demotoken
 ```
-*Watchtower is no longer maintained, you can read more about it [here](https://github.com/containrrr/watchtower/discussions/2135)
+_*Watchtower is no longer maintained, you can read more about it [here](https://github.com/containrrr/watchtower/discussions/2135)_

--- a/docs/widgets/services/watchtower.md
+++ b/docs/widgets/services/watchtower.md
@@ -3,7 +3,7 @@ title: Watchtower
 description: Watchtower Widget Configuration
 ---
 
-Learn more about [Watchtower](https://github.com/containrrr/watchtower).
+Learn more about [Watchtower](https://github.com/containrrr/watchtower).*
 
 To use this widget, Watchtower needs to be configured to [enable metrics](https://containrrr.dev/watchtower/metrics/).
 
@@ -15,3 +15,4 @@ widget:
   url: http://your-ip-address:8080
   key: demotoken
 ```
+*Watchtower is no longer maintained, you can read more about it [here](https://github.com/containrrr/watchtower/discussions/2135)


### PR DESCRIPTION
This pull request updates the Watchtower widget documentation to clarify the project's maintenance status. It adds a note that Watchtower is no longer maintained and provides a link for more information.

Documentation updates:

* Added a note to `docs/widgets/services/watchtower.md` indicating that Watchtower is no longer maintained, with a link to the relevant discussion.