### PR TITLE
Add optional Adanos sentiment to stocks widget

### DIFF
--- a/docs/configs/settings.md
+++ b/docs/configs/settings.md
@@ -481,6 +481,7 @@ The `providers` section allows you to define shared API provider options and sec
 providers:
   openweathermap: openweathermapapikey
   finnhub: yourfinnhubapikeyhere
+  adanos: youradanosapikeyhere
   longhorn:
     url: https://longhorn.example.com
     username: admin

--- a/docs/widgets/services/stocks.md
+++ b/docs/widgets/services/stocks.md
@@ -10,20 +10,28 @@ The widget includes:
 - US stock market status
 - Current price of provided stock symbol
 - Change in price of stock symbol for the day.
+- Optional market sentiment from Adanos.
 
-Finnhub.io is currently the only supported provider for the stocks widget.
+Finnhub.io is used for stock price quotes and market status.
 You can sign up for a free api key at [finnhub.io](https://finnhub.io).
 You are encouraged to read finnhub.io's
 [terms of service/privacy policy](https://finnhub.io/terms-of-service) before
 signing up.
 
+Adanos can optionally be used to show sentiment and buzz scores for the same
+watchlist. You can get access at
+[api.adanos.org/docs](https://api.adanos.org/docs/).
+
 Allowed fields: no configurable fields for this widget.
 
-You must set `finnhub` as a provider in your `settings.yaml`:
+Set `finnhub` as a provider in your `settings.yaml` for price quote mode.
+If you enable sentiment, set `adanos` instead. If you use sentiment together
+with `showUSMarketStatus`, keep `finnhub` configured as well:
 
 ```yaml
 providers:
   finnhub: yourfinnhubapikeyhere
+  adanos: youradanosapikeyhere
 ```
 
 Next, configure the stocks widget in your `services.yaml`:
@@ -48,3 +56,22 @@ widget:
     - AMZN
     - BRK.B
 ```
+
+To show Adanos sentiment instead of price quotes, enable `showSentiment`.
+Sentiment is fetched in a single batch request for the configured watchlist.
+Sentiment watchlists support up to 10 ticker symbols.
+
+```yaml
+widget:
+  type: stocks
+  showSentiment: true # optional, defaults to false
+  sentimentSource: news_stocks # optional, defaults to reddit_stocks
+  sentimentDays: 7 # optional, defaults to 7
+  watchlist:
+    - TSLA
+    - NVDA
+    - AAPL
+```
+
+Supported `sentimentSource` values are `reddit_stocks`, `x_stocks`,
+`news_stocks`, and `polymarket_stocks`.

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -403,6 +403,9 @@ export function cleanServiceGroups(groups) {
           enableQueue,
 
           // stocks
+          sentimentDays,
+          sentimentSource,
+          showSentiment,
           watchlist,
           showUSMarketStatus,
 
@@ -655,6 +658,9 @@ export function cleanServiceGroups(groups) {
           }
         }
         if (type === "stocks") {
+          if (sentimentDays !== undefined) widget.sentimentDays = parseInt(sentimentDays, 10);
+          if (sentimentSource) widget.sentimentSource = sentimentSource;
+          if (showSentiment !== undefined) widget.showSentiment = !!JSON.parse(showSentiment);
           if (watchlist) widget.watchlist = watchlist;
           if (showUSMarketStatus) widget.showUSMarketStatus = showUSMarketStatus;
         }

--- a/src/utils/config/service-helpers.test.js
+++ b/src/utils/config/service-helpers.test.js
@@ -311,7 +311,14 @@ describe("utils/config/service-helpers", () => {
               { type: "hdhomerun", tuner: 1 },
               { type: "healthchecks", uuid: "u" },
               { type: "speedtest", bitratePrecision: "3", version: "1" },
-              { type: "stocks", watchlist: "AAPL", showUSMarketStatus: true },
+              {
+                type: "stocks",
+                watchlist: "AAPL",
+                showUSMarketStatus: true,
+                showSentiment: "true",
+                sentimentSource: "news_stocks",
+                sentimentDays: "14",
+              },
               {
                 type: "tracearr",
                 expandOneStreamToTwoRows: "true",
@@ -356,6 +363,9 @@ describe("utils/config/service-helpers", () => {
     expect(widgets.find((w) => w.type === "qnap")).toEqual(expect.objectContaining({ volume: "vol1" }));
     expect(widgets.find((w) => w.type === "speedtest")).toEqual(
       expect.objectContaining({ bitratePrecision: 3, version: 1 }),
+    );
+    expect(widgets.find((w) => w.type === "stocks")).toEqual(
+      expect.objectContaining({ sentimentDays: 14, sentimentSource: "news_stocks", showSentiment: true }),
     );
     expect(widgets.find((w) => w.type === "tracearr")).toEqual(
       expect.objectContaining({

--- a/src/utils/proxy/handlers/credentialed.js
+++ b/src/utils/proxy/handlers/credentialed.js
@@ -1,4 +1,3 @@
-import { getSettings } from "utils/config/config";
 import getServiceWidget from "utils/config/service-helpers";
 import createLogger from "utils/logger";
 import { formatApiCall, sanitizeErrorURL } from "utils/proxy/api-helpers";
@@ -37,12 +36,7 @@ export default async function credentialedProxyHandler(req, res, map) {
         ...(req.extraHeaders ?? {}),
       };
 
-      if (widget.type === "stocks") {
-        const { providers } = getSettings();
-        if (widget.provider === "finnhub" && providers?.finnhub) {
-          headers["X-Finnhub-Token"] = `${providers?.finnhub}`;
-        }
-      } else if (widget.type === "coinmarketcap") {
+      if (widget.type === "coinmarketcap") {
         headers["X-CMC_PRO_API_KEY"] = `${widget.key}`;
       } else if (widget.type === "gotify") {
         headers["X-gotify-Key"] = `${widget.key}`;

--- a/src/utils/proxy/handlers/credentialed.test.js
+++ b/src/utils/proxy/handlers/credentialed.test.js
@@ -3,10 +3,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const { httpProxy } = vi.hoisted(() => ({ httpProxy: vi.fn() }));
 const { validateWidgetData } = vi.hoisted(() => ({ validateWidgetData: vi.fn(() => true) }));
 const { getServiceWidget } = vi.hoisted(() => ({ getServiceWidget: vi.fn() }));
-const { getSettings } = vi.hoisted(() => ({
-  getSettings: vi.fn(() => ({ providers: { finnhub: "finnhub-token" } })),
-}));
-
 vi.mock("utils/logger", () => ({
   default: () => ({
     debug: vi.fn(),
@@ -17,7 +13,6 @@ vi.mock("utils/logger", () => ({
 vi.mock("utils/proxy/http", () => ({ httpProxy }));
 vi.mock("utils/proxy/validate-widget-data", () => ({ default: validateWidgetData }));
 vi.mock("utils/config/service-helpers", () => ({ default: getServiceWidget }));
-vi.mock("utils/config/config", () => ({ getSettings }));
 
 // Keep the widget registry minimal so the test doesn't import the whole widget graph.
 vi.mock("widgets/widgets", () => ({
@@ -334,19 +329,6 @@ describe("utils/proxy/handlers/credentialed", () => {
     const [, params] = httpProxy.mock.calls.at(-1);
     expect(params.headers.Accept).toBe("application/json");
     expect(params.headers.Authorization).toBe("Bearer u p");
-  });
-
-  it("injects the configured finnhub provider token for stocks widgets", async () => {
-    getServiceWidget.mockResolvedValue({ type: "stocks", url: "http://stocks", provider: "finnhub" });
-    httpProxy.mockResolvedValue([200, "application/json", { ok: true }]);
-
-    const req = { method: "GET", query: { group: "g", service: "s", endpoint: "quote", index: 0 } };
-    const res = createMockRes();
-
-    await credentialedProxyHandler(req, res);
-
-    const [, params] = httpProxy.mock.calls.at(-1);
-    expect(params.headers["X-Finnhub-Token"]).toBe("finnhub-token");
   });
 
   it("sanitizes embedded query params when a downstream error contains a url", async () => {

--- a/src/widgets/stocks/component.jsx
+++ b/src/widgets/stocks/component.jsx
@@ -144,7 +144,10 @@ export default function Component({ service }) {
   const { sentimentDays, showSentiment, showUSMarketStatus, watchlist } = widget;
   const maxWatchlistItems = showSentiment === true ? MAX_SENTIMENT_WATCHLIST_ITEMS : MAX_PRICE_WATCHLIST_ITEMS;
   const validWatchlist =
-    watchlist && watchlist.length && watchlist.length <= maxWatchlistItems && new Set(watchlist).size === watchlist.length;
+    watchlist &&
+    watchlist.length &&
+    watchlist.length <= maxWatchlistItems &&
+    new Set(watchlist).size === watchlist.length;
 
   const { data: sentimentData, error: sentimentError } = useWidgetAPI(
     widget,

--- a/src/widgets/stocks/component.jsx
+++ b/src/widgets/stocks/component.jsx
@@ -5,6 +5,9 @@ import { useTranslation } from "next-i18next";
 
 import useWidgetAPI from "utils/proxy/use-widget-api";
 
+const MAX_PRICE_WATCHLIST_ITEMS = 28;
+const MAX_SENTIMENT_WATCHLIST_ITEMS = 10;
+
 function MarketStatus({ service }) {
   const { t } = useTranslation();
   const { widget } = service;
@@ -81,18 +84,98 @@ function StockItem({ service, ticker }) {
   );
 }
 
+function sentimentValue(record, ...keys) {
+  return keys.map((key) => record?.[key]).find((value) => value !== undefined && value !== null);
+}
+
+function normalizeSymbol(symbol) {
+  return symbol?.toString().trim().toUpperCase().replace(/^\$/, "");
+}
+
+function sentimentByTicker(data) {
+  const records = data?.stocks ?? data?.data ?? data?.results ?? [];
+  return Object.fromEntries(
+    records
+      .map((record) => [normalizeSymbol(sentimentValue(record, "ticker", "symbol")), record])
+      .filter(([ticker]) => ticker),
+  );
+}
+
+function SentimentBadge({ record }) {
+  const score = sentimentValue(record, "sentiment_score", "sentiment", "score");
+  const buzz = sentimentValue(record, "buzz_score", "buzz");
+  const numericBuzz = Number(buzz);
+
+  if (score === undefined && buzz === undefined) {
+    return null;
+  }
+
+  const numericScore = Number(score);
+  const tone = numericScore >= 0 ? "text-emerald-300" : "text-rose-300";
+  const formattedScore = Number.isNaN(numericScore) ? score : numericScore.toFixed(2);
+
+  return (
+    <span className={`font-bold ml-2 min-w-14 text-right ${Number.isNaN(numericScore) ? "" : tone}`}>
+      {score !== undefined ? formattedScore : "-"}
+      {buzz !== undefined && !Number.isNaN(numericBuzz) ? (
+        <span className="font-thin ml-1 text-theme-500 dark:text-theme-400">/{numericBuzz.toFixed(0)}</span>
+      ) : null}
+    </span>
+  );
+}
+
+function SentimentStockItem({ ticker, sentiment }) {
+  const { t } = useTranslation();
+  const record = sentiment?.[normalizeSymbol(ticker)];
+
+  return (
+    <div className="bg-theme-200/50 dark:bg-theme-900/20 rounded-sm flex flex-1 items-center justify-between m-1 p-1 text-xs">
+      <span className="font-thin ml-2 flex-none">{ticker}</span>
+      <div className="flex items-center mr-2 text-right">
+        {record ? <SentimentBadge record={record} /> : <span className="font-bold ml-2">{t("widget.api_error")}</span>}
+      </div>
+    </div>
+  );
+}
+
 export default function Component({ service }) {
   const { t } = useTranslation();
   const { widget } = service;
-  const { watchlist, showUSMarketStatus } = widget;
+  const { sentimentDays, showSentiment, showUSMarketStatus, watchlist } = widget;
+  const maxWatchlistItems = showSentiment === true ? MAX_SENTIMENT_WATCHLIST_ITEMS : MAX_PRICE_WATCHLIST_ITEMS;
+  const validWatchlist =
+    watchlist && watchlist.length && watchlist.length <= maxWatchlistItems && new Set(watchlist).size === watchlist.length;
 
-  if (!watchlist || !watchlist.length || watchlist.length > 28 || new Set(watchlist).size !== watchlist.length) {
+  const { data: sentimentData, error: sentimentError } = useWidgetAPI(
+    widget,
+    validWatchlist && showSentiment === true ? "sentiment" : "",
+    {
+      tickers: watchlist?.join(",") ?? "",
+      days: sentimentDays ?? 7,
+    },
+  );
+
+  if (!validWatchlist) {
     return (
       <Container service={service}>
         <Block value={t("stocks.invalidConfiguration")} />
       </Container>
     );
   }
+
+  if (showSentiment === true && (sentimentError || sentimentData?.error)) {
+    return <Container service={service} error={sentimentError} />;
+  }
+
+  if (showSentiment === true && !sentimentData) {
+    return (
+      <Container service={service}>
+        <Block value={t("stocks.loading")} />
+      </Container>
+    );
+  }
+
+  const sentiment = showSentiment === true ? sentimentByTicker(sentimentData) : null;
 
   return (
     <Container service={service}>
@@ -101,9 +184,13 @@ export default function Component({ service }) {
       </div>
 
       <div className="flex flex-col w-full">
-        {watchlist.map((ticker) => (
-          <StockItem key={ticker} service={service} ticker={ticker} />
-        ))}
+        {watchlist.map((ticker) =>
+          showSentiment === true ? (
+            <SentimentStockItem key={ticker} ticker={ticker} sentiment={sentiment} />
+          ) : (
+            <StockItem key={ticker} service={service} ticker={ticker} />
+          ),
+        )}
       </div>
     </Container>
   );

--- a/src/widgets/stocks/component.test.jsx
+++ b/src/widgets/stocks/component.test.jsx
@@ -84,6 +84,59 @@ describe("widgets/stocks/component", () => {
     expect(screen.getByText("/73")).toBeInTheDocument();
   });
 
+  it("renders alternate Adanos payload shapes and missing sentiment rows", () => {
+    useWidgetAPI.mockImplementation((_widget, endpoint) => {
+      if (endpoint === "sentiment") {
+        return {
+          data: {
+            data: [{ symbol: "$TSLA", sentiment: -0.51 }, { ticker: "MSFT", buzz_score: 9 }, { ticker: "GOOG" }],
+          },
+          error: undefined,
+        };
+      }
+      return { data: undefined, error: undefined };
+    });
+
+    renderWithProviders(
+      <Component
+        service={{
+          widget: {
+            type: "stocks",
+            watchlist: ["TSLA", "MSFT", "GOOG", "AAPL"],
+            showSentiment: true,
+          },
+        }}
+      />,
+      { settings: { hideErrors: false } },
+    );
+
+    expect(screen.getByText("-0.51")).toBeInTheDocument();
+    expect(screen.getByText("-")).toBeInTheDocument();
+    expect(screen.getByText("/9")).toBeInTheDocument();
+    expect(screen.getByText("GOOG")).toBeInTheDocument();
+    expect(screen.getByText("widget.api_error")).toBeInTheDocument();
+  });
+
+  it("renders loading and error states for Adanos sentiment mode", () => {
+    useWidgetAPI.mockReturnValueOnce({ data: undefined, error: undefined });
+
+    renderWithProviders(
+      <Component service={{ widget: { type: "stocks", watchlist: ["AAPL"], showSentiment: true } }} />,
+      { settings: { hideErrors: false } },
+    );
+
+    expect(screen.getByText("stocks.loading")).toBeInTheDocument();
+
+    useWidgetAPI.mockReturnValueOnce({ data: undefined, error: { message: "missing key" } });
+
+    renderWithProviders(
+      <Component service={{ widget: { type: "stocks", watchlist: ["MSFT"], showSentiment: true } }} />,
+      { settings: { hideErrors: false } },
+    );
+
+    expect(screen.getByText("missing key")).toBeInTheDocument();
+  });
+
   it("rejects Adanos sentiment watchlists above the compare endpoint limit", () => {
     useWidgetAPI.mockReturnValue({ data: undefined, error: undefined });
 

--- a/src/widgets/stocks/component.test.jsx
+++ b/src/widgets/stocks/component.test.jsx
@@ -40,4 +40,72 @@ describe("widgets/stocks/component", () => {
     expect(screen.getByText("AAPL")).toBeInTheDocument();
     expect(screen.getByText("1.23%")).toBeInTheDocument();
   });
+
+  it("renders Adanos sentiment rows when sentiment is enabled", () => {
+    useWidgetAPI.mockImplementation((_widget, endpoint) => {
+      if (endpoint === "sentiment") {
+        return {
+          data: {
+            stocks: [
+              {
+                ticker: "AAPL",
+                sentiment_score: 0.42,
+                buzz_score: 73,
+              },
+            ],
+          },
+          error: undefined,
+        };
+      }
+      return { data: undefined, error: undefined };
+    });
+
+    renderWithProviders(
+      <Component
+        service={{
+          widget: {
+            type: "stocks",
+            watchlist: ["AAPL"],
+            showSentiment: true,
+            sentimentDays: 14,
+            sentimentSource: "news_stocks",
+          },
+        }}
+      />,
+      { settings: { hideErrors: false } },
+    );
+
+    expect(useWidgetAPI).toHaveBeenCalledWith(
+      expect.objectContaining({ showSentiment: true }),
+      "sentiment",
+      { tickers: "AAPL", days: 14 },
+    );
+    expect(screen.getByText("AAPL")).toBeInTheDocument();
+    expect(screen.getByText("0.42")).toBeInTheDocument();
+    expect(screen.getByText("/73")).toBeInTheDocument();
+  });
+
+  it("rejects Adanos sentiment watchlists above the compare endpoint limit", () => {
+    useWidgetAPI.mockReturnValue({ data: undefined, error: undefined });
+
+    renderWithProviders(
+      <Component
+        service={{
+          widget: {
+            type: "stocks",
+            watchlist: ["AAPL", "MSFT", "NVDA", "TSLA", "AMZN", "META", "GOOGL", "AVGO", "AMD", "NFLX", "PLTR"],
+            showSentiment: true,
+          },
+        }}
+      />,
+      { settings: { hideErrors: false } },
+    );
+
+    expect(screen.getByText("stocks.invalidConfiguration")).toBeInTheDocument();
+    expect(useWidgetAPI).toHaveBeenCalledWith(
+      expect.objectContaining({ showSentiment: true }),
+      "",
+      expect.objectContaining({ tickers: expect.any(String) }),
+    );
+  });
 });

--- a/src/widgets/stocks/component.test.jsx
+++ b/src/widgets/stocks/component.test.jsx
@@ -75,11 +75,10 @@ describe("widgets/stocks/component", () => {
       { settings: { hideErrors: false } },
     );
 
-    expect(useWidgetAPI).toHaveBeenCalledWith(
-      expect.objectContaining({ showSentiment: true }),
-      "sentiment",
-      { tickers: "AAPL", days: 14 },
-    );
+    expect(useWidgetAPI).toHaveBeenCalledWith(expect.objectContaining({ showSentiment: true }), "sentiment", {
+      tickers: "AAPL",
+      days: 14,
+    });
     expect(screen.getByText("AAPL")).toBeInTheDocument();
     expect(screen.getByText("0.42")).toBeInTheDocument();
     expect(screen.getByText("/73")).toBeInTheDocument();

--- a/src/widgets/stocks/proxy.js
+++ b/src/widgets/stocks/proxy.js
@@ -1,0 +1,107 @@
+import { getSettings } from "utils/config/config";
+import getServiceWidget from "utils/config/service-helpers";
+import createLogger from "utils/logger";
+import { sanitizeErrorURL } from "utils/proxy/api-helpers";
+import { httpProxy } from "utils/proxy/http";
+import validateWidgetData from "utils/proxy/validate-widget-data";
+
+const logger = createLogger("stocksProxyHandler");
+
+const FINNHUB_BASE_URL = "https://finnhub.io/api";
+const ADANOS_BASE_URL = "https://api.adanos.org";
+
+const ADANOS_STOCK_SOURCES = {
+  reddit_stocks: "reddit/stocks/v1",
+  x_stocks: "x/stocks/v1",
+  news_stocks: "news/stocks/v1",
+  polymarket_stocks: "polymarket/stocks/v1",
+};
+
+function providerToken(provider) {
+  const providers = getSettings()?.providers ?? {};
+  return providers?.[provider];
+}
+
+function buildUrl(baseUrl, endpoint) {
+  return new URL(`${baseUrl.replace(/\/+$/, "")}/${endpoint.replace(/^\/+/, "")}`);
+}
+
+function buildAdanosUrl(widget, endpoint) {
+  const sourcePath = ADANOS_STOCK_SOURCES[widget.sentimentSource ?? "reddit_stocks"];
+  if (!sourcePath) return null;
+  return buildUrl(`${ADANOS_BASE_URL}/${sourcePath}`, endpoint);
+}
+
+function stockHeaders(widget, endpoint) {
+  if (endpoint.startsWith("v1/")) {
+    const token = providerToken("finnhub");
+    return token ? { "X-Finnhub-Token": `${token}` } : {};
+  }
+
+  const token = providerToken("adanos");
+  if (!token) return null;
+  return { "X-API-Key": `${token}` };
+}
+
+function stockUrl(widget, endpoint) {
+  if (endpoint.startsWith("v1/")) {
+    return buildUrl(FINNHUB_BASE_URL, endpoint);
+  }
+
+  return buildAdanosUrl(widget, endpoint);
+}
+
+export default async function stocksProxyHandler(req, res, map) {
+  const { group, service, endpoint, index } = req.query;
+
+  if (!endpoint) {
+    return res.status(400).json({ error: "Invalid proxy service endpoint" });
+  }
+
+  const widget = await getServiceWidget(group, service, index);
+
+  if (!widget) {
+    logger.debug("Invalid or missing stocks widget for service '%s' in group '%s'", service, group);
+    return res.status(400).json({ error: "Invalid proxy service type" });
+  }
+
+  const url = stockUrl(widget, endpoint);
+  if (!url) {
+    return res.status(400).json({ error: "Invalid Adanos sentiment source" });
+  }
+
+  const headers = stockHeaders(widget, endpoint);
+  if (!headers) {
+    return res.status(400).json({ error: "Missing or invalid API Key for provider" });
+  }
+
+  const [status, contentType, data] = await httpProxy(url, {
+    method: req.method,
+    withCredentials: true,
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+      ...headers,
+    },
+  });
+
+  let resultData = data;
+
+  if (resultData.error?.url) {
+    resultData.error.url = sanitizeErrorURL(url);
+  }
+
+  if (status >= 400) {
+    logger.error("HTTP Error %d calling %s", status, url.toString());
+  }
+
+  if (status === 200) {
+    if (!validateWidgetData(widget, endpoint.split("?")[0], resultData)) {
+      return res.status(500).json({ error: { message: "Invalid data", url: sanitizeErrorURL(url), data: resultData } });
+    }
+    if (map) resultData = map(resultData);
+  }
+
+  if (contentType) res.setHeader("Content-Type", contentType);
+  return res.status(status).send(resultData);
+}

--- a/src/widgets/stocks/proxy.test.js
+++ b/src/widgets/stocks/proxy.test.js
@@ -66,6 +66,35 @@ describe("widgets/stocks/proxy", () => {
     expect(res.statusCode).toBe(200);
   });
 
+  it("defaults Adanos sentiment requests to the Reddit stocks source", async () => {
+    getServiceWidget.mockResolvedValue({ type: "stocks" });
+    const res = createMockRes();
+
+    await stocksProxyHandler(
+      { method: "GET", query: { group: "g", service: "s", endpoint: "compare?tickers=AAPL", index: 0 } },
+      res,
+    );
+
+    const [url] = httpProxy.mock.calls[0];
+    expect(url.toString()).toBe("https://api.adanos.org/reddit/stocks/v1/compare?tickers=AAPL");
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("returns 400 when the service widget cannot be found", async () => {
+    getServiceWidget.mockResolvedValue(null);
+    const res = createMockRes();
+
+    await stocksProxyHandler(
+      { method: "GET", query: { group: "g", service: "s", endpoint: "compare?tickers=AAPL", index: 0 } },
+      res,
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toContain("Invalid proxy service type");
+    expect(logger.debug).toHaveBeenCalled();
+    expect(httpProxy).not.toHaveBeenCalled();
+  });
+
   it("returns 400 when the Adanos provider token is missing", async () => {
     getSettings.mockReturnValue({ providers: { finnhub: "finnhub-token" } });
     getServiceWidget.mockResolvedValue({ type: "stocks", sentimentSource: "reddit_stocks" });
@@ -93,5 +122,56 @@ describe("widgets/stocks/proxy", () => {
     expect(res.statusCode).toBe(400);
     expect(res.body.error).toContain("source");
     expect(httpProxy).not.toHaveBeenCalled();
+  });
+
+  it("sanitizes downstream error urls and logs failed responses", async () => {
+    getServiceWidget.mockResolvedValue({ type: "stocks", sentimentSource: "news_stocks" });
+    httpProxy.mockResolvedValue([
+      500,
+      "application/json",
+      { error: { url: "https://api.adanos.org/news/stocks/v1/compare?token=secret" } },
+    ]);
+    const res = createMockRes();
+
+    await stocksProxyHandler(
+      {
+        method: "GET",
+        query: { group: "g", service: "s", endpoint: "compare?tickers=AAPL&token=secret", index: 0 },
+      },
+      res,
+    );
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body.error.url).toBe("https://api.adanos.org/news/stocks/v1/compare?tickers=AAPL&token=***");
+    expect(logger.error).toHaveBeenCalledWith("HTTP Error %d calling %s", 500, expect.any(String));
+  });
+
+  it("returns invalid data errors from widget validation", async () => {
+    getServiceWidget.mockResolvedValue({ type: "stocks", sentimentSource: "news_stocks" });
+    validateWidgetData.mockReturnValue(false);
+    const res = createMockRes();
+
+    await stocksProxyHandler(
+      { method: "GET", query: { group: "g", service: "s", endpoint: "compare?tickers=AAPL", index: 0 } },
+      res,
+    );
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body.error.message).toBe("Invalid data");
+  });
+
+  it("applies response maps when provided", async () => {
+    getServiceWidget.mockResolvedValue({ type: "stocks", sentimentSource: "news_stocks" });
+    httpProxy.mockResolvedValue([200, undefined, { ok: true }]);
+    const res = createMockRes();
+
+    await stocksProxyHandler(
+      { method: "GET", query: { group: "g", service: "s", endpoint: "compare?tickers=AAPL", index: 0 } },
+      res,
+      (data) => ({ ...data, mapped: true }),
+    );
+
+    expect(res.headers["Content-Type"]).toBeUndefined();
+    expect(res.body).toEqual({ ok: true, mapped: true });
   });
 });

--- a/src/widgets/stocks/proxy.test.js
+++ b/src/widgets/stocks/proxy.test.js
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import createMockRes from "test-utils/create-mock-res";
+
+const { getSettings, getServiceWidget, httpProxy, validateWidgetData, logger } = vi.hoisted(() => ({
+  getSettings: vi.fn(() => ({ providers: { adanos: "adanos-token", finnhub: "finnhub-token" } })),
+  getServiceWidget: vi.fn(),
+  httpProxy: vi.fn(),
+  validateWidgetData: vi.fn(() => true),
+  logger: { debug: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("utils/config/config", () => ({ getSettings }));
+vi.mock("utils/config/service-helpers", () => ({ default: getServiceWidget }));
+vi.mock("utils/proxy/http", () => ({ httpProxy }));
+vi.mock("utils/proxy/validate-widget-data", () => ({ default: validateWidgetData }));
+vi.mock("utils/logger", () => ({ default: () => logger }));
+
+import stocksProxyHandler from "./proxy";
+
+describe("widgets/stocks/proxy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getSettings.mockReturnValue({ providers: { adanos: "adanos-token", finnhub: "finnhub-token" } });
+    httpProxy.mockResolvedValue([200, "application/json", { ok: true }]);
+    validateWidgetData.mockReturnValue(true);
+  });
+
+  it("returns 400 when the endpoint is missing", async () => {
+    const res = createMockRes();
+
+    await stocksProxyHandler({ method: "GET", query: { group: "g", service: "s", index: 0 } }, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toContain("endpoint");
+    expect(getServiceWidget).not.toHaveBeenCalled();
+  });
+
+  it("proxies Finnhub quote requests with the configured Finnhub token", async () => {
+    getServiceWidget.mockResolvedValue({ type: "stocks", provider: "finnhub" });
+    const res = createMockRes();
+
+    await stocksProxyHandler(
+      { method: "GET", query: { group: "g", service: "s", endpoint: "v1/quote?symbol=AAPL", index: 0 } },
+      res,
+    );
+
+    const [url, params] = httpProxy.mock.calls[0];
+    expect(url.toString()).toBe("https://finnhub.io/api/v1/quote?symbol=AAPL");
+    expect(params.headers["X-Finnhub-Token"]).toBe("finnhub-token");
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("proxies Adanos sentiment requests with the configured Adanos token", async () => {
+    getServiceWidget.mockResolvedValue({ type: "stocks", sentimentSource: "news_stocks" });
+    const res = createMockRes();
+
+    await stocksProxyHandler(
+      { method: "GET", query: { group: "g", service: "s", endpoint: "compare?tickers=AAPL,NVDA&days=7", index: 0 } },
+      res,
+    );
+
+    const [url, params] = httpProxy.mock.calls[0];
+    expect(url.toString()).toBe("https://api.adanos.org/news/stocks/v1/compare?tickers=AAPL,NVDA&days=7");
+    expect(params.headers["X-API-Key"]).toBe("adanos-token");
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("returns 400 when the Adanos provider token is missing", async () => {
+    getSettings.mockReturnValue({ providers: { finnhub: "finnhub-token" } });
+    getServiceWidget.mockResolvedValue({ type: "stocks", sentimentSource: "reddit_stocks" });
+    const res = createMockRes();
+
+    await stocksProxyHandler(
+      { method: "GET", query: { group: "g", service: "s", endpoint: "compare?tickers=AAPL", index: 0 } },
+      res,
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toContain("API Key");
+    expect(httpProxy).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when the Adanos source is not supported", async () => {
+    getServiceWidget.mockResolvedValue({ type: "stocks", sentimentSource: "reddit_crypto" });
+    const res = createMockRes();
+
+    await stocksProxyHandler(
+      { method: "GET", query: { group: "g", service: "s", endpoint: "compare?tickers=BTC", index: 0 } },
+      res,
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toContain("source");
+    expect(httpProxy).not.toHaveBeenCalled();
+  });
+});

--- a/src/widgets/stocks/widget.js
+++ b/src/widgets/stocks/widget.js
@@ -1,8 +1,7 @@
-import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
+import stocksProxyHandler from "./proxy";
 
 const widget = {
-  api: `https://finnhub.io/api/{endpoint}`,
-  proxyHandler: credentialedProxyHandler,
+  proxyHandler: stocksProxyHandler,
 
   mappings: {
     quote: {
@@ -14,6 +13,11 @@ const widget = {
       // https://finnhub.io/docs/api/market-status
       endpoint: "v1/stock/market-status",
       params: ["exchange"],
+    },
+    sentiment: {
+      endpoint: "compare",
+      params: ["tickers"],
+      optionalParams: ["days"],
     },
   },
 };


### PR DESCRIPTION
## Proposed change

Adds an optional Adanos sentiment mode to the existing stocks service widget. The default behavior remains unchanged: Finnhub is still used for price quotes and US market status.

When `showSentiment: true` is configured, the widget fetches watchlist sentiment and buzz scores from Adanos in a single batch request. The Adanos API key is configured centrally through `providers.adanos`, similar to the existing `providers.finnhub` setup.

## Configuration

```yaml
providers:
  adanos: youradanosapikeyhere

services:
  - Finance:
      - Stocks:
          widget:
            type: stocks
            showSentiment: true
            sentimentSource: news_stocks
            sentimentDays: 7
            watchlist:
              - TSLA
              - NVDA
              - AAPL
```

Supported sentiment sources are `reddit_stocks`, `x_stocks`, `news_stocks`, and `polymarket_stocks`.

## Notes

- Sentiment mode is fully optional and does not affect existing Finnhub quote rendering.
- Sentiment watchlists are limited to 10 tickers to match the Adanos compare endpoint limit.
- `showUSMarketStatus` can still be used with sentiment mode if `providers.finnhub` is also configured.

## Tests

- `pnpm vitest run src/widgets/stocks/component.test.jsx src/widgets/stocks/proxy.test.js src/widgets/stocks/widget.test.js src/utils/config/service-helpers.test.js src/utils/proxy/handlers/credentialed.test.js`
- `pnpm lint`
- `pnpm test`
