### PR TITLE
Enhancement: Cache and reuse keep-alive HTTP(S) agents

### DIFF
--- a/src/utils/proxy/http.js
+++ b/src/utils/proxy/http.js
@@ -224,23 +224,43 @@ function homepageDNSLookupFn() {
   };
 }
 
+const homepageLookup = homepageDNSLookupFn();
+const agentCache = new Map();
+
+function getAgent(protocol, disableIpv6) {
+  const cacheKey = `${protocol}:${disableIpv6 ? "ipv4" : "auto"}`;
+  const cachedAgent = agentCache.get(cacheKey);
+  if (cachedAgent) {
+    return cachedAgent;
+  }
+
+  const agentOptions = {
+    keepAlive: true,
+    ...(disableIpv6 ? { family: 4, autoSelectFamily: false } : { autoSelectFamilyAttemptTimeout: 500 }),
+    lookup: homepageLookup,
+  };
+
+  const agent =
+    protocol === "https:"
+      ? new https.Agent({ ...agentOptions, rejectUnauthorized: false })
+      : new http.Agent(agentOptions);
+
+  agentCache.set(cacheKey, agent);
+  return agent;
+}
+
 export async function httpProxy(url, params = {}) {
   const constructedUrl = new URL(url);
   const disableIpv6 = process.env.HOMEPAGE_PROXY_DISABLE_IPV6 === "true";
-  const agentOptions = {
-    ...(disableIpv6 ? { family: 4, autoSelectFamily: false } : { autoSelectFamilyAttemptTimeout: 500 }),
-    lookup: homepageDNSLookupFn(),
-  };
-
   let request = null;
   if (constructedUrl.protocol === "https:") {
     request = httpsRequest(constructedUrl, {
-      agent: new https.Agent({ ...agentOptions, rejectUnauthorized: false }),
+      agent: getAgent(constructedUrl.protocol, disableIpv6),
       ...params,
     });
   } else {
     request = httpRequest(constructedUrl, {
-      agent: new http.Agent(agentOptions),
+      agent: getAgent(constructedUrl.protocol, disableIpv6),
       ...params,
     });
   }

--- a/src/utils/proxy/http.test.js
+++ b/src/utils/proxy/http.test.js
@@ -8,6 +8,7 @@ const { state, cache, logger, dns, net, cookieJar } = vi.hoisted(() => ({
       body: Buffer.from(""),
     },
     error: null,
+    lastAgent: null,
     lastAgentOptions: null,
     lastRequestParams: null,
     lastWrittenBody: null,
@@ -59,6 +60,7 @@ vi.mock("follow-redirects", async () => {
         state.lastWrittenBody = chunk;
       });
       req.end = vi.fn(() => {
+        state.lastAgent = params?.agent ?? null;
         state.lastAgentOptions = params?.agent?.opts ?? null;
         if (state.error) {
           req.emit("error", state.error);
@@ -104,6 +106,7 @@ describe("utils/proxy/http cachedRequest", () => {
       headers: { "content-type": "application/json" },
       body: Buffer.from(""),
     };
+    state.lastAgent = null;
     state.lastAgentOptions = null;
     state.lastRequestParams = null;
     state.lastWrittenBody = null;
@@ -307,6 +310,7 @@ describe("utils/proxy/http httpProxy", () => {
       headers: { "content-type": "application/json" },
       body: Buffer.from("ok"),
     };
+    state.lastAgent = null;
     state.lastAgentOptions = null;
     state.lastRequestParams = null;
     state.lastWrittenBody = null;
@@ -397,6 +401,7 @@ describe("utils/proxy/http httpProxy", () => {
 
     await httpMod.httpProxy("http://example.com");
 
+    expect(state.lastAgentOptions.keepAlive).toBe(true);
     expect(state.lastAgentOptions.family).toBe(4);
     expect(state.lastAgentOptions.autoSelectFamily).toBe(false);
   });
@@ -407,6 +412,17 @@ describe("utils/proxy/http httpProxy", () => {
     await httpMod.httpProxy("https://example.com");
 
     expect(state.lastAgentOptions.rejectUnauthorized).toBe(false);
+  });
+
+  it("reuses the same keep-alive agent for repeated http requests", async () => {
+    const httpMod = await import("./http");
+
+    await httpMod.httpProxy("http://example.com/first");
+    const firstAgent = state.lastAgent;
+    await httpMod.httpProxy("http://example.com/second");
+
+    expect(state.lastAgentOptions.keepAlive).toBe(true);
+    expect(state.lastAgent).toBe(firstAgent);
   });
 
   it("returns a sanitized error response when the request fails", async () => {


### PR DESCRIPTION
<!--
==== STOP ====================
======== STOP ================
============ STOP ============
================ STOP ========
==================== STOP ====

⚠️ Before opening this pull request please review the guidelines in the checklist below.

If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.
-->

## Proposed change

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

see #6529

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [ ] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] In the description above I have disclosed the use of AI tools in the coding of this PR.
