### PR TITLE
Enhancement: support custom labels for cpu temp sensors

### DIFF
--- a/docs/widgets/info/glances.md
+++ b/docs/widgets/info/glances.md
@@ -16,6 +16,7 @@ The Glances widget allows you to monitor the resources (CPU, memory, storage, te
     cpu: true # optional, enabled by default, disable by setting to false
     mem: true # optional, enabled by default, disable by setting to false
     cputemp: true # disabled by default
+    cpuSensorLabel: Package id # optional additional cputemp sensor label prefix
     unit: imperial # optional for temp, default is metric
     uptime: true # disabled by default
     disk: / # disabled by default, use mount point of disk(s) in glances. Can also be a list (see below)
@@ -23,6 +24,8 @@ The Glances widget allows you to monitor the resources (CPU, memory, storage, te
     expanded: true # show the expanded view
     label: MyMachine # optional
 ```
+
+The built-in `cputemp` sensor matching already checks common prefixes such as `cpu_thermal`, `Core`, `Tctl`, and `Temperature`. Use `cpuSensorLabel` to add your own Glances sensor label prefix when your system reports CPU temperatures under a different name.
 
 Multiple disks can be specified as:
 

--- a/src/components/widgets/glances/glances.jsx
+++ b/src/components/widgets/glances/glances.jsx
@@ -11,10 +11,14 @@ import Resource from "../widget/resource";
 import Resources from "../widget/resources";
 import WidgetLabel from "../widget/widget_label";
 
-const cpuSensorLabels = ["cpu_thermal", "Core", "Tctl", "Temperature"];
+const defaultCpuSensorLabels = ["cpu_thermal", "Core", "Tctl", "Temperature"];
 
 function convertToFahrenheit(t) {
   return (t * 9) / 5 + 32;
+}
+
+function getCpuSensorLabels(options) {
+  return [...defaultCpuSensorLabels, options.cpuSensorLabel].filter(Boolean);
 }
 
 export default function Widget({ options }) {
@@ -56,6 +60,7 @@ export default function Widget({ options }) {
   const unit = options.units === "imperial" ? "fahrenheit" : "celsius";
   let mainTemp = 0;
   let maxTemp = 80;
+  const cpuSensorLabels = getCpuSensorLabels(options);
   const cpuSensors = data.sensors?.filter(
     (s) => cpuSensorLabels.some((label) => s.label.startsWith(label)) && s.type === "temperature_core",
   );

--- a/src/components/widgets/glances/glances.test.jsx
+++ b/src/components/widgets/glances/glances.test.jsx
@@ -120,6 +120,26 @@ describe("components/widgets/glances", () => {
     expect(screen.getByRole("link")).toHaveClass("expanded");
   });
 
+  it("renders temperature for custom cpu sensor labels", () => {
+    useSWR.mockReturnValue({
+      data: {
+        cpu: { total: 1 },
+        load: { min15: 1 },
+        mem: { available: 1, total: 1, percent: 1 },
+        fs: [],
+        sensors: [{ label: "Package id 0", type: "temperature_core", value: 42, warning: 90 }],
+      },
+      error: undefined,
+    });
+
+    renderWithProviders(<Glances options={{ cputemp: true, cpuSensorLabel: "Package id", url: "http://glances" }} />, {
+      settings: { target: "_self" },
+    });
+
+    expect(screen.getByText("42")).toBeInTheDocument();
+    expect(screen.getByText("glances.temp")).toBeInTheDocument();
+  });
+
   it("renders disk resources for an array of mount points and filters missing mounts", () => {
     useSWR.mockReturnValue({
       data: {


### PR DESCRIPTION
<!--
==== STOP ====================
======== STOP ================
============ STOP ============
================ STOP ========
==================== STOP ====

⚠️ Before opening this pull request please review the guidelines in the checklist below.

If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.
-->

## Proposed change

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

Supersedes #6594

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [ ] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] In the description above I have disclosed the use of AI tools in the coding of this PR.
