### PR TITLE
Harden Docker discovery when container labels are missing

### DIFF
--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -92,7 +92,7 @@ export async function servicesFromDocker() {
 
         const discovered = containers.map((container) => {
           let constructedService = null;
-          const containerLabels = isSwarm ? shvl.get(container, "Spec.Labels") : container.Labels;
+          const containerLabels = (isSwarm ? shvl.get(container, "Spec.Labels") : container.Labels) ?? {};
           const containerName = isSwarm ? shvl.get(container, "Spec.Name") : container.Names[0];
 
           Object.keys(containerLabels).forEach((label) => {

--- a/src/utils/config/service-helpers.test.js
+++ b/src/utils/config/service-helpers.test.js
@@ -587,6 +587,59 @@ describe("utils/config/service-helpers", () => {
     expect(state.logger.error).toHaveBeenCalled();
   });
 
+  it("servicesFromDocker skips containers and swarm services with missing labels", async () => {
+    state.dockerYaml = {
+      "docker-local": {},
+      "docker-swarm": { swarm: true },
+    };
+
+    state.dockerContainersByServer["docker-local"] = [
+      {
+        Names: ["/nolabels"],
+      },
+      {
+        Names: ["/c1"],
+        Labels: {
+          "homepage.group": "G",
+          "homepage.name": "Svc",
+        },
+      },
+    ];
+
+    state.dockerServicesByServer["docker-swarm"] = [
+      {
+        Spec: {
+          Name: "swarm-no-labels",
+        },
+      },
+      {
+        Spec: {
+          Name: "swarm1",
+          Labels: {
+            "homepage.group": "G2",
+            "homepage.name": "SwarmSvc",
+          },
+        },
+      },
+    ];
+
+    const mod = await import("./service-helpers");
+    const discoveredGroups = await mod.servicesFromDocker();
+
+    expect(discoveredGroups).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "G",
+          services: [expect.objectContaining({ name: "Svc", container: "c1" })],
+        }),
+        expect.objectContaining({
+          name: "G2",
+          services: [expect.objectContaining({ name: "SwarmSvc", container: "swarm1" })],
+        }),
+      ]),
+    );
+  });
+
   it("servicesFromDocker tolerates per-server failures and still returns other results", async () => {
     state.dockerYaml = { "docker-a": {}, "docker-b": {} };
 


### PR DESCRIPTION
## Summary
- treat missing Docker label maps as empty during service discovery
- prevent discovery from crashing when a container or swarm service has no labels
- add a regression test covering both Docker and Swarm discovery paths

Related: https://github.com/gethomepage/homepage/issues/2551

## Validation
- corepack pnpm vitest run src/utils/config/service-helpers.test.js
- corepack pnpm eslint src/utils/config/service-helpers.js src/utils/config/service-helpers.test.js
- git diff --check

## Note
- This PR was AI-assisted, per the repository contribution guidance.