### PR TITLE
Enhancement: add additional fields to Tailscale Widget

### DIFF
--- a/docs/widgets/services/tailscale.md
+++ b/docs/widgets/services/tailscale.md
@@ -9,7 +9,7 @@ You will need to generate an API access token from the [keys page](https://login
 
 To find your device ID, go to the [machine overview page](https://login.tailscale.com/admin/machines) and select your machine. In the "Machine Details" section, copy your `ID`. It will end with `CNTRL`.
 
-Allowed fields: `["address", "last_seen", "expires"]`.
+Allowed fields: `[ "address", "last_seen", "expires", "user", "hostname", "name", "client_version", "os", "created", "authorized", "is_external", "update_available", "tags" ]`.
 
 ```yaml
 widget:

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -344,6 +344,16 @@
         "address": "Address",
         "expires": "Expires",
         "never": "Never",
+        "user": "User",
+        "hostname": "Hostname",
+        "name": "Name",
+        "client_version": "Client Version",
+        "os": "OS",
+        "created": "Created",
+        "authorized": "Authorized",
+        "is_external": "Is External",
+        "update_available": "Update Available",
+        "tags": "Tags",
         "last_seen": "Last Seen",
         "now": "Now",
         "years": "{{number}}y",
@@ -352,7 +362,9 @@
         "hours": "{{number}}h",
         "minutes": "{{number}}m",
         "seconds": "{{number}}s",
-        "ago": "{{value}} Ago"
+        "ago": "{{value}} Ago",
+        "true": "Yes",
+        "false": "No"
     },
     "technitium": {
         "totalQueries": "Queries",

--- a/src/widgets/tailscale/component.jsx
+++ b/src/widgets/tailscale/component.jsx
@@ -28,8 +28,7 @@ export default function Component({ service }) {
   const MAX_ALLOWED_FIELDS = 4;
   if (widget.fields?.length == 0 || !widget.fields) {
     widget.fields = ["address", "last_seen", "expires"];
-  }
-  else if(widget.fields?.length > MAX_ALLOWED_FIELDS){
+  } else if (widget.fields?.length > MAX_ALLOWED_FIELDS) {
     widget.fields = widget.fields.slice(0, MAX_ALLOWED_FIELDS);
   }
 
@@ -47,7 +46,7 @@ export default function Component({ service }) {
     authorized,
     isExternal,
     updateAvailable,
-    tags
+    tags,
   } = tailscaleData;
 
   const now = new Date();
@@ -82,26 +81,26 @@ export default function Component({ service }) {
 
   const getBooleanAsString = (value) => {
     return value ? t("tailscale.true") : t("tailscale.false");
-  }
+  };
 
   const clientVersionString = clientVersion ? clientVersion.toString() : "-";
   const tagsString = tags && Array.isArray(tags) ? tags.join(", ") : "-";
 
   return (
-        <Container service={service}>
-          <Block label="tailscale.address" value={address} />
-          <Block label="tailscale.last_seen" value={getLastSeen()} />
-          <Block label="tailscale.expires" value={getExpiry()} />
-          <Block label="tailscale.user" value={user} />
-          <Block label="tailscale.hostname" value={hostname} />
-          <Block label="tailscale.name" value={name} />
-          <Block label="tailscale.client_version" value={clientVersionString} />
-          <Block label="tailscale.os" value={os} />
-          <Block label="tailscale.created" value={created} />
-          <Block label="tailscale.authorized" value={getBooleanAsString(authorized)} />
-          <Block label="tailscale.is_external" value={getBooleanAsString(isExternal)} />
-          <Block label="tailscale.update_available" value={getBooleanAsString(updateAvailable)} />
-          <Block label="tailscale.tags" value={tagsString} />
-        </Container>
+    <Container service={service}>
+      <Block label="tailscale.address" value={address} />
+      <Block label="tailscale.last_seen" value={getLastSeen()} />
+      <Block label="tailscale.expires" value={getExpiry()} />
+      <Block label="tailscale.user" value={user} />
+      <Block label="tailscale.hostname" value={hostname} />
+      <Block label="tailscale.name" value={name} />
+      <Block label="tailscale.client_version" value={clientVersionString} />
+      <Block label="tailscale.os" value={os} />
+      <Block label="tailscale.created" value={created} />
+      <Block label="tailscale.authorized" value={getBooleanAsString(authorized)} />
+      <Block label="tailscale.is_external" value={getBooleanAsString(isExternal)} />
+      <Block label="tailscale.update_available" value={getBooleanAsString(updateAvailable)} />
+      <Block label="tailscale.tags" value={tagsString} />
+    </Container>
   );
 }

--- a/src/widgets/tailscale/component.jsx
+++ b/src/widgets/tailscale/component.jsx
@@ -9,13 +9,13 @@ export default function Component({ service }) {
 
   const { widget } = service;
 
-  const { data: statsData, error: statsError } = useWidgetAPI(widget, "device");
+  const { data: tailscaleData, error: tailscaleError } = useWidgetAPI(widget, "device");
 
-  if (statsError || statsData?.message) {
-    return <Container service={service} error={statsError ?? statsData} />;
+  if (tailscaleError || tailscaleData?.message) {
+    return <Container service={service} error={tailscaleError ?? tailscaleData} />;
   }
 
-  if (!statsData) {
+  if (!tailscaleData) {
     return (
       <Container service={service}>
         <Block label="tailscale.address" />
@@ -25,12 +25,30 @@ export default function Component({ service }) {
     );
   }
 
+  const MAX_ALLOWED_FIELDS = 4;
+  if (widget.fields?.length == 0 || !widget.fields) {
+    widget.fields = ["address", "last_seen", "expires"];
+  }
+  else if(widget.fields?.length > MAX_ALLOWED_FIELDS){
+    widget.fields = widget.fields.slice(0, MAX_ALLOWED_FIELDS);
+  }
+
   const {
     addresses: [address],
     keyExpiryDisabled,
     lastSeen,
     expires,
-  } = statsData;
+    user,
+    hostname,
+    name,
+    clientVersion,
+    os,
+    created,
+    authorized,
+    isExternal,
+    updateAvailable,
+    tags
+  } = tailscaleData;
 
   const now = new Date();
   const compareDifferenceInTwoDates = (priorDate, futureDate) => {
@@ -62,11 +80,28 @@ export default function Component({ service }) {
     return compareDifferenceInTwoDates(now, date);
   };
 
+  const getBooleanAsString = (value) => {
+    return value ? t("tailscale.true") : t("tailscale.false");
+  }
+
+  const clientVersionString = clientVersion ? clientVersion.toString() : "-";
+  const tagsString = tags && Array.isArray(tags) ? tags.join(", ") : "-";
+
   return (
-    <Container service={service}>
-      <Block label="tailscale.address" value={address} />
-      <Block label="tailscale.last_seen" value={getLastSeen()} />
-      <Block label="tailscale.expires" value={getExpiry()} />
-    </Container>
+        <Container service={service}>
+          <Block label="tailscale.address" value={address} />
+          <Block label="tailscale.last_seen" value={getLastSeen()} />
+          <Block label="tailscale.expires" value={getExpiry()} />
+          <Block label="tailscale.user" value={user} />
+          <Block label="tailscale.hostname" value={hostname} />
+          <Block label="tailscale.name" value={name} />
+          <Block label="tailscale.client_version" value={clientVersionString} />
+          <Block label="tailscale.os" value={os} />
+          <Block label="tailscale.created" value={created} />
+          <Block label="tailscale.authorized" value={getBooleanAsString(authorized)} />
+          <Block label="tailscale.is_external" value={getBooleanAsString(isExternal)} />
+          <Block label="tailscale.update_available" value={getBooleanAsString(updateAvailable)} />
+          <Block label="tailscale.tags" value={tagsString} />
+        </Container>
   );
 }

--- a/src/widgets/tailscale/component.test.jsx
+++ b/src/widgets/tailscale/component.test.jsx
@@ -22,6 +22,23 @@ describe("widgets/tailscale/component", () => {
     vi.useRealTimers();
   });
 
+  const fullData = {
+    addresses: ["127.0.0.1"],
+    keyExpiryDisabled: false,
+    expires: "2020-06-01T00:00:00Z",
+    lastSeen: "2019-12-31T23:55:00Z",
+    user: "fin@example.com",
+    hostname: "localhost",
+    name: "localhost.tail1234.ts.net",
+    clientVersion: "1.1.0",
+    os: "linux",
+    created: "2019-06-01T00:00:00Z",
+    authorized: true,
+    isExternal: false,
+    updateAvailable: true,
+    tags: ["server", "prod"],
+  };
+
   it("renders placeholders while loading", () => {
     useWidgetAPI.mockReturnValue({ data: undefined, error: undefined });
 
@@ -35,14 +52,103 @@ describe("widgets/tailscale/component", () => {
     expect(screen.getByText("tailscale.expires")).toBeInTheDocument();
   });
 
-  it("renders address and expiry/last-seen strings when loaded", () => {
+  describe("fields group: address, last_seen, expires, user", () => {
+    it("renders only the specified 4 fields", () => {
+      useWidgetAPI.mockReturnValue({ data: fullData, error: undefined });
+
+      const { container } = renderWithProviders(
+        <Component service={{ widget: { type: "tailscale", fields: ["address", "last_seen", "expires", "user"] } }} />,
+        { settings: { hideErrors: false } },
+      );
+
+      expect(container.querySelectorAll(".service-block")).toHaveLength(4);
+      expectBlockValue(container, "tailscale.address", "127.0.0.1");
+      expectBlockValue(container, "tailscale.last_seen", "tailscale.ago");
+      expectBlockValue(container, "tailscale.expires", "tailscale.weeks");
+      expectBlockValue(container, "tailscale.user", "fin@example.com");
+    });
+  });
+
+  describe("fields group: hostname, name, client_version, os", () => {
+    it("renders only the specified 4 fields", () => {
+      useWidgetAPI.mockReturnValue({ data: fullData, error: undefined });
+
+      const { container } = renderWithProviders(
+        <Component service={{ widget: { type: "tailscale", fields: ["hostname", "name", "client_version", "os"] } }} />,
+        { settings: { hideErrors: false } },
+      );
+
+      expect(container.querySelectorAll(".service-block")).toHaveLength(4);
+      expectBlockValue(container, "tailscale.hostname", "localhost");
+      expectBlockValue(container, "tailscale.name", "localhost.tail1234.ts.net");
+      expectBlockValue(container, "tailscale.client_version", "1.1.0");
+      expectBlockValue(container, "tailscale.os", "linux");
+    });
+  });
+
+  describe("fields group: created, authorized, is_external, update_available", () => {
+    it("renders only the specified 4 fields", () => {
+      useWidgetAPI.mockReturnValue({ data: fullData, error: undefined });
+
+      const { container } = renderWithProviders(
+        <Component service={{ widget: { type: "tailscale", fields: ["created", "authorized", "is_external", "update_available"] } }} />,
+        { settings: { hideErrors: false } },
+      );
+
+      expect(container.querySelectorAll(".service-block")).toHaveLength(4);
+      expectBlockValue(container, "tailscale.created", "2019-06-01T00:00:00Z");
+      expectBlockValue(container, "tailscale.authorized", "tailscale.true");
+      expectBlockValue(container, "tailscale.is_external", "tailscale.false");
+      expectBlockValue(container, "tailscale.update_available", "tailscale.true");
+    });
+  });
+
+  describe("fields group: tags with defaults", () => {
+    it("renders tags alongside default fields", () => {
+      useWidgetAPI.mockReturnValue({ data: fullData, error: undefined });
+
+      const { container } = renderWithProviders(
+        <Component service={{ widget: { type: "tailscale", fields: ["address", "last_seen", "expires", "tags"] } }} />,
+        { settings: { hideErrors: false } },
+      );
+
+      expect(container.querySelectorAll(".service-block")).toHaveLength(4);
+      expectBlockValue(container, "tailscale.address", "127.0.0.1");
+      expectBlockValue(container, "tailscale.tags", "server, prod");
+    });
+  });
+
+  describe("fields truncation", () => {
+    it("truncates to 4 fields when more than 4 are specified", () => {
+      useWidgetAPI.mockReturnValue({ data: fullData, error: undefined });
+
+      const { container } = renderWithProviders(
+        <Component service={{ widget: { type: "tailscale", fields: ["address", "last_seen", "expires", "user", "hostname"] } }} />,
+        { settings: { hideErrors: false } },
+      );
+
+      expect(container.querySelectorAll(".service-block")).toHaveLength(4);
+      expect(findServiceBlockByLabel(container, "tailscale.hostname")).toBeFalsy();
+    });
+
+    it("defaults to address, last_seen, expires when fields is empty", () => {
+      useWidgetAPI.mockReturnValue({ data: fullData, error: undefined });
+
+      const { container } = renderWithProviders(
+        <Component service={{ widget: { type: "tailscale", fields: [] } }} />,
+        { settings: { hideErrors: false } },
+      );
+
+      expect(container.querySelectorAll(".service-block")).toHaveLength(3);
+      expectBlockValue(container, "tailscale.address", "127.0.0.1");
+      expectBlockValue(container, "tailscale.last_seen", "tailscale.ago");
+      expectBlockValue(container, "tailscale.expires", "tailscale.weeks");
+    });
+  });
+
+  it ("renders never for expires if key expiry is disabled", () => {
     useWidgetAPI.mockReturnValue({
-      data: {
-        addresses: ["100.64.0.1"],
-        keyExpiryDisabled: true,
-        lastSeen: "2019-12-31T23:00:00Z",
-        expires: "2021-01-01T00:00:00Z",
-      },
+      data: { ...fullData, keyExpiryDisabled: true },
       error: undefined,
     });
 
@@ -50,8 +156,17 @@ describe("widgets/tailscale/component", () => {
       settings: { hideErrors: false },
     });
 
-    expectBlockValue(container, "tailscale.address", "100.64.0.1");
-    expect(findServiceBlockByLabel(container, "tailscale.last_seen")?.textContent).toContain("tailscale.ago");
     expectBlockValue(container, "tailscale.expires", "tailscale.never");
+  });
+
+  it ("renders error message when API returns an error", () => {
+    useWidgetAPI.mockReturnValue({ data: undefined, error: { message: "API error" } });
+
+    const { container } = renderWithProviders(<Component service={{ widget: { type: "tailscale" } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expect(container.querySelectorAll(".service-block")).toHaveLength(0);
+    expect(container.textContent).toContain("API error");
   });
 });

--- a/src/widgets/tailscale/component.test.jsx
+++ b/src/widgets/tailscale/component.test.jsx
@@ -91,7 +91,11 @@ describe("widgets/tailscale/component", () => {
       useWidgetAPI.mockReturnValue({ data: fullData, error: undefined });
 
       const { container } = renderWithProviders(
-        <Component service={{ widget: { type: "tailscale", fields: ["created", "authorized", "is_external", "update_available"] } }} />,
+        <Component
+          service={{
+            widget: { type: "tailscale", fields: ["created", "authorized", "is_external", "update_available"] },
+          }}
+        />,
         { settings: { hideErrors: false } },
       );
 
@@ -123,7 +127,9 @@ describe("widgets/tailscale/component", () => {
       useWidgetAPI.mockReturnValue({ data: fullData, error: undefined });
 
       const { container } = renderWithProviders(
-        <Component service={{ widget: { type: "tailscale", fields: ["address", "last_seen", "expires", "user", "hostname"] } }} />,
+        <Component
+          service={{ widget: { type: "tailscale", fields: ["address", "last_seen", "expires", "user", "hostname"] } }}
+        />,
         { settings: { hideErrors: false } },
       );
 
@@ -134,10 +140,9 @@ describe("widgets/tailscale/component", () => {
     it("defaults to address, last_seen, expires when fields is empty", () => {
       useWidgetAPI.mockReturnValue({ data: fullData, error: undefined });
 
-      const { container } = renderWithProviders(
-        <Component service={{ widget: { type: "tailscale", fields: [] } }} />,
-        { settings: { hideErrors: false } },
-      );
+      const { container } = renderWithProviders(<Component service={{ widget: { type: "tailscale", fields: [] } }} />, {
+        settings: { hideErrors: false },
+      });
 
       expect(container.querySelectorAll(".service-block")).toHaveLength(3);
       expectBlockValue(container, "tailscale.address", "127.0.0.1");
@@ -146,7 +151,7 @@ describe("widgets/tailscale/component", () => {
     });
   });
 
-  it ("renders never for expires if key expiry is disabled", () => {
+  it("renders never for expires if key expiry is disabled", () => {
     useWidgetAPI.mockReturnValue({
       data: { ...fullData, keyExpiryDisabled: true },
       error: undefined,
@@ -159,7 +164,7 @@ describe("widgets/tailscale/component", () => {
     expectBlockValue(container, "tailscale.expires", "tailscale.never");
   });
 
-  it ("renders error message when API returns an error", () => {
+  it("renders error message when API returns an error", () => {
     useWidgetAPI.mockReturnValue({ data: undefined, error: { message: "API error" } });
 
     const { container } = renderWithProviders(<Component service={{ widget: { type: "tailscale" } }} />, {


### PR DESCRIPTION
<!--
==== STOP ====================
======== STOP ================
============ STOP ============
================ STOP ========
==================== STOP ====

⚠️ Before opening this pull request please review the guidelines in the checklist below.

If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.
-->

## Proposed change

Updating the Tailscale widget per [this discussion](https://github.com/gethomepage/homepage/discussions/5778) to include additional fields returned by the TS API. Additional fields are now supported but the default fields remain unchanged.

I used AI to write the initial pass at variable-field and field-count test cases, edited them myself and then wrote the other tests myself in the same style. I hand coded the widget changes.

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] In the description above I have disclosed the use of AI tools in the coding of this PR.
