### PR TITLE
Deeper tailscale info

### DIFF
--- a/docs/widgets/services/tailscale.md
+++ b/docs/widgets/services/tailscale.md
@@ -7,6 +7,8 @@ Learn more about [Tailscale](https://github.com/tailscale/tailscale).
 
 You will need to generate an API access token from the [keys page](https://login.tailscale.com/admin/settings/keys) on the Tailscale dashboard.
 
+## Single Device
+
 To find your device ID, go to the [machine overview page](https://login.tailscale.com/admin/machines) and select your machine. In the "Machine Details" section, copy your `ID`. It will end with `CNTRL`.
 
 Allowed fields: `["address", "last_seen", "expires"]`.
@@ -16,4 +18,27 @@ widget:
   type: tailscale
   deviceid: deviceid
   key: tailscalekey
+```
+
+## Tailnet (All Devices)
+
+To view all devices in your tailnet, use the `tailnet` option instead of `deviceid`. Your tailnet name can be found on the [Tailscale admin dashboard](https://login.tailscale.com/admin/settings/general).
+
+Allowed fields: `["total_devices", "online", "offline"]`.
+
+```yaml
+widget:
+  type: tailscale
+  tailnet: your-tailnet-name
+  key: tailscalekey
+```
+
+By default, the tailnet view shows a summary with device counts. To show a detailed list of all devices with their name, address, and online status, set `summaryView` to `false`:
+
+```yaml
+widget:
+  type: tailscale
+  tailnet: your-tailnet-name
+  key: tailscalekey
+  summaryView: false
 ```

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -352,7 +352,13 @@
         "hours": "{{number}}h",
         "minutes": "{{number}}m",
         "seconds": "{{number}}s",
-        "ago": "{{value}} Ago"
+        "ago": "{{value}} Ago",
+        "total_devices": "Devices",
+        "online": "Online",
+        "offline": "Offline",
+        "ssh": "SSH",
+        "subnets": "Subnet Router",
+        "exit_node": "Exit Node"
     },
     "technitium": {
         "totalQueries": "Queries",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -358,7 +358,9 @@
         "offline": "Offline",
         "ssh": "SSH",
         "subnets": "Subnet Router",
-        "exit_node": "Exit Node"
+        "exit_node": "Exit Node",
+        "copy": "Copy",
+        "copied": "Copied!"
     },
     "technitium": {
         "totalQueries": "Queries",

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -428,6 +428,10 @@ export function cleanServiceGroups(groups) {
           // yourspotify
           interval,
 
+          // tailscale
+          tailnet,
+          summaryView,
+
           // technitium
           range,
 
@@ -554,6 +558,10 @@ export function cleanServiceGroups(groups) {
         }
         if (["sonarr", "radarr"].includes(type)) {
           if (enableQueue !== undefined) widget.enableQueue = JSON.parse(enableQueue);
+        }
+        if (type === "tailscale") {
+          if (tailnet) widget.tailnet = tailnet;
+          if (summaryView !== undefined) widget.summaryView = JSON.parse(summaryView);
         }
         if (type === "truenas") {
           if (enablePools !== undefined) widget.enablePools = JSON.parse(enablePools);

--- a/src/widgets/tailscale/component.jsx
+++ b/src/widgets/tailscale/component.jsx
@@ -2,11 +2,28 @@ import Block from "components/services/widget/block";
 import Container from "components/services/widget/container";
 import { useTranslation } from "next-i18next";
 
+import Device from "widgets/tailscale/device";
 import useWidgetAPI from "utils/proxy/use-widget-api";
 
-export default function Component({ service }) {
-  const { t } = useTranslation();
+function compareDifferenceInTwoDates(t, priorDate, futureDate) {
+  const diff = futureDate.getTime() - priorDate.getTime();
+  const diffInYears = Math.ceil(diff / (1000 * 60 * 60 * 24 * 365));
+  if (diffInYears > 1) return t("tailscale.years", { number: diffInYears });
+  const diffInWeeks = Math.ceil(diff / (1000 * 60 * 60 * 24 * 7));
+  if (diffInWeeks > 1) return t("tailscale.weeks", { number: diffInWeeks });
+  const diffInDays = Math.ceil(diff / (1000 * 60 * 60 * 24));
+  if (diffInDays > 1) return t("tailscale.days", { number: diffInDays });
+  const diffInHours = Math.ceil(diff / (1000 * 60 * 60));
+  if (diffInHours > 1) return t("tailscale.hours", { number: diffInHours });
+  const diffInMinutes = Math.ceil(diff / (1000 * 60));
+  if (diffInMinutes > 1) return t("tailscale.minutes", { number: diffInMinutes });
+  const diffInSeconds = Math.ceil(diff / 1000);
+  if (diffInSeconds > 10) return t("tailscale.seconds", { number: diffInSeconds });
+  return "Now";
+}
 
+function SingleDevice({ service }) {
+  const { t } = useTranslation();
   const { widget } = service;
 
   const { data: statsData, error: statsError } = useWidgetAPI(widget, "device");
@@ -33,33 +50,17 @@ export default function Component({ service }) {
   } = statsData;
 
   const now = new Date();
-  const compareDifferenceInTwoDates = (priorDate, futureDate) => {
-    const diff = futureDate.getTime() - priorDate.getTime();
-    const diffInYears = Math.ceil(diff / (1000 * 60 * 60 * 24 * 365));
-    if (diffInYears > 1) return t("tailscale.years", { number: diffInYears });
-    const diffInWeeks = Math.ceil(diff / (1000 * 60 * 60 * 24 * 7));
-    if (diffInWeeks > 1) return t("tailscale.weeks", { number: diffInWeeks });
-    const diffInDays = Math.ceil(diff / (1000 * 60 * 60 * 24));
-    if (diffInDays > 1) return t("tailscale.days", { number: diffInDays });
-    const diffInHours = Math.ceil(diff / (1000 * 60 * 60));
-    if (diffInHours > 1) return t("tailscale.hours", { number: diffInHours });
-    const diffInMinutes = Math.ceil(diff / (1000 * 60));
-    if (diffInMinutes > 1) return t("tailscale.minutes", { number: diffInMinutes });
-    const diffInSeconds = Math.ceil(diff / 1000);
-    if (diffInSeconds > 10) return t("tailscale.seconds", { number: diffInSeconds });
-    return "Now";
-  };
 
   const getLastSeen = () => {
     const date = new Date(lastSeen);
-    const diff = compareDifferenceInTwoDates(date, now);
+    const diff = compareDifferenceInTwoDates(t, date, now);
     return diff === "Now" ? t("tailscale.now") : t("tailscale.ago", { value: diff });
   };
 
   const getExpiry = () => {
     if (keyExpiryDisabled) return t("tailscale.never");
     const date = new Date(expires);
-    return compareDifferenceInTwoDates(now, date);
+    return compareDifferenceInTwoDates(t, now, date);
   };
 
   return (
@@ -69,4 +70,91 @@ export default function Component({ service }) {
       <Block label="tailscale.expires" value={getExpiry()} />
     </Container>
   );
+}
+
+function TailnetDevices({ service }) {
+  const { t } = useTranslation();
+  const { widget } = service;
+  const summaryView = widget.summaryView !== false;
+
+  const { data: devicesData, error: devicesError } = useWidgetAPI(widget, "devices");
+
+  if (devicesError || devicesData?.message) {
+    return <Container service={service} error={devicesError ?? devicesData} />;
+  }
+
+  if (!devicesData) {
+    if (summaryView) {
+      return (
+        <Container service={service}>
+          <Block label="tailscale.total_devices" />
+          <Block label="tailscale.online" />
+          <Block label="tailscale.offline" />
+        </Container>
+      );
+    }
+    return (
+      <Container service={service}>
+        <Block label="tailscale.total_devices" />
+      </Container>
+    );
+  }
+
+  const devices = Array.isArray(devicesData) ? devicesData : [];
+  const online = devices.filter((d) => d.online).length;
+  const offline = devices.length - online;
+
+  if (summaryView) {
+    return (
+      <Container service={service}>
+        <Block label="tailscale.total_devices" value={t("common.number", { value: devices.length })} />
+        <Block label="tailscale.online" value={t("common.number", { value: online })} />
+        <Block label="tailscale.offline" value={t("common.number", { value: offline })} />
+      </Container>
+    );
+  }
+
+  return (
+    <>
+      <Container service={service}>
+        <Block label="tailscale.total_devices" value={t("common.number", { value: devices.length })} />
+        <Block label="tailscale.online" value={t("common.number", { value: online })} />
+        <Block label="tailscale.offline" value={t("common.number", { value: offline })} />
+      </Container>
+      {devices
+        .sort((a, b) => {
+          if (a.online !== b.online) return a.online ? -1 : 1;
+          return a.name.localeCompare(b.name);
+        })
+        .map((device) => {
+          const exitNodeRoutes = ["0.0.0.0/0", "::/0"];
+          const advertisedRoutes = device.advertisedRoutes ?? [];
+          const enabledRoutes = device.enabledRoutes ?? [];
+          const isExitNode = advertisedRoutes.some((r) => exitNodeRoutes.includes(r));
+          const hasSubnets = enabledRoutes.some((r) => !exitNodeRoutes.includes(r));
+
+          return (
+            <Device
+              key={device.id}
+              name={device.name}
+              address={device.addresses?.[0]}
+              online={device.online}
+              isExitNode={isExitNode}
+              hasSubnets={hasSubnets}
+              sshEnabled={device.sshEnabled}
+            />
+          );
+        })}
+    </>
+  );
+}
+
+export default function Component({ service }) {
+  const { widget } = service;
+
+  if (widget.tailnet) {
+    return <TailnetDevices service={service} />;
+  }
+
+  return <SingleDevice service={service} />;
 }

--- a/src/widgets/tailscale/component.jsx
+++ b/src/widgets/tailscale/component.jsx
@@ -101,7 +101,7 @@ function TailnetDevices({ service }) {
   }
 
   const devices = Array.isArray(devicesData) ? devicesData : [];
-  const online = devices.filter((d) => d.online).length;
+  const online = devices.filter((d) => d.connectedToControl).length;
   const offline = devices.length - online;
 
   if (summaryView) {
@@ -123,7 +123,7 @@ function TailnetDevices({ service }) {
       </Container>
       {devices
         .sort((a, b) => {
-          if (a.online !== b.online) return a.online ? -1 : 1;
+          if (a.connectedToControl !== b.connectedToControl) return a.connectedToControl ? -1 : 1;
           return a.name.localeCompare(b.name);
         })
         .map((device) => {
@@ -138,7 +138,7 @@ function TailnetDevices({ service }) {
               key={device.id}
               name={device.name}
               address={device.addresses?.[0]}
-              online={device.online}
+              online={device.connectedToControl}
               isExitNode={isExitNode}
               hasSubnets={hasSubnets}
               sshEnabled={device.sshEnabled}

--- a/src/widgets/tailscale/component.jsx
+++ b/src/widgets/tailscale/component.jsx
@@ -2,8 +2,8 @@ import Block from "components/services/widget/block";
 import Container from "components/services/widget/container";
 import { useTranslation } from "next-i18next";
 
-import Device from "widgets/tailscale/device";
 import useWidgetAPI from "utils/proxy/use-widget-api";
+import Device from "widgets/tailscale/device";
 
 function compareDifferenceInTwoDates(t, priorDate, futureDate) {
   const diff = futureDate.getTime() - priorDate.getTime();

--- a/src/widgets/tailscale/component.test.jsx
+++ b/src/widgets/tailscale/component.test.jsx
@@ -9,7 +9,49 @@ import { expectBlockValue, findServiceBlockByLabel } from "test-utils/widget-ass
 const { useWidgetAPI } = vi.hoisted(() => ({ useWidgetAPI: vi.fn() }));
 vi.mock("utils/proxy/use-widget-api", () => ({ default: useWidgetAPI }));
 
+vi.mock("widgets/tailscale/device", () => ({
+  default: ({ name, online, isExitNode, hasSubnets, sshEnabled }) => (
+    <div
+      data-testid="tailscale-device"
+      data-name={name}
+      data-online={String(!!online)}
+      data-exit-node={String(!!isExitNode)}
+      data-subnets={String(!!hasSubnets)}
+      data-ssh={String(!!sshEnabled)}
+    />
+  ),
+}));
+
 import Component from "./component";
+
+const MOCK_DEVICES = [
+  {
+    id: "1",
+    name: "server-a",
+    addresses: ["100.64.0.1"],
+    connectedToControl: true,
+    advertisedRoutes: ["0.0.0.0/0", "::/0", "192.168.1.0/24"],
+    enabledRoutes: ["192.168.1.0/24"],
+    sshEnabled: true,
+  },
+  {
+    id: "2",
+    name: "laptop-b",
+    addresses: ["100.64.0.2"],
+    connectedToControl: false,
+    advertisedRoutes: [],
+    enabledRoutes: [],
+    sshEnabled: false,
+  },
+  {
+    id: "3",
+    name: "phone-c",
+    addresses: ["100.64.0.3"],
+    connectedToControl: true,
+    advertisedRoutes: [],
+    enabledRoutes: [],
+  },
+];
 
 describe("widgets/tailscale/component", () => {
   beforeEach(() => {
@@ -22,7 +64,19 @@ describe("widgets/tailscale/component", () => {
     vi.useRealTimers();
   });
 
-  it("renders placeholders while loading", () => {
+  // --- Backwards compat: single device mode (no tailnet set) ---
+
+  it("uses device endpoint when no tailnet is configured", () => {
+    useWidgetAPI.mockReturnValue({ data: undefined, error: undefined });
+
+    renderWithProviders(<Component service={{ widget: { type: "tailscale" } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expect(useWidgetAPI).toHaveBeenCalledWith(expect.objectContaining({ type: "tailscale" }), "device");
+  });
+
+  it("renders single-device placeholders while loading", () => {
     useWidgetAPI.mockReturnValue({ data: undefined, error: undefined });
 
     const { container } = renderWithProviders(<Component service={{ widget: { type: "tailscale" } }} />, {
@@ -35,7 +89,7 @@ describe("widgets/tailscale/component", () => {
     expect(screen.getByText("tailscale.expires")).toBeInTheDocument();
   });
 
-  it("renders address and expiry/last-seen strings when loaded", () => {
+  it("renders single-device address and expiry when loaded", () => {
     useWidgetAPI.mockReturnValue({
       data: {
         addresses: ["100.64.0.1"],
@@ -53,5 +107,150 @@ describe("widgets/tailscale/component", () => {
     expectBlockValue(container, "tailscale.address", "100.64.0.1");
     expect(findServiceBlockByLabel(container, "tailscale.last_seen")?.textContent).toContain("tailscale.ago");
     expectBlockValue(container, "tailscale.expires", "tailscale.never");
+  });
+
+  it("renders single-device expiry countdown when key expiry is enabled", () => {
+    useWidgetAPI.mockReturnValue({
+      data: {
+        addresses: ["100.64.0.1"],
+        keyExpiryDisabled: false,
+        lastSeen: "2019-12-31T23:59:50Z",
+        expires: "2020-02-01T00:00:00Z",
+      },
+      error: undefined,
+    });
+
+    const { container } = renderWithProviders(<Component service={{ widget: { type: "tailscale" } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    // Should show a time duration, not "never"
+    const expiresBlock = findServiceBlockByLabel(container, "tailscale.expires");
+    expect(expiresBlock?.textContent).not.toContain("tailscale.never");
+  });
+
+  // --- Tailnet mode: summary view (default) ---
+
+  it("uses devices endpoint when tailnet is configured", () => {
+    useWidgetAPI.mockReturnValue({ data: undefined, error: undefined });
+
+    renderWithProviders(
+      <Component service={{ widget: { type: "tailscale", tailnet: "-" } }} />,
+      { settings: { hideErrors: false } },
+    );
+
+    expect(useWidgetAPI).toHaveBeenCalledWith(expect.objectContaining({ tailnet: "-" }), "devices");
+  });
+
+  it("renders summary placeholders while loading", () => {
+    useWidgetAPI.mockReturnValue({ data: undefined, error: undefined });
+
+    const { container } = renderWithProviders(
+      <Component service={{ widget: { type: "tailscale", tailnet: "-" } }} />,
+      { settings: { hideErrors: false } },
+    );
+
+    expect(container.querySelectorAll(".service-block")).toHaveLength(3);
+    expect(screen.getByText("tailscale.total_devices")).toBeInTheDocument();
+    expect(screen.getByText("tailscale.online")).toBeInTheDocument();
+    expect(screen.getByText("tailscale.offline")).toBeInTheDocument();
+  });
+
+  it("renders summary counts from connectedToControl field", () => {
+    useWidgetAPI.mockReturnValue({ data: MOCK_DEVICES, error: undefined });
+
+    const { container } = renderWithProviders(
+      <Component service={{ widget: { type: "tailscale", tailnet: "-" } }} />,
+      { settings: { hideErrors: false } },
+    );
+
+    expectBlockValue(container, "tailscale.total_devices", "3");
+    expectBlockValue(container, "tailscale.online", "2");
+    expectBlockValue(container, "tailscale.offline", "1");
+    // Summary view should not render device rows
+    expect(screen.queryByTestId("tailscale-device")).toBeNull();
+  });
+
+  // --- Tailnet mode: detail view (summaryView: false) ---
+
+  it("renders device rows when summaryView is false", () => {
+    useWidgetAPI.mockReturnValue({ data: MOCK_DEVICES, error: undefined });
+
+    renderWithProviders(
+      <Component service={{ widget: { type: "tailscale", tailnet: "-", summaryView: false } }} />,
+      { settings: { hideErrors: false } },
+    );
+
+    const deviceRows = screen.getAllByTestId("tailscale-device");
+    expect(deviceRows).toHaveLength(3);
+  });
+
+  it("sorts online devices before offline, then alphabetical", () => {
+    useWidgetAPI.mockReturnValue({ data: MOCK_DEVICES, error: undefined });
+
+    renderWithProviders(
+      <Component service={{ widget: { type: "tailscale", tailnet: "-", summaryView: false } }} />,
+      { settings: { hideErrors: false } },
+    );
+
+    const deviceRows = screen.getAllByTestId("tailscale-device");
+    const names = deviceRows.map((d) => d.getAttribute("data-name"));
+    // Online first (phone-c, server-a alphabetical), then offline (laptop-b)
+    expect(names).toEqual(["phone-c", "server-a", "laptop-b"]);
+  });
+
+  it("derives exit node flag from advertisedRoutes", () => {
+    useWidgetAPI.mockReturnValue({ data: MOCK_DEVICES, error: undefined });
+
+    renderWithProviders(
+      <Component service={{ widget: { type: "tailscale", tailnet: "-", summaryView: false } }} />,
+      { settings: { hideErrors: false } },
+    );
+
+    const deviceRows = screen.getAllByTestId("tailscale-device");
+    const exitNodes = deviceRows.filter((d) => d.getAttribute("data-exit-node") === "true");
+    expect(exitNodes).toHaveLength(1);
+    expect(exitNodes[0].getAttribute("data-name")).toBe("server-a");
+  });
+
+  it("derives subnet flag from enabledRoutes excluding exit node routes", () => {
+    useWidgetAPI.mockReturnValue({ data: MOCK_DEVICES, error: undefined });
+
+    renderWithProviders(
+      <Component service={{ widget: { type: "tailscale", tailnet: "-", summaryView: false } }} />,
+      { settings: { hideErrors: false } },
+    );
+
+    const deviceRows = screen.getAllByTestId("tailscale-device");
+    const subnetRouters = deviceRows.filter((d) => d.getAttribute("data-subnets") === "true");
+    expect(subnetRouters).toHaveLength(1);
+    expect(subnetRouters[0].getAttribute("data-name")).toBe("server-a");
+  });
+
+  it("passes sshEnabled from API response", () => {
+    useWidgetAPI.mockReturnValue({ data: MOCK_DEVICES, error: undefined });
+
+    renderWithProviders(
+      <Component service={{ widget: { type: "tailscale", tailnet: "-", summaryView: false } }} />,
+      { settings: { hideErrors: false } },
+    );
+
+    const deviceRows = screen.getAllByTestId("tailscale-device");
+    const sshDevices = deviceRows.filter((d) => d.getAttribute("data-ssh") === "true");
+    expect(sshDevices).toHaveLength(1);
+    expect(sshDevices[0].getAttribute("data-name")).toBe("server-a");
+  });
+
+  // --- Error handling ---
+
+  it("renders error when API returns an error", () => {
+    useWidgetAPI.mockReturnValue({ data: undefined, error: { message: "Unauthorized" } });
+
+    renderWithProviders(
+      <Component service={{ widget: { type: "tailscale", tailnet: "-" } }} />,
+      { settings: { hideErrors: false } },
+    );
+
+    expect(screen.queryByText("tailscale.total_devices")).not.toBeInTheDocument();
   });
 });

--- a/src/widgets/tailscale/component.test.jsx
+++ b/src/widgets/tailscale/component.test.jsx
@@ -134,10 +134,9 @@ describe("widgets/tailscale/component", () => {
   it("uses devices endpoint when tailnet is configured", () => {
     useWidgetAPI.mockReturnValue({ data: undefined, error: undefined });
 
-    renderWithProviders(
-      <Component service={{ widget: { type: "tailscale", tailnet: "-" } }} />,
-      { settings: { hideErrors: false } },
-    );
+    renderWithProviders(<Component service={{ widget: { type: "tailscale", tailnet: "-" } }} />, {
+      settings: { hideErrors: false },
+    });
 
     expect(useWidgetAPI).toHaveBeenCalledWith(expect.objectContaining({ tailnet: "-" }), "devices");
   });
@@ -145,10 +144,9 @@ describe("widgets/tailscale/component", () => {
   it("renders summary placeholders while loading", () => {
     useWidgetAPI.mockReturnValue({ data: undefined, error: undefined });
 
-    const { container } = renderWithProviders(
-      <Component service={{ widget: { type: "tailscale", tailnet: "-" } }} />,
-      { settings: { hideErrors: false } },
-    );
+    const { container } = renderWithProviders(<Component service={{ widget: { type: "tailscale", tailnet: "-" } }} />, {
+      settings: { hideErrors: false },
+    });
 
     expect(container.querySelectorAll(".service-block")).toHaveLength(3);
     expect(screen.getByText("tailscale.total_devices")).toBeInTheDocument();
@@ -159,10 +157,9 @@ describe("widgets/tailscale/component", () => {
   it("renders summary counts from connectedToControl field", () => {
     useWidgetAPI.mockReturnValue({ data: MOCK_DEVICES, error: undefined });
 
-    const { container } = renderWithProviders(
-      <Component service={{ widget: { type: "tailscale", tailnet: "-" } }} />,
-      { settings: { hideErrors: false } },
-    );
+    const { container } = renderWithProviders(<Component service={{ widget: { type: "tailscale", tailnet: "-" } }} />, {
+      settings: { hideErrors: false },
+    });
 
     expectBlockValue(container, "tailscale.total_devices", "3");
     expectBlockValue(container, "tailscale.online", "2");
@@ -176,10 +173,9 @@ describe("widgets/tailscale/component", () => {
   it("renders device rows when summaryView is false", () => {
     useWidgetAPI.mockReturnValue({ data: MOCK_DEVICES, error: undefined });
 
-    renderWithProviders(
-      <Component service={{ widget: { type: "tailscale", tailnet: "-", summaryView: false } }} />,
-      { settings: { hideErrors: false } },
-    );
+    renderWithProviders(<Component service={{ widget: { type: "tailscale", tailnet: "-", summaryView: false } }} />, {
+      settings: { hideErrors: false },
+    });
 
     const deviceRows = screen.getAllByTestId("tailscale-device");
     expect(deviceRows).toHaveLength(3);
@@ -188,10 +184,9 @@ describe("widgets/tailscale/component", () => {
   it("sorts online devices before offline, then alphabetical", () => {
     useWidgetAPI.mockReturnValue({ data: MOCK_DEVICES, error: undefined });
 
-    renderWithProviders(
-      <Component service={{ widget: { type: "tailscale", tailnet: "-", summaryView: false } }} />,
-      { settings: { hideErrors: false } },
-    );
+    renderWithProviders(<Component service={{ widget: { type: "tailscale", tailnet: "-", summaryView: false } }} />, {
+      settings: { hideErrors: false },
+    });
 
     const deviceRows = screen.getAllByTestId("tailscale-device");
     const names = deviceRows.map((d) => d.getAttribute("data-name"));
@@ -202,10 +197,9 @@ describe("widgets/tailscale/component", () => {
   it("derives exit node flag from advertisedRoutes", () => {
     useWidgetAPI.mockReturnValue({ data: MOCK_DEVICES, error: undefined });
 
-    renderWithProviders(
-      <Component service={{ widget: { type: "tailscale", tailnet: "-", summaryView: false } }} />,
-      { settings: { hideErrors: false } },
-    );
+    renderWithProviders(<Component service={{ widget: { type: "tailscale", tailnet: "-", summaryView: false } }} />, {
+      settings: { hideErrors: false },
+    });
 
     const deviceRows = screen.getAllByTestId("tailscale-device");
     const exitNodes = deviceRows.filter((d) => d.getAttribute("data-exit-node") === "true");
@@ -216,10 +210,9 @@ describe("widgets/tailscale/component", () => {
   it("derives subnet flag from enabledRoutes excluding exit node routes", () => {
     useWidgetAPI.mockReturnValue({ data: MOCK_DEVICES, error: undefined });
 
-    renderWithProviders(
-      <Component service={{ widget: { type: "tailscale", tailnet: "-", summaryView: false } }} />,
-      { settings: { hideErrors: false } },
-    );
+    renderWithProviders(<Component service={{ widget: { type: "tailscale", tailnet: "-", summaryView: false } }} />, {
+      settings: { hideErrors: false },
+    });
 
     const deviceRows = screen.getAllByTestId("tailscale-device");
     const subnetRouters = deviceRows.filter((d) => d.getAttribute("data-subnets") === "true");
@@ -230,10 +223,9 @@ describe("widgets/tailscale/component", () => {
   it("passes sshEnabled from API response", () => {
     useWidgetAPI.mockReturnValue({ data: MOCK_DEVICES, error: undefined });
 
-    renderWithProviders(
-      <Component service={{ widget: { type: "tailscale", tailnet: "-", summaryView: false } }} />,
-      { settings: { hideErrors: false } },
-    );
+    renderWithProviders(<Component service={{ widget: { type: "tailscale", tailnet: "-", summaryView: false } }} />, {
+      settings: { hideErrors: false },
+    });
 
     const deviceRows = screen.getAllByTestId("tailscale-device");
     const sshDevices = deviceRows.filter((d) => d.getAttribute("data-ssh") === "true");
@@ -246,10 +238,9 @@ describe("widgets/tailscale/component", () => {
   it("renders error when API returns an error", () => {
     useWidgetAPI.mockReturnValue({ data: undefined, error: { message: "Unauthorized" } });
 
-    renderWithProviders(
-      <Component service={{ widget: { type: "tailscale", tailnet: "-" } }} />,
-      { settings: { hideErrors: false } },
-    );
+    renderWithProviders(<Component service={{ widget: { type: "tailscale", tailnet: "-" } }} />, {
+      settings: { hideErrors: false },
+    });
 
     expect(screen.queryByText("tailscale.total_devices")).not.toBeInTheDocument();
   });

--- a/src/widgets/tailscale/device.jsx
+++ b/src/widgets/tailscale/device.jsx
@@ -1,0 +1,32 @@
+import classNames from "classnames";
+import { useTranslation } from "next-i18next";
+import { MdOutlineSecurity } from "react-icons/md";
+import { FiShare2, FiGlobe } from "react-icons/fi";
+
+export default function Device({ name, address, online, isExitNode, hasSubnets, sshEnabled }) {
+  const { t } = useTranslation();
+  const statusColor = online ? "bg-green-500" : "bg-gray-500/50 dark:bg-gray-600/50";
+
+  return (
+    <div className="flex flex-row text-theme-700 dark:text-theme-200 items-center text-xs relative h-5 w-full rounded-md bg-theme-200/50 dark:bg-theme-900/20 mt-1">
+      <span className="ml-2 h-2 w-2 z-10">
+        <span className={classNames("block w-2 h-2 rounded-full", statusColor)} />
+      </span>
+      <div className="text-xs z-10 self-center ml-2 relative h-4 grow mr-2">
+        <div className="absolute w-full whitespace-nowrap text-ellipsis overflow-hidden text-left">{name}</div>
+      </div>
+      <div className="self-center flex items-center gap-1 mr-1.5 pl-1 z-10">
+        {sshEnabled && (
+          <MdOutlineSecurity className="w-3 h-3 opacity-60" title={t("tailscale.ssh")} />
+        )}
+        {hasSubnets && (
+          <FiShare2 className="w-3 h-3 opacity-60" title={t("tailscale.subnets")} />
+        )}
+        {isExitNode && (
+          <FiGlobe className="w-3 h-3 opacity-60" title={t("tailscale.exit_node")} />
+        )}
+        <span className="text-theme-500 dark:text-theme-300 ml-1">{address}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/widgets/tailscale/device.jsx
+++ b/src/widgets/tailscale/device.jsx
@@ -1,8 +1,8 @@
 import classNames from "classnames";
-import { useState } from "react";
 import { useTranslation } from "next-i18next";
+import { useState } from "react";
+import { FiGlobe, FiShare2 } from "react-icons/fi";
 import { MdOutlineSecurity } from "react-icons/md";
-import { FiShare2, FiGlobe } from "react-icons/fi";
 
 export default function Device({ name, address, online, isExitNode, hasSubnets, sshEnabled }) {
   const { t } = useTranslation();
@@ -31,15 +31,9 @@ export default function Device({ name, address, online, isExitNode, hasSubnets, 
         <div className="absolute w-full whitespace-nowrap text-ellipsis overflow-hidden text-left">{name}</div>
       </div>
       <div className="self-center flex items-center gap-1 mr-1.5 pl-1 z-10">
-        {sshEnabled && (
-          <MdOutlineSecurity className="w-3 h-3 opacity-60" title={t("tailscale.ssh")} />
-        )}
-        {hasSubnets && (
-          <FiShare2 className="w-3 h-3 opacity-60" title={t("tailscale.subnets")} />
-        )}
-        {isExitNode && (
-          <FiGlobe className="w-3 h-3 opacity-60" title={t("tailscale.exit_node")} />
-        )}
+        {sshEnabled && <MdOutlineSecurity className="w-3 h-3 opacity-60" title={t("tailscale.ssh")} />}
+        {hasSubnets && <FiShare2 className="w-3 h-3 opacity-60" title={t("tailscale.subnets")} />}
+        {isExitNode && <FiGlobe className="w-3 h-3 opacity-60" title={t("tailscale.exit_node")} />}
         <button
           type="button"
           onClick={handleCopy}

--- a/src/widgets/tailscale/device.jsx
+++ b/src/widgets/tailscale/device.jsx
@@ -1,14 +1,29 @@
 import classNames from "classnames";
+import { useState } from "react";
 import { useTranslation } from "next-i18next";
 import { MdOutlineSecurity } from "react-icons/md";
 import { FiShare2, FiGlobe } from "react-icons/fi";
 
 export default function Device({ name, address, online, isExitNode, hasSubnets, sshEnabled }) {
   const { t } = useTranslation();
-  const statusColor = online ? "bg-green-500" : "bg-gray-500/50 dark:bg-gray-600/50";
+  const [copied, setCopied] = useState(false);
+  const statusColor = online ? "bg-green-500" : "bg-red-500/80";
+
+  const handleCopy = () => {
+    if (!address) return;
+    navigator.clipboard.writeText(address).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  };
 
   return (
-    <div className="flex flex-row text-theme-700 dark:text-theme-200 items-center text-xs relative h-5 w-full rounded-md bg-theme-200/50 dark:bg-theme-900/20 mt-1">
+    <div
+      className={classNames(
+        "flex flex-row text-theme-700 dark:text-theme-200 items-center text-xs relative h-5 w-full rounded-md bg-theme-200/50 dark:bg-theme-900/20 mt-1",
+        !online && "opacity-40",
+      )}
+    >
       <span className="ml-2 h-2 w-2 z-10">
         <span className={classNames("block w-2 h-2 rounded-full", statusColor)} />
       </span>
@@ -25,7 +40,14 @@ export default function Device({ name, address, online, isExitNode, hasSubnets, 
         {isExitNode && (
           <FiGlobe className="w-3 h-3 opacity-60" title={t("tailscale.exit_node")} />
         )}
-        <span className="text-theme-500 dark:text-theme-300 ml-1">{address}</span>
+        <button
+          type="button"
+          onClick={handleCopy}
+          title={copied ? t("tailscale.copied") : t("tailscale.copy")}
+          className="text-theme-500 dark:text-theme-300 ml-1 hover:text-white hover:underline cursor-pointer transition-colors"
+        >
+          {copied ? t("tailscale.copied") : address}
+        </button>
       </div>
     </div>
   );

--- a/src/widgets/tailscale/widget.js
+++ b/src/widgets/tailscale/widget.js
@@ -1,5 +1,5 @@
-import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
 import { asJson } from "utils/proxy/api-helpers";
+import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
 
 const widget = {
   api: "https://api.tailscale.com/api/v2/{endpoint}",

--- a/src/widgets/tailscale/widget.js
+++ b/src/widgets/tailscale/widget.js
@@ -1,12 +1,17 @@
 import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
+import { asJson } from "utils/proxy/api-helpers";
 
 const widget = {
-  api: "https://api.tailscale.com/api/v2/{endpoint}/{deviceid}",
+  api: "https://api.tailscale.com/api/v2/{endpoint}",
   proxyHandler: credentialedProxyHandler,
 
   mappings: {
     device: {
-      endpoint: "device",
+      endpoint: "device/{deviceid}",
+    },
+    devices: {
+      endpoint: "tailnet/{tailnet}/devices?fields=all",
+      map: (data) => asJson(data).devices,
     },
   },
 };

--- a/src/widgets/tailscale/widget.test.js
+++ b/src/widgets/tailscale/widget.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { expectWidgetConfigShape } from "test-utils/widget-config";
 import { formatApiCall } from "utils/proxy/api-helpers";

--- a/src/widgets/tailscale/widget.test.js
+++ b/src/widgets/tailscale/widget.test.js
@@ -1,11 +1,49 @@
-import { describe, it } from "vitest";
+import { describe, it, expect } from "vitest";
 
 import { expectWidgetConfigShape } from "test-utils/widget-config";
+import { formatApiCall } from "utils/proxy/api-helpers";
 
 import widget from "./widget";
 
 describe("tailscale widget config", () => {
   it("exports a valid widget config", () => {
     expectWidgetConfigShape(widget);
+  });
+
+  it("has device and devices mappings", () => {
+    expect(widget.mappings.device).toBeTruthy();
+    expect(widget.mappings.devices).toBeTruthy();
+  });
+
+  it("builds correct single-device URL (backwards compat)", () => {
+    const url = formatApiCall(widget.api, {
+      endpoint: widget.mappings.device.endpoint,
+      deviceid: "test-device-123",
+    });
+    expect(url).toBe("https://api.tailscale.com/api/v2/device/test-device-123");
+  });
+
+  it("builds correct tailnet devices URL with tailnet ID", () => {
+    const url = formatApiCall(widget.api, {
+      endpoint: widget.mappings.devices.endpoint,
+      tailnet: "test-tailnet-456",
+    });
+    expect(url).toBe("https://api.tailscale.com/api/v2/tailnet/test-tailnet-456/devices?fields=all");
+  });
+
+  it("builds correct tailnet devices URL with dash shorthand", () => {
+    const url = formatApiCall(widget.api, {
+      endpoint: widget.mappings.devices.endpoint,
+      tailnet: "-",
+    });
+    expect(url).toBe("https://api.tailscale.com/api/v2/tailnet/-/devices?fields=all");
+  });
+
+  it("builds correct tailnet devices URL with domain name", () => {
+    const url = formatApiCall(widget.api, {
+      endpoint: widget.mappings.devices.endpoint,
+      tailnet: "example.com",
+    });
+    expect(url).toBe("https://api.tailscale.com/api/v2/tailnet/example.com/devices?fields=all");
   });
 });


### PR DESCRIPTION
<!--
==== STOP ====================
======== STOP ================
============ STOP ============
================ STOP ========
==================== STOP ====

⚠️ Before opening this pull request please review the guidelines in the checklist below.

If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.
-->

## Proposed change

This PR provides deeper integration with tailscale. It is backwards compatible with the existing tailscale integration which shows information for a specifc device, but can now be used to summarize all devices in the tailnet, or show details: 

### Existing behavior still supported
<img width="317" height="154" alt="CleanShot 2026-04-06 at 13 45 01@2x" src="https://github.com/user-attachments/assets/3af5ed78-8fba-4c56-9d20-82645a24dbe9" />

### New behavior
Now, users can elect to define `tailnet` instead of `deviceid` and get information on the whole tailnet instead of a particular device.

`summaryView: true` (default):
<img width="318" height="149" alt="CleanShot 2026-04-06 at 13 43 26@2x" src="https://github.com/user-attachments/assets/f1c4c36b-bb50-4ac5-a0bd-01fad50519f0" />

`summaryView: false`:
<img width="310" height="407" alt="CleanShot 2026-04-06 at 13 42 39@2x" src="https://github.com/user-attachments/assets/849ab7f9-d0f4-45b5-b565-fdc55b4ab8fd" />


**Note**: claude-code was used to **assist** in the writing of these changes.

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [X] If applicable, I have added corresponding documentation changes.
- [X] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [X] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [X] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [X] In the description above I have disclosed the use of AI tools in the coding of this PR.
