### PR TITLE
feat: add abbreviate option to AdGuard widget to compact counts

### DIFF
--- a/docs/widgets/services/adguard-home.md
+++ b/docs/widgets/services/adguard-home.md
@@ -8,6 +8,7 @@ Learn more about [Adguard Home](https://github.com/AdguardTeam/AdGuardHome).
 The username and password are the same as used to login to the web interface.
 
 Allowed fields: `["queries", "blocked", "filtered", "latency"]`.
+Optional fields: `abbreviate: true` (Shortens counts and rounds latency).
 
 ```yaml
 widget:
@@ -15,4 +16,5 @@ widget:
   url: http://adguard.host.or.ip
   username: admin
   password: password
+  abbreviate: true
 ```

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -436,6 +436,9 @@ export function cleanServiceGroups(groups) {
 
           // grafana
           alerts,
+ 
+          // adguard
+          abbreviate,
         } = widgetData;
 
         let fieldsList = fields;
@@ -696,6 +699,9 @@ export function cleanServiceGroups(groups) {
           if (interval !== undefined) {
             widget.interval = interval;
           }
+        }
+        if (type === "adguard") {
+          if (abbreviate !== undefined) widget.abbreviate = abbreviate === true || abbreviate === "true";
         }
         return widget;
       });

--- a/src/widgets/adguard/component.jsx
+++ b/src/widgets/adguard/component.jsx
@@ -8,6 +8,7 @@ export default function Component({ service }) {
   const { t } = useTranslation();
 
   const { widget } = service;
+  const { abbreviate } = widget;
 
   const { data: adguardData, error: adguardError } = useWidgetAPI(widget, "stats");
 
@@ -29,14 +30,28 @@ export default function Component({ service }) {
   const filtered =
     adguardData.num_replaced_safebrowsing + adguardData.num_replaced_safesearch + adguardData.num_replaced_parental;
 
+  const formatNumber = (value) => {
+    if (abbreviate) {
+      return new Intl.NumberFormat(undefined, {
+        notation: "compact",
+        maximumFractionDigits: 1,
+      }).format(value);
+    }
+    return t("common.number", { value });
+  };
+
   return (
     <Container service={service}>
-      <Block label="adguard.queries" value={t("common.number", { value: adguardData.num_dns_queries })} />
-      <Block label="adguard.blocked" value={t("common.number", { value: adguardData.num_blocked_filtering })} />
-      <Block label="adguard.filtered" value={t("common.number", { value: filtered })} />
+      <Block label="adguard.queries" value={formatNumber(adguardData.num_dns_queries)} />
+      <Block label="adguard.blocked" value={formatNumber(adguardData.num_blocked_filtering)} />
+      <Block label="adguard.filtered" value={formatNumber(filtered)} />
       <Block
         label="adguard.latency"
-        value={t("common.ms", { value: adguardData.avg_processing_time * 1000, style: "unit", unit: "millisecond" })}
+        value={
+          abbreviate
+            ? `${Math.round(adguardData.avg_processing_time * 1000)} ms`
+            : t("common.ms", { value: adguardData.avg_processing_time * 1000, style: "unit", unit: "millisecond" })
+        }
         highlightValue={adguardData.avg_processing_time * 1000}
       />
     </Container>

--- a/src/widgets/adguard/component.test.jsx
+++ b/src/widgets/adguard/component.test.jsx
@@ -60,4 +60,27 @@ describe("widgets/adguard/component", () => {
     expect(screen.getByText("6")).toBeInTheDocument(); // filtered sum
     expect(screen.getByText("10")).toBeInTheDocument(); // 0.01s -> 10ms
   });
+  it("renders abbreviated counts and rounded latency when abbreviate flag is true", () => {
+    useWidgetAPI.mockReturnValue({
+      data: {
+        num_dns_queries: 1500,
+        num_blocked_filtering: 2000,
+        num_replaced_safebrowsing: 100,
+        num_replaced_safesearch: 200,
+        num_replaced_parental: 300,
+        avg_processing_time: 0.008697,
+      },
+      error: undefined,
+    });
+
+    renderWithProviders(<Component service={{ widget: { type: "adguard", abbreviate: true } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    // In 'en' locale, compact notation for 1500 is 1.5K
+    expect(screen.getByText("1.5K")).toBeInTheDocument();
+    expect(screen.getByText("2K")).toBeInTheDocument();
+    expect(screen.getByText("600")).toBeInTheDocument(); // 100+200+300
+    expect(screen.getByText("9")).toBeInTheDocument(); // 8.697ms -> 9ms
+  });
 });


### PR DESCRIPTION
## Proposed change

Introduced a new flag to enable abbreviated numbers on the AdGuard widget.

Before:
<img width="451" height="251" alt="Screenshot 2026-04-13 at 00 42 42" src="https://github.com/user-attachments/assets/8fb5cfcc-c0ed-4518-b134-8cdc7a049011" />
After:
<img width="433" height="231" alt="Screenshot 2026-04-13 at 01 30 12" src="https://github.com/user-attachments/assets/51c88c9f-d84c-40ba-acc4-72592896b17a" />


## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] In the description above I have disclosed the use of AI tools in the coding of this PR.
