### PR TITLE
Adding enphase energy widget, for monitoring solar

### DIFF
--- a/docs/widgets/services/enphase.md
+++ b/docs/widgets/services/enphase.md
@@ -26,6 +26,6 @@ The token is valid for one year.
 ```yaml
 widget:
   type: enphase
-  url: https://192.168.1.x    # gateway IP, always HTTPS
-  token: <jwt>                 # only required for firmware 7.x+
+  url: https://192.168.1.x # gateway IP, always HTTPS
+  token: <jwt> # only required for firmware 7.x+
 ```

--- a/docs/widgets/services/enphase.md
+++ b/docs/widgets/services/enphase.md
@@ -1,0 +1,31 @@
+---
+title: Enphase
+description: Enphase Solar Widget Configuration
+---
+
+Learn more about [Enphase](https://enphase.com).
+
+This widget reads data directly from your local Enphase IQ Gateway (Envoy) over your LAN — no cloud account or API key required.
+
+Displayed fields: current solar production, today's total production, today's total consumption, and today's imported or exported energy. Consumption and import/export fields are only shown if your gateway has consumption CT clamps installed.
+
+## Finding your gateway IP
+
+Your gateway's IP address can be found in your router's DHCP client list, or by checking the Enlighten app under **Devices**.
+
+## Token (firmware 7.x+ only)
+
+Gateways on firmware 7.0 or later require a JWT for local API access. Older firmware requires no authentication.
+
+Visit `https://entrez.enphaseenergy.com` (your site is typically your name, found under "Site Details" on your `https://enlighten.enphaseenergy.com` page) and log in with your Enlighten credentials. The page will display a token you can copy directly.
+
+The token is valid for one year.
+
+## Configuration
+
+```yaml
+widget:
+  type: enphase
+  url: https://192.168.1.x    # gateway IP, always HTTPS
+  token: <jwt>                 # only required for firmware 7.x+
+```

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -112,6 +112,13 @@
         "episodes": "Episodes",
         "songs": "Songs"
     },
