### PR TITLE
Fix: use v2 storage API for UniFi Drive widget

### DIFF
--- a/src/widgets/unifi_drive/component.jsx
+++ b/src/widgets/unifi_drive/component.jsx
@@ -25,9 +25,9 @@ export default function Component({ service }) {
     );
   }
 
-  const { data: storage } = storageData;
+  const { pools } = storageData;
 
-  if (!storage) {
+  if (!Array.isArray(pools) || pools.length === 0) {
     return (
       <Container service={service}>
         <Block value={t("unifi_drive.no_data")} />
@@ -35,12 +35,13 @@ export default function Component({ service }) {
     );
   }
 
-  const { totalQuota, usage, status } = storage;
-  const totalBytes = totalQuota ?? 0;
-  const usedBytes = (usage?.system || 0) + (usage?.myDrives || 0) + (usage?.sharedDrives || 0);
+  const totalBytes = pools.reduce((sum, p) => sum + (p.capacity ?? 0), 0);
+  const usedBytes = pools.reduce((sum, p) => sum + (p.usage ?? 0), 0);
   const availableBytes = Math.max(0, totalBytes - usedBytes);
+
+  const status = pools.some((p) => p.status === "degraded") ? "degraded" : pools[0]?.status;
   let statusValue = status;
-  if (status === "healthy") statusValue = t("unifi_drive.healthy");
+  if (status === "fullyOperational" || status === "noDataProtectionYet") statusValue = t("unifi_drive.healthy");
   else if (status === "degraded") statusValue = t("unifi_drive.degraded");
 
   return (

--- a/src/widgets/unifi_drive/component.test.jsx
+++ b/src/widgets/unifi_drive/component.test.jsx
@@ -39,8 +39,8 @@ describe("widgets/unifi_drive/component", () => {
     expect(screen.getAllByText("widget.api_error", { exact: false }).length).toBeGreaterThan(0);
   });
 
-  it("renders no_data when storage data is missing", () => {
-    useWidgetAPI.mockReturnValue({ data: { data: null }, error: undefined });
+  it("renders no_data when pools array is empty", () => {
+    useWidgetAPI.mockReturnValue({ data: { pools: [] }, error: undefined });
 
     const service = { widget: { type: "unifi_drive" } };
     renderWithProviders(<Component service={service} />, { settings: { hideErrors: false } });
@@ -48,14 +48,19 @@ describe("widgets/unifi_drive/component", () => {
     expect(screen.getByText("unifi_drive.no_data")).toBeInTheDocument();
   });
 
-  it("renders storage statistics when data is loaded", () => {
+  it("renders no_data when pools is missing", () => {
+    useWidgetAPI.mockReturnValue({ data: {}, error: undefined });
+
+    const service = { widget: { type: "unifi_drive" } };
+    renderWithProviders(<Component service={service} />, { settings: { hideErrors: false } });
+
+    expect(screen.getByText("unifi_drive.no_data")).toBeInTheDocument();
+  });
+
+  it("renders storage statistics from single pool", () => {
     useWidgetAPI.mockReturnValue({
       data: {
-        data: {
-          totalQuota: 1000000000000,
-          usage: { system: 100000000000, myDrives: 200000000000, sharedDrives: 50000000000 },
-          status: "healthy",
-        },
+        pools: [{ capacity: 1000000000000, usage: 350000000000, status: "fullyOperational" }],
       },
       error: undefined,
     });
@@ -70,14 +75,34 @@ describe("widgets/unifi_drive/component", () => {
     expectBlockValue(container, "widget.status", "unifi_drive.healthy");
   });
 
-  it("renders degraded status", () => {
+  it("aggregates storage across multiple pools", () => {
     useWidgetAPI.mockReturnValue({
       data: {
-        data: {
-          totalQuota: 100,
-          usage: { system: 10, myDrives: 20, sharedDrives: 5 },
-          status: "degraded",
-        },
+        pools: [
+          { capacity: 1000000000000, usage: 300000000000, status: "fullyOperational" },
+          { capacity: 500000000000, usage: 100000000000, status: "noDataProtectionYet" },
+        ],
+      },
+      error: undefined,
+    });
+
+    const service = { widget: { type: "unifi_drive" } };
+    const { container } = renderWithProviders(<Component service={service} />, { settings: { hideErrors: false } });
+
+    expect(container.querySelectorAll(".service-block")).toHaveLength(4);
+    expectBlockValue(container, "resources.total", 1500000000000);
+    expectBlockValue(container, "resources.used", 400000000000);
+    expectBlockValue(container, "resources.free", 1100000000000);
+    expectBlockValue(container, "widget.status", "unifi_drive.healthy");
+  });
+
+  it("renders degraded status when any pool is degraded", () => {
+    useWidgetAPI.mockReturnValue({
+      data: {
+        pools: [
+          { capacity: 1000, usage: 400, status: "fullyOperational" },
+          { capacity: 500, usage: 100, status: "degraded" },
+        ],
       },
       error: undefined,
     });
@@ -87,6 +112,20 @@ describe("widgets/unifi_drive/component", () => {
 
     expect(container.querySelectorAll(".service-block")).toHaveLength(4);
     expectBlockValue(container, "widget.status", "unifi_drive.degraded");
-    expectBlockValue(container, "resources.free", 65);
+    expectBlockValue(container, "resources.free", 1000);
+  });
+
+  it("renders noDataProtectionYet as healthy", () => {
+    useWidgetAPI.mockReturnValue({
+      data: {
+        pools: [{ capacity: 1000, usage: 200, status: "noDataProtectionYet" }],
+      },
+      error: undefined,
+    });
+
+    const service = { widget: { type: "unifi_drive" } };
+    const { container } = renderWithProviders(<Component service={service} />, { settings: { hideErrors: false } });
+
+    expectBlockValue(container, "widget.status", "unifi_drive.healthy");
   });
 });

--- a/src/widgets/unifi_drive/component.test.jsx
+++ b/src/widgets/unifi_drive/component.test.jsx
@@ -128,4 +128,21 @@ describe("widgets/unifi_drive/component", () => {
 
     expectBlockValue(container, "widget.status", "unifi_drive.healthy");
   });
+
+  it("handles pools with missing capacity or usage", () => {
+    useWidgetAPI.mockReturnValue({
+      data: {
+        pools: [{ status: "fullyOperational" }],
+      },
+      error: undefined,
+    });
+
+    const service = { widget: { type: "unifi_drive" } };
+    const { container } = renderWithProviders(<Component service={service} />, { settings: { hideErrors: false } });
+
+    expect(container.querySelectorAll(".service-block")).toHaveLength(4);
+    expectBlockValue(container, "resources.total", 0);
+    expectBlockValue(container, "resources.used", 0);
+    expectBlockValue(container, "resources.free", 0);
+  });
 });

--- a/src/widgets/unifi_drive/widget.js
+++ b/src/widgets/unifi_drive/widget.js
@@ -6,7 +6,7 @@ const widget = {
 
   mappings: {
     storage: {
-      endpoint: "v1/systems/storage?type=detail",
+      endpoint: "v2/storage",
     },
   },
 };


### PR DESCRIPTION
## Description

Switches the `unifi_drive` widget storage endpoint from v1 (`/v1/systems/storage?type=detail`) to v2 (`/v2/storage`).

The v1 endpoint returns empty `usage` data and `status: "not_setup"` on certain pool configurations (single-drive pools on UNAS-2 and UNAS Pro). The v2 endpoint returns correct per-pool storage data for all configurations.

## Changes

- **widget.js** — Switch storage mapping to v2 endpoint
- **component.jsx** — Extract data from v2 `pools` array, aggregate capacity/usage across pools, map v2 status values (`fullyOperational`, `noDataProtectionYet`) to existing translation keys
- **component.test.jsx** — Update mocks to v2 response shape, add tests for multi-pool aggregation, `noDataProtectionYet` status, and missing pools

## Testing

- 13/13 unit tests pass
- Tested against live UNAS Pro (5-drive RAID6 pool) — widget renders correctly
- Docker container build and runtime verified

## Related

Ref: #6479

## AI Disclosure

AI tools were used to assist with development of this PR.