### PR TITLE
Handle bookmark URLs without protocol in hostname fallback

### DIFF
--- a/src/components/bookmarks/item.jsx
+++ b/src/components/bookmarks/item.jsx
@@ -2,9 +2,10 @@ import classNames from "classnames";
 import ResolvedIcon from "components/resolvedicon";
 import { useContext } from "react";
 import { SettingsContext } from "utils/contexts/settings";
+import { safeHostnameFromUrl } from "utils/url-helpers";
 
 export default function Item({ bookmark, iconOnly = false }) {
-  const description = bookmark.description ?? new URL(bookmark.href).hostname;
+  const description = bookmark.description ?? safeHostnameFromUrl(bookmark.href);
   const { settings } = useContext(SettingsContext);
 
   return (

--- a/src/utils/url-helpers.js
+++ b/src/utils/url-helpers.js
@@ -1,0 +1,25 @@
+export function ensureUrlProtocol(value) {
+  if (!value || typeof value !== "string") {
+    return value;
+  }
+
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    return trimmed;
+  }
+
+  if (/^[a-zA-Z][a-zA-Z\d+.-]*:/.test(trimmed)) {
+    return trimmed;
+  }
+
+  return `https://${trimmed}`;
+}
+
+export function safeHostnameFromUrl(value) {
+  try {
+    return new URL(ensureUrlProtocol(value)).hostname;
+  } catch {
+    return value;
+  }
+}

--- a/src/utils/url-helpers.test.js
+++ b/src/utils/url-helpers.test.js
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { ensureUrlProtocol, safeHostnameFromUrl } from "./url-helpers";
+
+describe("ensureUrlProtocol", () => {
+  it("adds https when protocol is missing", () => {
+    expect(ensureUrlProtocol("example.com")).toBe("https://example.com");
+  });
+
+  it("keeps http URLs unchanged", () => {
+    expect(ensureUrlProtocol("http://example.com")).toBe("http://example.com");
+  });
+
+  it("keeps https URLs unchanged", () => {
+    expect(ensureUrlProtocol("https://example.com")).toBe("https://example.com");
+  });
+
+  it("keeps custom schemes unchanged", () => {
+    expect(ensureUrlProtocol("mailto:test@example.com")).toBe("mailto:test@example.com");
+  });
+});
+
+describe("safeHostnameFromUrl", () => {
+  it("extracts hostname from protocol-less URLs", () => {
+    expect(safeHostnameFromUrl("example.com")).toBe("example.com");
+  });
+
+  it("extracts hostname from full URLs", () => {
+    expect(safeHostnameFromUrl("https://example.com/path")).toBe("example.com");
+  });
+
+  it("falls back to the original value when parsing fails", () => {
+    expect(safeHostnameFromUrl("not a valid url value")).toBe("not a valid url value");
+  });
+});

--- a/src/utils/url-helpers.test.js
+++ b/src/utils/url-helpers.test.js
@@ -18,6 +18,19 @@ describe("ensureUrlProtocol", () => {
   it("keeps custom schemes unchanged", () => {
     expect(ensureUrlProtocol("mailto:test@example.com")).toBe("mailto:test@example.com");
   });
+
+  it("returns non-string values unchanged", () => {
+    expect(ensureUrlProtocol(undefined)).toBe(undefined);
+    expect(ensureUrlProtocol(null)).toBe(null);
+  });
+
+  it("returns empty trimmed strings unchanged", () => {
+    expect(ensureUrlProtocol("   ")).toBe("");
+  });
+
+  it("trims protocol-less values before adding https", () => {
+    expect(ensureUrlProtocol("  example.com/test  ")).toBe("https://example.com/test");
+  });
 });
 
 describe("safeHostnameFromUrl", () => {
@@ -31,5 +44,9 @@ describe("safeHostnameFromUrl", () => {
 
   it("falls back to the original value when parsing fails", () => {
     expect(safeHostnameFromUrl("not a valid url value")).toBe("not a valid url value");
+  });
+
+  it("returns undefined unchanged for invalid input", () => {
+    expect(safeHostnameFromUrl(undefined)).toBe(undefined);
   });
 });


### PR DESCRIPTION
## Summary
This small change avoids failures when a bookmark URL is entered without a protocol.

Homepage already handles protocol-less URLs in some places (for example Quick Launch), but bookmark hostname fallback was still doing a direct `new URL(bookmark.href)`, which can throw for values like `example.com`.

## Changes
- add a small shared helper to normalize protocol-less URLs
- use it in bookmark hostname fallback
- add tests for the helper

## Example
Before:
- `href: example.com`
- bookmark hostname fallback could throw when no custom description was set

After:
- `href: example.com`
- fallback hostname resolves correctly to `example.com`

I’m working on a fork of Homepage and ran into this while testing real-world configs, so I thought this small fix would also make sense upstream.