+    "enphase": {
+        "produced_today": "Produced Today",
+        "consumed_today": "Consumed Today",
+        "producing": "Current Production",
+        "imported_today": "Imported Today",
+        "exported_today": "Exported Today"
+    },
     "jellyfin": {
         "playing": "Playing",
         "transcoding": "Transcoding",

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -34,6 +34,7 @@ const components = {
   dockhand: dynamic(() => import("./dockhand/component")),
   kubernetes: dynamic(() => import("./kubernetes/component")),
   emby: dynamic(() => import("./emby/component")),
+  enphase: dynamic(() => import("./enphase/component")),
   esphome: dynamic(() => import("./esphome/component")),
   evcc: dynamic(() => import("./evcc/component")),
   filebrowser: dynamic(() => import("./filebrowser/component")),

--- a/src/widgets/enphase/component.jsx
+++ b/src/widgets/enphase/component.jsx
@@ -1,0 +1,52 @@
+import Block from "components/services/widget/block";
+import Container from "components/services/widget/container";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+function formatPower(watts) {
+  if (watts === undefined || watts === null) return "-";
+  if (Math.abs(watts) >= 1000) return `${(watts / 1000).toFixed(2)} kW`;
+  return `${Math.round(watts)} W`;
+}
+
+function formatEnergy(wattHours) {
+  if (wattHours === undefined || wattHours === null) return "-";
+  if (wattHours >= 1000) return `${(wattHours / 1000).toFixed(2)} kWh`;
+  return `${Math.round(wattHours)} Wh`;
+}
+
+export default function Component({ service }) {
+  const { widget } = service;
+
+  const { data, error } = useWidgetAPI(widget, "production", { refreshInterval: 60000 });
+
+  if (error) {
+    return <Container service={service} error={error} />;
+  }
+
+  if (!data) {
+    return (
+      <Container service={service}>
+        <Block label="enphase.produced_today" />
+        <Block label="enphase.consumed_today" />
+        <Block label="enphase.producing" />
+        <Block label="enphase.imported_today" />
+      </Container>
+    );
+  }
+
+  return (
+    <Container service={service}>
+      <Block label="enphase.produced_today" value={formatEnergy(data.whToday)} />
+      {data.consumptionWhToday !== null && (
+        <Block label="enphase.consumed_today" value={formatEnergy(data.consumptionWhToday)} />
+      )}
+      <Block label="enphase.producing" value={formatPower(data.wNow)} />
+      {data.exportedToday !== null && data.exportedToday > 0 && (
+        <Block label="enphase.exported_today" value={formatEnergy(data.exportedToday)} />
+      )}
+      {data.importedToday !== null && data.importedToday > 0 && (
+        <Block label="enphase.imported_today" value={formatEnergy(data.importedToday)} />
+      )}
+    </Container>
+  );
+}

--- a/src/widgets/enphase/component.test.jsx
+++ b/src/widgets/enphase/component.test.jsx
@@ -107,6 +107,27 @@ describe("widgets/enphase/component", () => {
     expect(screen.queryByText("enphase.imported_today")).toBeNull();
   });
 
+  it("renders dashes when wNow and whToday are null", () => {
+    useWidgetAPI.mockReturnValue({
+      data: {
+        wNow: null,
+        whToday: null,
+        consumptionWhToday: null,
+        exportedToday: null,
+        importedToday: null,
+      },
+      error: undefined,
+    });
+
+    const { container } = renderWithProviders(<Component service={service} />, {
+      settings: { hideErrors: false },
+    });
+
+    const blocks = container.querySelectorAll(".service-block");
+    expect(blocks).toHaveLength(2);
+    blocks.forEach((b) => expect(b.textContent).toContain("-"));
+  });
+
   it("formats sub-kW power in watts", () => {
     useWidgetAPI.mockReturnValue({
       data: {

--- a/src/widgets/enphase/component.test.jsx
+++ b/src/widgets/enphase/component.test.jsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+
+import { screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "test-utils/render-with-providers";
+import { expectBlockValue } from "test-utils/widget-assertions";
+
+const { useWidgetAPI } = vi.hoisted(() => ({ useWidgetAPI: vi.fn() }));
+vi.mock("utils/proxy/use-widget-api", () => ({ default: useWidgetAPI }));
+
+import Component from "./component";
+
+const service = { widget: { type: "enphase", url: "https://10.9.8.242" } };
+
+describe("widgets/enphase/component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders 4 placeholder blocks while loading", () => {
+    useWidgetAPI.mockReturnValue({ data: undefined, error: undefined });
+
+    const { container } = renderWithProviders(<Component service={service} />, {
+      settings: { hideErrors: false },
+    });
+
+    expect(container.querySelectorAll(".service-block")).toHaveLength(4);
+    expect(screen.getByText("enphase.produced_today")).toBeInTheDocument();
+    expect(screen.getByText("enphase.consumed_today")).toBeInTheDocument();
+    expect(screen.getByText("enphase.producing")).toBeInTheDocument();
+    expect(screen.getByText("enphase.imported_today")).toBeInTheDocument();
+  });
+
+  it("renders error UI on API error", () => {
+    useWidgetAPI.mockReturnValue({ data: undefined, error: { message: "fail" } });
+
+    renderWithProviders(<Component service={service} />, { settings: { hideErrors: false } });
+
+    expect(screen.getAllByText(/widget\.api_error/i).length).toBeGreaterThan(0);
+  });
+
+  it("renders produced, consuming, current production and exported blocks when exporting", () => {
+    useWidgetAPI.mockReturnValue({
+      data: {
+        wNow: 2400,
+        whToday: 14500,
+        consumptionWhToday: 12000,
+        exportedToday: 2500,
+        importedToday: 0,
+      },
+      error: undefined,
+    });
+
+    const { container } = renderWithProviders(<Component service={service} />, {
+      settings: { hideErrors: false },
+    });
+
+    expectBlockValue(container, "enphase.produced_today", "14.50 kWh");
+    expectBlockValue(container, "enphase.consumed_today", "12.00 kWh");
+    expectBlockValue(container, "enphase.producing", "2.40 kW");
+    expectBlockValue(container, "enphase.exported_today", "2.50 kWh");
+    expect(screen.queryByText("enphase.imported_today")).toBeNull();
+  });
+
+  it("renders imported block and hides exported block when importing", () => {
+    useWidgetAPI.mockReturnValue({
+      data: {
+        wNow: 500,
+        whToday: 3000,
+        consumptionWhToday: 8000,
+        exportedToday: 0,
+        importedToday: 5000,
+      },
+      error: undefined,
+    });
+
+    const { container } = renderWithProviders(<Component service={service} />, {
+      settings: { hideErrors: false },
+    });
+
+    expectBlockValue(container, "enphase.imported_today", "5.00 kWh");
+    expect(screen.queryByText("enphase.exported_today")).toBeNull();
+  });
+
+  it("omits consumed/exported/imported blocks when consumption meters are absent", () => {
+    useWidgetAPI.mockReturnValue({
+      data: {
+        wNow: 1200,
+        whToday: 8000,
+        consumptionWhToday: null,
+        exportedToday: null,
+        importedToday: null,
+      },
+      error: undefined,
+    });
+
+    const { container } = renderWithProviders(<Component service={service} />, {
+      settings: { hideErrors: false },
+    });
+
+    expect(container.querySelectorAll(".service-block")).toHaveLength(2);
+    expectBlockValue(container, "enphase.produced_today", "8.00 kWh");
+    expectBlockValue(container, "enphase.producing", "1.20 kW");
+    expect(screen.queryByText("enphase.consumed_today")).toBeNull();
+    expect(screen.queryByText("enphase.exported_today")).toBeNull();
+    expect(screen.queryByText("enphase.imported_today")).toBeNull();
+  });
+
+  it("formats sub-kW power in watts", () => {
+    useWidgetAPI.mockReturnValue({
+      data: {
+        wNow: 450,
+        whToday: 800,
+        consumptionWhToday: null,
+        exportedToday: null,
+        importedToday: null,
+      },
+      error: undefined,
+    });
+
+    const { container } = renderWithProviders(<Component service={service} />, {
+      settings: { hideErrors: false },
+    });
+
+    expectBlockValue(container, "enphase.producing", "450 W");
+    expectBlockValue(container, "enphase.produced_today", "800 Wh");
+  });
+});

--- a/src/widgets/enphase/proxy.js
+++ b/src/widgets/enphase/proxy.js
@@ -43,8 +43,7 @@ export default async function enphaseProxyHandler(req, res) {
   // net-consumption whToday only measures grid import (never negative).
   // Exported energy must be calculated from produced - consumed.
   const importedToday = netConsumption != null ? (netConsumption.whToday ?? 0) : null;
-  const exportedToday =
-    consumedToday !== null ? Math.max(0, producedToday - consumedToday) : null;
+  const exportedToday = consumedToday !== null ? Math.max(0, producedToday - consumedToday) : null;
 
   return res.status(200).json({
     wNow: production?.wNow ?? 0,

--- a/src/widgets/enphase/proxy.js
+++ b/src/widgets/enphase/proxy.js
@@ -1,0 +1,56 @@
+import getServiceWidget from "utils/config/service-helpers";
+import createLogger from "utils/logger";
+import { asJson, formatApiCall, sanitizeErrorURL } from "utils/proxy/api-helpers";
+import { httpProxy } from "utils/proxy/http";
+import widgets from "widgets/widgets";
+
+const logger = createLogger("enphaseProxyHandler");
+
+export default async function enphaseProxyHandler(req, res) {
+  const { group, service, index } = req.query;
+  const widget = await getServiceWidget(group, service, index);
+
+  const url = formatApiCall(widgets[widget.type].api, { ...widget });
+
+  const headers = {};
+  if (widget.token) {
+    headers.Authorization = `Bearer ${widget.token}`;
+  }
+
+  const [status, contentType, data] = await httpProxy(url, { headers });
+
+  if (status !== 200) {
+    logger.debug("HTTP Error %d calling Envoy: %s", status, sanitizeErrorURL(new URL(url)));
+    return res.status(status).json({
+      error: {
+        message: "HTTP Error",
+        url: sanitizeErrorURL(new URL(url)),
+        data: Buffer.isBuffer(data) ? Buffer.from(data).toString() : data,
+      },
+    });
+  }
+
+  const json = asJson(data);
+
+  const production =
+    json.production?.find((p) => p.type === "eim") ?? json.production?.find((p) => p.type === "inverters");
+  const totalConsumption = json.consumption?.find((c) => c.measurementType === "total-consumption");
+  const netConsumption = json.consumption?.find((c) => c.measurementType === "net-consumption");
+
+  const producedToday = production?.whToday ?? 0;
+  const consumedToday = totalConsumption?.whToday ?? null;
+
+  // net-consumption whToday only measures grid import (never negative).
+  // Exported energy must be calculated from produced - consumed.
+  const importedToday = netConsumption != null ? (netConsumption.whToday ?? 0) : null;
+  const exportedToday =
+    consumedToday !== null ? Math.max(0, producedToday - consumedToday) : null;
+
+  return res.status(200).json({
+    wNow: production?.wNow ?? 0,
+    whToday: producedToday,
+    consumptionWhToday: consumedToday,
+    importedToday,
+    exportedToday,
+  });
+}

--- a/src/widgets/enphase/proxy.test.js
+++ b/src/widgets/enphase/proxy.test.js
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import createMockRes from "test-utils/create-mock-res";
+
+const { httpProxy, getServiceWidget, logger } = vi.hoisted(() => ({
+  httpProxy: vi.fn(),
+  getServiceWidget: vi.fn(),
+  logger: { debug: vi.fn() },
+}));
+
+vi.mock("utils/logger", () => ({
+  default: () => logger,
+}));
+vi.mock("utils/config/service-helpers", () => ({
+  default: getServiceWidget,
+}));
+vi.mock("utils/proxy/http", () => ({
+  httpProxy,
+}));
+vi.mock("widgets/widgets", () => ({
+  default: {
+    enphase: {
+      api: "{url}/production.json",
+    },
+  },
+}));
+
+import enphaseProxyHandler from "./proxy";
+
+const makeReq = () => ({ query: { group: "g", service: "svc", index: "0" } });
+
+const makeProductionJson = ({ hasConsumption = true, netWhToday = -5000 } = {}) => ({
+  production: [
+    { type: "inverters", wNow: 100, whToday: 800 },
+    { type: "eim", wNow: 2400, whToday: 14500 },
+  ],
+  consumption: hasConsumption
+    ? [
+        { measurementType: "total-consumption", wNow: 1800, whToday: 12000 },
+        { measurementType: "net-consumption", wNow: -600, whToday: netWhToday },
+      ]
+    : undefined,
+});
+
+describe("widgets/enphase/proxy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns shaped data from EIM production and consumption meters", async () => {
+    getServiceWidget.mockResolvedValue({ type: "enphase", url: "https://10.9.8.242" });
+    httpProxy.mockResolvedValue([200, "application/json", Buffer.from(JSON.stringify(makeProductionJson()))]);
+
+    const res = createMockRes();
+    await enphaseProxyHandler(makeReq(), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({
+      wNow: 2400,
+      whToday: 14500,
+      consumptionWhToday: 12000,
+      importedToday: 0,       // net-consumption whToday (grid import)
+      exportedToday: 2500,    // 14500 produced - 12000 consumed
+    });
+  });
+
+  it("shows exported when production exceeds consumption", async () => {
+    getServiceWidget.mockResolvedValue({ type: "enphase", url: "https://10.9.8.242" });
+    const json = makeProductionJson();
+    // 82560 Wh produced, 42430 Wh consumed => ~40130 Wh exported
+    json.production[1].whToday = 82560;
+    json.consumption[0].whToday = 42430;
+    json.consumption[1].whToday = 0;
+    httpProxy.mockResolvedValue([200, "application/json", Buffer.from(JSON.stringify(json))]);
+
+    const res = createMockRes();
+    await enphaseProxyHandler(makeReq(), res);
+
+    expect(res.body.exportedToday).toBe(40130);
+    expect(res.body.importedToday).toBe(0);
+  });
+
+  it("falls back to inverters when no EIM meter is present", async () => {
+    const json = makeProductionJson();
+    json.production = json.production.filter((p) => p.type !== "eim");
+
+    getServiceWidget.mockResolvedValue({ type: "enphase", url: "https://10.9.8.242" });
+    httpProxy.mockResolvedValue([200, "application/json", Buffer.from(JSON.stringify(json))]);
+
+    const res = createMockRes();
+    await enphaseProxyHandler(makeReq(), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.wNow).toBe(100);
+    expect(res.body.whToday).toBe(800);
+  });
+
+  it("returns null for consumption fields when no consumption meters are present", async () => {
+    getServiceWidget.mockResolvedValue({ type: "enphase", url: "https://10.9.8.242" });
+    httpProxy.mockResolvedValue([
+      200,
+      "application/json",
+      Buffer.from(JSON.stringify(makeProductionJson({ hasConsumption: false }))),
+    ]);
+
+    const res = createMockRes();
+    await enphaseProxyHandler(makeReq(), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.consumptionWhToday).toBeNull();
+    expect(res.body.importedToday).toBeNull();
+    expect(res.body.exportedToday).toBeNull();
+  });
+
+  it("sends Bearer token header when widget.token is set", async () => {
+    getServiceWidget.mockResolvedValue({ type: "enphase", url: "https://10.9.8.242", token: "mytoken" });
+    httpProxy.mockResolvedValue([200, "application/json", Buffer.from(JSON.stringify(makeProductionJson()))]);
+
+    const res = createMockRes();
+    await enphaseProxyHandler(makeReq(), res);
+
+    expect(httpProxy.mock.calls[0][1].headers.Authorization).toBe("Bearer mytoken");
+  });
+
+  it("sends no Authorization header when widget.token is absent", async () => {
+    getServiceWidget.mockResolvedValue({ type: "enphase", url: "https://10.9.8.242" });
+    httpProxy.mockResolvedValue([200, "application/json", Buffer.from(JSON.stringify(makeProductionJson()))]);
+
+    const res = createMockRes();
+    await enphaseProxyHandler(makeReq(), res);
+
+    expect(httpProxy.mock.calls[0][1].headers.Authorization).toBeUndefined();
+  });
+
+  it("returns an error object on non-200 response", async () => {
+    getServiceWidget.mockResolvedValue({ type: "enphase", url: "https://10.9.8.242" });
+    httpProxy.mockResolvedValue([401, "application/json", Buffer.from("Unauthorized")]);
+
+    const res = createMockRes();
+    await enphaseProxyHandler(makeReq(), res);
+
+    expect(res.statusCode).toBe(401);
+    expect(res.body.error.message).toBe("HTTP Error");
+    expect(res.body.error.data).toBe("Unauthorized");
+  });
+
+  it("does not expose the token in error URLs", async () => {
+    getServiceWidget.mockResolvedValue({
+      type: "enphase",
+      url: "https://10.9.8.242",
+      token: "supersecret",
+    });
+    httpProxy.mockResolvedValue([500, "application/json", Buffer.from("error")]);
+
+    const res = createMockRes();
+    await enphaseProxyHandler(makeReq(), res);
+
+    expect(res.body.error.url).not.toContain("supersecret");
+  });
+});

--- a/src/widgets/enphase/proxy.test.js
+++ b/src/widgets/enphase/proxy.test.js
@@ -29,7 +29,7 @@ import enphaseProxyHandler from "./proxy";
 
 const makeReq = () => ({ query: { group: "g", service: "svc", index: "0" } });
 
-const makeProductionJson = ({ hasConsumption = true, netWhToday = -5000 } = {}) => ({
+const makeProductionJson = ({ hasConsumption = true, netWhToday = 0 } = {}) => ({
   production: [
     { type: "inverters", wNow: 100, whToday: 800 },
     { type: "eim", wNow: 2400, whToday: 14500 },
@@ -59,8 +59,8 @@ describe("widgets/enphase/proxy", () => {
       wNow: 2400,
       whToday: 14500,
       consumptionWhToday: 12000,
-      importedToday: 0,       // net-consumption whToday (grid import)
-      exportedToday: 2500,    // 14500 produced - 12000 consumed
+      importedToday: 0, // net-consumption whToday (grid import)
+      exportedToday: 2500, // 14500 produced - 12000 consumed
     });
   });
 
@@ -157,4 +157,16 @@ describe("widgets/enphase/proxy", () => {
 
     expect(res.body.error.url).not.toContain("supersecret");
   });
+
+  it("passes through non-Buffer error data as-is", async () => {
+    getServiceWidget.mockResolvedValue({ type: "enphase", url: "https://10.9.8.242" });
+    httpProxy.mockResolvedValue([503, "application/json", { message: "unavailable" }]);
+
+    const res = createMockRes();
+    await enphaseProxyHandler(makeReq(), res);
+
+    expect(res.statusCode).toBe(503);
+    expect(res.body.error.data).toEqual({ message: "unavailable" });
+  });
+
 });

--- a/src/widgets/enphase/proxy.test.js
+++ b/src/widgets/enphase/proxy.test.js
@@ -36,9 +36,9 @@ const makeProductionJson = ({ hasConsumption = true, netWhToday = 0 } = {}) => (
   ],
   consumption: hasConsumption
     ? [
-        { measurementType: "total-consumption", wNow: 1800, whToday: 12000 },
-        { measurementType: "net-consumption", wNow: -600, whToday: netWhToday },
-      ]
+      { measurementType: "total-consumption", wNow: 1800, whToday: 12000 },
+      { measurementType: "net-consumption", wNow: -600, whToday: netWhToday },
+    ]
     : undefined,
 });
 
@@ -168,5 +168,4 @@ describe("widgets/enphase/proxy", () => {
     expect(res.statusCode).toBe(503);
     expect(res.body.error.data).toEqual({ message: "unavailable" });
   });
-
 });

--- a/src/widgets/enphase/proxy.test.js
+++ b/src/widgets/enphase/proxy.test.js
@@ -36,9 +36,9 @@ const makeProductionJson = ({ hasConsumption = true, netWhToday = 0 } = {}) => (
   ],
   consumption: hasConsumption
     ? [
-      { measurementType: "total-consumption", wNow: 1800, whToday: 12000 },
-      { measurementType: "net-consumption", wNow: -600, whToday: netWhToday },
-    ]
+        { measurementType: "total-consumption", wNow: 1800, whToday: 12000 },
+        { measurementType: "net-consumption", wNow: -600, whToday: netWhToday },
+      ]
     : undefined,
 });
 

--- a/src/widgets/enphase/widget.js
+++ b/src/widgets/enphase/widget.js
@@ -1,0 +1,9 @@
+import enphaseProxyHandler from "./proxy";
+
+const widget = {
+  api: "{url}/production.json",
+  proxyHandler: enphaseProxyHandler,
+  allowedEndpoints: /^production$/,
+};
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -28,6 +28,7 @@ import dispatcharr from "./dispatcharr/widget";
 import dockhand from "./dockhand/widget";
 import downloadstation from "./downloadstation/widget";
 import emby from "./emby/widget";
+import enphase from "./enphase/widget";
 import esphome from "./esphome/widget";
 import evcc from "./evcc/widget";
 import filebrowser from "./filebrowser/widget";
@@ -182,6 +183,7 @@ const widgets = {
   dockhand,
   downloadstation,
   emby,
+  enphase,
   esphome,
   evcc,
   filebrowser,


### PR DESCRIPTION
## Proposed change

Adds a new service widget for Enphase solar systems via the local IQ Gateway (Envoy) API. This avoids cloud/OAuth dependencies by reading directly from the gateway on the local network.

The widget displays:
- **Produced Today** — daily solar production (Wh/kWh)
- **Consumed Today** — daily home consumption (only shown if consumption CT clamps are installed)
- **Current Production** — live solar output (W/kW)
- **Exported Today** / **Imported Today** — daily net grid flow, calculated from production minus consumption; label and visibility are dynamic based on the day's net direction

Example API response from `/production.json`:

```json
{
  "production": [
    { "type": "inverters", "wNow": 100, "whToday": 800 },
    { "type": "eim", "wNow": 2400, "whToday": 14500 }
  ],
  "consumption": [
    { "measurementType": "total-consumption", "wNow": 1800, "whToday": 12000 },
    { "measurementType": "net-consumption", "wNow": -600, "whToday": 0 }
  ]
}
```

Documentation added at `docs/widgets/services/enphase.md`.

> ⚠️ This PR was developed with the assistance of AI (Claude).

## Type of change

- [X] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [X] If applicable, I have added corresponding documentation changes.
- [X] If applicable, I have added or updated tests for new features and bug fixes.
- [X] If applicable, I have reviewed the feature / enhancement and / or service widget guidelines.
- [X] I have checked that all code style checks pass using pre-commit hooks and linting checks.
- [X] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [X] In the description above I have disclosed the use of AI tools in the coding of this PR.