### PR TITLE
Fix: Swap `cputemp` and `disk` resources in glances loading state skeleton

### DIFF
--- a/src/components/widgets/glances/glances.jsx
+++ b/src/components/widgets/glances/glances.jsx
@@ -38,7 +38,6 @@ export default function Widget({ options }) {
       <Resources options={options} additionalClassNames="information-widget-glances">
         {options.cpu !== false && <Resource icon={FiCpu} label={t("glances.wait")} percentage="0" />}
         {options.mem !== false && <Resource icon={FaMemory} label={t("glances.wait")} percentage="0" />}
-        {options.cputemp && <Resource icon={FaThermometerHalf} label={t("glances.wait")} percentage="0" />}
         {options.disk && !Array.isArray(options.disk) && (
           <Resource key={options.disk} icon={FiHardDrive} label={t("glances.wait")} percentage="0" />
         )}
@@ -47,6 +46,7 @@ export default function Widget({ options }) {
           options.disk.map((disk) => (
             <Resource key={`disk_${disk}`} icon={FiHardDrive} label={t("glances.wait")} percentage="0" />
           ))}
+        {options.cputemp && <Resource icon={FaThermometerHalf} label={t("glances.wait")} percentage="0" />}
         {options.uptime && <Resource icon={FaRegClock} label={t("glances.wait")} percentage="0" />}
         {options.label && <WidgetLabel label={options.label} />}
       </Resources>


### PR DESCRIPTION
## Proposed change

The "Please wait" placeholders render temperature and disk resources in a different order than the actual resources once their values are loaded.

This looks like:
<img width="551" height="133" alt="Screenshot 2026-04-17 at 17 21 06" src="https://github.com/user-attachments/assets/4c1afc52-e4ef-4f08-8def-c5cedd07b2c7" />
<img width="552" height="128" alt="Screenshot 2026-04-17 at 17 21 42" src="https://github.com/user-attachments/assets/444ee583-a209-48b1-8aff-2827c68338ab" />

This PR simply swaps them in the loading state so things don't jump around after loading.

## Type of change

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [N/A] If applicable, I have added corresponding documentation changes.
- [N/A] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [N/A] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [N/A] In the description above I have disclosed the use of AI tools in the coding of this PR.
