### PR TITLE
Enhancement: add Navidrome library stats blocks

### DIFF
--- a/docs/widgets/services/navidrome.md
+++ b/docs/widgets/services/navidrome.md
@@ -5,15 +5,20 @@ description: Navidrome Widget Configuration
 
 Learn more about [Navidrome](https://github.com/navidrome/navidrome).
 
-For detailed information about how to generate the token see http://www.subsonic.org/pages/api.jsp.
+For detailed information about Subsonic token authentication see http://www.subsonic.org/pages/api.jsp.
 
-Allowed fields: no configurable fields for this widget.
+As of this version the widget supports library statistic blocks for `songs`, `albums`, and `artists`. These blocks are disabled by default and can be enabled with the `enableBlocks` option. "Now Playing" remains enabled by default and can be disabled with the `enableNowPlaying` option.
+
+If you enable blocks, `password` is required because Navidrome's library API uses JWT-based authentication. If you provide `password`, Homepage can also use it for "Now Playing", so `token` and `salt` become optional.
 
 ```yaml
 widget:
   type: navidrome
   url: http://navidrome.host.or.ip:port
   user: username
-  token: token #md5(password + salt)
-  salt: randomsalt
+  password: password # optional, required for enableBlocks
+  token: token # optional, md5(password + salt)
+  salt: randomsalt # optional
+  enableBlocks: true # optional, defaults to false
+  enableNowPlaying: false # optional, defaults to true
 ```

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -397,8 +397,11 @@
         "unknown": "Unknown"
     },
     "navidrome": {
+        "albums": "Albums",
+        "artists": "Artists",
         "nothing_streaming": "No Active Streams",
-        "please_wait": "Please Wait"
+        "please_wait": "Please Wait",
+        "songs": "Songs"
     },
     "npm": {
         "enabled": "Enabled",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -399,6 +399,7 @@
     "navidrome": {
         "albums": "Albums",
         "artists": "Artists",
+        "enable_one": "Enable now playing or library blocks for the Navidrome widget.",
         "nothing_streaming": "No Active Streams",
         "please_wait": "Please Wait",
         "songs": "Songs"

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -309,9 +309,11 @@ export function cleanServiceGroups(groups) {
           // dockhand
           environment,
 
-          // emby, jellyfin
+          // emby, jellyfin, navidrome
           enableBlocks,
           enableNowPlaying,
+
+          // emby, jellyfin
           enableMediaControl,
 
           // emby, jellyfin, tautulli, tracearr
@@ -538,10 +540,12 @@ export function cleanServiceGroups(groups) {
         if (["opnsense", "pfsense"].includes(type)) {
           if (wan) widget.wan = wan;
         }
-        if (["emby", "jellyfin"].includes(type)) {
-          if (enableMediaControl !== undefined) widget.enableMediaControl = !!JSON.parse(enableMediaControl);
+        if (["emby", "jellyfin", "navidrome"].includes(type)) {
           if (enableBlocks !== undefined) widget.enableBlocks = JSON.parse(enableBlocks);
           if (enableNowPlaying !== undefined) widget.enableNowPlaying = JSON.parse(enableNowPlaying);
+        }
+        if (["emby", "jellyfin"].includes(type)) {
+          if (enableMediaControl !== undefined) widget.enableMediaControl = !!JSON.parse(enableMediaControl);
         }
         if (["emby", "jellyfin", "tautulli", "tracearr"].includes(type)) {
           if (expandOneStreamToTwoRows !== undefined)

--- a/src/utils/config/service-helpers.test.js
+++ b/src/utils/config/service-helpers.test.js
@@ -286,6 +286,7 @@ describe("utils/config/service-helpers", () => {
               { type: "qbittorrent", enableLeechProgress: "true", enableLeechSize: "true" },
               { type: "opnsense", wan: "wan1" },
               { type: "emby", enableBlocks: "true", enableNowPlaying: "false", enableMediaControl: "true" },
+              { type: "navidrome", enableBlocks: "true", enableNowPlaying: "false" },
               { type: "tautulli", expandOneStreamToTwoRows: "true", showEpisodeNumber: "true", enableUser: "true" },
               { type: "radarr", enableQueue: "true" },
               { type: "truenas", enablePools: "true", nasType: "scale" },
@@ -354,6 +355,9 @@ describe("utils/config/service-helpers", () => {
       expect.objectContaining({ namespace: "default", app: "app", podSelector: "app=test" }),
     );
     expect(widgets.find((w) => w.type === "qnap")).toEqual(expect.objectContaining({ volume: "vol1" }));
+    expect(widgets.find((w) => w.type === "navidrome")).toEqual(
+      expect.objectContaining({ enableBlocks: true, enableNowPlaying: false }),
+    );
     expect(widgets.find((w) => w.type === "speedtest")).toEqual(
       expect.objectContaining({ bitratePrecision: 3, version: 1 }),
     );

--- a/src/widgets/navidrome/component.jsx
+++ b/src/widgets/navidrome/component.jsx
@@ -1,3 +1,4 @@
+import Block from "components/services/widget/block";
 import Container from "components/services/widget/container";
 import { useTranslation } from "next-i18next";
 
@@ -19,34 +20,84 @@ function SinglePlayingEntry({ entry }) {
   );
 }
 
+function CountBlocks({ service, libraryData }) {
+  const { t } = useTranslation();
+
+  if (!libraryData) {
+    return (
+      <Container service={service}>
+        <Block label="navidrome.songs" />
+        <Block label="navidrome.albums" />
+        <Block label="navidrome.artists" />
+      </Container>
+    );
+  }
+
+  return (
+    <Container service={service}>
+      <Block label="navidrome.songs" value={t("common.number", { value: libraryData.totalSongs })} />
+      <Block label="navidrome.albums" value={t("common.number", { value: libraryData.totalAlbums })} />
+      <Block label="navidrome.artists" value={t("common.number", { value: libraryData.totalArtists })} />
+    </Container>
+  );
+}
+
 export default function Component({ service }) {
   const { t } = useTranslation();
 
   const { widget } = service;
+  const enableBlocks = service.widget?.enableBlocks;
+  const enableNowPlaying = service.widget?.enableNowPlaying ?? true;
 
-  const { data: navidromeData, error: navidromeError } = useWidgetAPI(widget, "getNowPlaying");
+  const { data: navidromeData, error: navidromeError } = useWidgetAPI(widget, enableNowPlaying ? "getNowPlaying" : "", {
+    refreshInterval: enableNowPlaying ? 5000 : undefined,
+  });
+  const { data: libraryData, error: libraryError } = useWidgetAPI(widget, enableBlocks ? "Library" : "", {
+    refreshInterval: enableBlocks ? 60000 : undefined,
+  });
 
-  if (navidromeError || navidromeData?.["subsonic-response"]?.error) {
-    return <Container service={service} error={navidromeError ?? navidromeData?.["subsonic-response"]?.error} />;
+  if (navidromeError || libraryError || navidromeData?.["subsonic-response"]?.error) {
+    return (
+      <Container
+        service={service}
+        error={navidromeError ?? libraryError ?? navidromeData?.["subsonic-response"]?.error}
+      />
+    );
   }
 
-  if (!navidromeData) {
-    return <SinglePlayingEntry entry={{ title: t("navidrome.please_wait") }} />;
+  if ((enableNowPlaying && !navidromeData) || (enableBlocks && !libraryData)) {
+    return (
+      <>
+        {enableBlocks && <CountBlocks service={service} libraryData={null} />}
+        {enableNowPlaying && <SinglePlayingEntry entry={{ title: t("navidrome.please_wait") }} />}
+      </>
+    );
+  }
+
+  if (!enableNowPlaying && enableBlocks) {
+    return <CountBlocks service={service} libraryData={libraryData} />;
   }
 
   const { nowPlaying } = navidromeData["subsonic-response"];
-  if (!nowPlaying.entry) {
-    // nothing playing
-    return <SinglePlayingEntry entry={{ title: t("navidrome.nothing_streaming") }} />;
+  if (!nowPlaying?.entry) {
+    return (
+      <>
+        {enableBlocks && <CountBlocks service={service} libraryData={libraryData} />}
+        <SinglePlayingEntry entry={{ title: t("navidrome.nothing_streaming") }} />
+      </>
+    );
   }
 
   const nowPlayingEntries = Object.values(nowPlaying.entry);
 
   return (
-    <div className="flex flex-col pb-1 mx-1">
-      {nowPlayingEntries.map((entry) => (
-        <SinglePlayingEntry key={entry.id} entry={entry} />
-      ))}
-    </div>
+    <>
+      {enableBlocks && <CountBlocks service={service} libraryData={libraryData} />}
+      <div className="flex flex-col pb-1 mx-1">
+        {nowPlayingEntries.map((entry) => (
+          <SinglePlayingEntry key={entry.id} entry={entry} />
+        ))}
+      </div>
+    </>
   );
 }

--- a/src/widgets/navidrome/component.jsx
+++ b/src/widgets/navidrome/component.jsx
@@ -46,7 +46,7 @@ export default function Component({ service }) {
   const { t } = useTranslation();
 
   const { widget } = service;
-  const enableBlocks = service.widget?.enableBlocks;
+  const enableBlocks = service.widget?.enableBlocks ?? false;
   const enableNowPlaying = service.widget?.enableNowPlaying ?? true;
 
   const { data: navidromeData, error: navidromeError } = useWidgetAPI(widget, enableNowPlaying ? "getNowPlaying" : "", {
@@ -55,6 +55,10 @@ export default function Component({ service }) {
   const { data: libraryData, error: libraryError } = useWidgetAPI(widget, enableBlocks ? "Library" : "", {
     refreshInterval: enableBlocks ? 60000 : undefined,
   });
+
+  if (!enableNowPlaying && !enableBlocks) {
+    return <Container service={service} error={t("navidrome.enable_one")} />;
+  }
 
   if (navidromeError || libraryError || navidromeData?.["subsonic-response"]?.error) {
     return (

--- a/src/widgets/navidrome/component.test.jsx
+++ b/src/widgets/navidrome/component.test.jsx
@@ -47,6 +47,17 @@ describe("widgets/navidrome/component", () => {
     expect(screen.getByText("nope")).toBeInTheDocument();
   });
 
+  it("renders an error when both now playing and library blocks are disabled", () => {
+    useWidgetAPI.mockReturnValue({ data: undefined, error: undefined });
+
+    renderWithProviders(
+      <Component service={{ widget: { type: "navidrome", enableBlocks: false, enableNowPlaying: false } }} />,
+      { settings: { hideErrors: false } },
+    );
+
+    expect(screen.getByText("navidrome.enable_one")).toBeInTheDocument();
+  });
+
   it("renders now playing entries when present", () => {
     useWidgetAPI.mockReturnValue({
       data: {
@@ -66,13 +77,36 @@ describe("widgets/navidrome/component", () => {
     expect(screen.getByText("Artist - Song — Album (user)")).toBeInTheDocument();
   });
 
-  it("renders library totals when enableBlocks is true and now playing is disabled", () => {
+  it("renders a no active streams row when nothing is playing", () => {
     useWidgetAPI
-      .mockReturnValueOnce({ data: undefined, error: undefined })
+      .mockReturnValueOnce({
+        data: {
+          "subsonic-response": {
+            nowPlaying: {},
+          },
+        },
+        error: undefined,
+      })
       .mockReturnValueOnce({
         data: { totalSongs: 461, totalAlbums: 411, totalArtists: 304 },
         error: undefined,
       });
+
+    renderWithProviders(<Component service={{ widget: { type: "navidrome", enableBlocks: true } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expect(screen.getByText("navidrome.nothing_streaming")).toBeInTheDocument();
+    expect(screen.getByText("461")).toBeInTheDocument();
+    expect(screen.getByText("411")).toBeInTheDocument();
+    expect(screen.getByText("304")).toBeInTheDocument();
+  });
+
+  it("renders library totals when enableBlocks is true and now playing is disabled", () => {
+    useWidgetAPI.mockReturnValueOnce({ data: undefined, error: undefined }).mockReturnValueOnce({
+      data: { totalSongs: 461, totalAlbums: 411, totalArtists: 304 },
+      error: undefined,
+    });
 
     renderWithProviders(
       <Component service={{ widget: { type: "navidrome", enableBlocks: true, enableNowPlaying: false } }} />,

--- a/src/widgets/navidrome/component.test.jsx
+++ b/src/widgets/navidrome/component.test.jsx
@@ -23,6 +23,21 @@ describe("widgets/navidrome/component", () => {
     expect(screen.getByText("navidrome.please_wait")).toBeInTheDocument();
   });
 
+  it("renders library block placeholders while loading when enableBlocks is true", () => {
+    useWidgetAPI
+      .mockReturnValueOnce({ data: undefined, error: undefined })
+      .mockReturnValueOnce({ data: undefined, error: undefined });
+
+    renderWithProviders(<Component service={{ widget: { type: "navidrome", enableBlocks: true } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expect(screen.getByText("navidrome.songs")).toBeInTheDocument();
+    expect(screen.getByText("navidrome.albums")).toBeInTheDocument();
+    expect(screen.getByText("navidrome.artists")).toBeInTheDocument();
+    expect(screen.getAllByText("-").length).toBeGreaterThan(0);
+  });
+
   it("renders an error container when the API errors", () => {
     useWidgetAPI.mockReturnValue({ data: undefined, error: { message: "nope" } });
 
@@ -49,5 +64,23 @@ describe("widgets/navidrome/component", () => {
     renderWithProviders(<Component service={{ widget: { type: "navidrome" } }} />, { settings: { hideErrors: false } });
 
     expect(screen.getByText("Artist - Song — Album (user)")).toBeInTheDocument();
+  });
+
+  it("renders library totals when enableBlocks is true and now playing is disabled", () => {
+    useWidgetAPI
+      .mockReturnValueOnce({ data: undefined, error: undefined })
+      .mockReturnValueOnce({
+        data: { totalSongs: 461, totalAlbums: 411, totalArtists: 304 },
+        error: undefined,
+      });
+
+    renderWithProviders(
+      <Component service={{ widget: { type: "navidrome", enableBlocks: true, enableNowPlaying: false } }} />,
+      { settings: { hideErrors: false } },
+    );
+
+    expect(screen.getByText("461")).toBeInTheDocument();
+    expect(screen.getByText("411")).toBeInTheDocument();
+    expect(screen.getByText("304")).toBeInTheDocument();
   });
 });

--- a/src/widgets/navidrome/proxy.js
+++ b/src/widgets/navidrome/proxy.js
@@ -1,0 +1,251 @@
+import { createHash, randomBytes } from "node:crypto";
+
+import cache from "memory-cache";
+
+import getServiceWidget from "utils/config/service-helpers";
+import createLogger from "utils/logger";
+import { sanitizeErrorURL } from "utils/proxy/api-helpers";
+import { httpProxy } from "utils/proxy/http";
+import validateWidgetData from "utils/proxy/validate-widget-data";
+
+const proxyName = "navidromeProxyHandler";
+const sessionCacheKey = `${proxyName}__session`;
+const logger = createLogger(proxyName);
+
+function getWidgetUser(widget) {
+  return widget.user?.toString() ?? widget.username?.toString() ?? "";
+}
+
+function getCacheKey(group, service, index) {
+  return `${sessionCacheKey}.${group}.${service}.${index ?? "0"}`;
+}
+
+function parseResponseData(data) {
+  if (!Buffer.isBuffer(data)) {
+    return data;
+  }
+
+  const text = data.toString();
+  try {
+    return JSON.parse(text);
+  } catch (_error) {
+    return text;
+  }
+}
+
+function createErrorResponse(message, status = 400) {
+  return [status, "application/json", { error: { message } }];
+}
+
+function getLibraryHeaders(sessionToken) {
+  return {
+    Accept: "application/json",
+    "X-ND-Authorization": `Bearer ${sessionToken}`,
+  };
+}
+
+function getTokenTtl(sessionToken) {
+  try {
+    const payloadSegment = sessionToken.split(".")[1];
+    if (!payloadSegment) {
+      return 55 * 60 * 1000;
+    }
+
+    const base64 = payloadSegment.replace(/-/g, "+").replace(/_/g, "/");
+    const normalized = `${base64}${"=".repeat((4 - (base64.length % 4)) % 4)}`;
+    const payload = JSON.parse(Buffer.from(normalized, "base64").toString());
+
+    if (typeof payload.exp !== "number") {
+      return 55 * 60 * 1000;
+    }
+
+    return Math.max(payload.exp * 1000 - Date.now() - 5 * 60 * 1000, 60 * 1000);
+  } catch (_error) {
+    return 55 * 60 * 1000;
+  }
+}
+
+async function login(widget, cacheKey) {
+  const user = getWidgetUser(widget);
+  if (!user || !widget.password) {
+    return createErrorResponse("Navidrome library stats require widget.user and widget.password.");
+  }
+
+  const loginUrl = new URL(`${widget.url.replace(/\/+$/, "")}/auth/login`);
+  const headers = {
+    Accept: "application/json",
+    "Content-Type": "application/json",
+  };
+  const body = JSON.stringify({
+    username: user,
+    password: widget.password.toString(),
+  });
+
+  const [status, contentType, data] = await httpProxy(loginUrl, {
+    method: "POST",
+    headers,
+    body,
+  });
+
+  const parsedData = parseResponseData(data);
+  if (status !== 200) {
+    return [status, contentType, parsedData];
+  }
+
+  if (!parsedData?.token) {
+    logger.error("Invalid Navidrome login response: %s", JSON.stringify(parsedData));
+    return createErrorResponse("Invalid data received from Navidrome auth/login.", 500);
+  }
+
+  cache.put(cacheKey, parsedData.token, getTokenTtl(parsedData.token));
+  return [status, contentType, parsedData];
+}
+
+function buildSubsonicToken(widget) {
+  if (widget.token && widget.salt) {
+    return {
+      token: widget.token.toString(),
+      salt: widget.salt.toString(),
+    };
+  }
+
+  if (!widget.password) {
+    return null;
+  }
+
+  const salt = randomBytes(4).toString("hex");
+  const token = createHash("md5").update(`${widget.password.toString()}${salt}`).digest("hex");
+
+  return { token, salt };
+}
+
+async function proxyNowPlaying(widget) {
+  const user = getWidgetUser(widget);
+  if (!user) {
+    return createErrorResponse("Navidrome now playing requires widget.user.");
+  }
+
+  const credentials = buildSubsonicToken(widget);
+  if (!credentials) {
+    return createErrorResponse("Navidrome now playing requires widget.token/widget.salt or widget.password.");
+  }
+
+  const url = new URL(`${widget.url.replace(/\/+$/, "")}/rest/getNowPlaying`);
+  url.searchParams.set("u", user);
+  url.searchParams.set("t", credentials.token);
+  url.searchParams.set("s", credentials.salt);
+  url.searchParams.set("v", "1.16.1");
+  url.searchParams.set("c", "homepage");
+  url.searchParams.set("f", "json");
+
+  return httpProxy(url, {
+    method: "GET",
+    headers: {
+      Accept: "application/json",
+    },
+  });
+}
+
+function aggregateLibraryData(libraries) {
+  return libraries.reduce(
+    (totals, library) => ({
+      totalSongs: totals.totalSongs + (library.totalSongs ?? 0),
+      totalAlbums: totals.totalAlbums + (library.totalAlbums ?? 0),
+      totalArtists: totals.totalArtists + (library.totalArtists ?? 0),
+    }),
+    { totalSongs: 0, totalAlbums: 0, totalArtists: 0 },
+  );
+}
+
+async function proxyLibrary(widget, cacheKey) {
+  let sessionToken = cache.get(cacheKey);
+  if (!sessionToken) {
+    const [loginStatus, , loginData] = await login(widget, cacheKey);
+    if (loginStatus !== 200) {
+      return [loginStatus, "application/json", loginData];
+    }
+    sessionToken = loginData.token;
+  }
+
+  const libraryUrl = new URL(`${widget.url.replace(/\/+$/, "")}/api/library`);
+  let [status, contentType, data] = await httpProxy(libraryUrl, {
+    method: "GET",
+    headers: getLibraryHeaders(sessionToken),
+  });
+
+  if (status === 401 || status === 403) {
+    const [loginStatus, , loginData] = await login(widget, cacheKey);
+    if (loginStatus !== 200) {
+      return [loginStatus, "application/json", loginData];
+    }
+
+    [status, contentType, data] = await httpProxy(libraryUrl, {
+      method: "GET",
+      headers: getLibraryHeaders(loginData.token),
+    });
+  }
+
+  if (status !== 200) {
+    return [status, contentType, parseResponseData(data)];
+  }
+
+  const parsedData = parseResponseData(data);
+  if (!Array.isArray(parsedData)) {
+    logger.error("Invalid Navidrome library response: %s", JSON.stringify(parsedData));
+    return createErrorResponse("Invalid data received from Navidrome api/library.", 500);
+  }
+
+  return [status, contentType, aggregateLibraryData(parsedData)];
+}
+
+export default async function navidromeProxyHandler(req, res) {
+  const { group, service, endpoint, index } = req.query;
+
+  if (!group || !service) {
+    logger.debug("Invalid or missing service '%s' or group '%s'", service, group);
+    return res.status(400).json({ error: "Invalid proxy service type" });
+  }
+
+  const widget = await getServiceWidget(group, service, index);
+
+  if (!widget) {
+    logger.debug("Invalid or missing widget for service '%s' in group '%s'", service, group);
+    return res.status(400).json({ error: "Invalid proxy service type" });
+  }
+
+  const cacheKey = getCacheKey(group, service, index);
+
+  let response;
+  switch (endpoint) {
+    case "getNowPlaying":
+      response = await proxyNowPlaying(widget);
+      break;
+    case "Library":
+      response = await proxyLibrary(widget, cacheKey);
+      break;
+    default:
+      response = createErrorResponse(`Unsupported Navidrome endpoint '${endpoint}'.`);
+      break;
+  }
+
+  const [status, contentType, data] = response;
+  let resultData = parseResponseData(data);
+
+  if (resultData?.error?.url) {
+    resultData.error.url = sanitizeErrorURL(resultData.error.url);
+  }
+
+  if (status === 200 && !validateWidgetData(widget, endpoint, resultData)) {
+    return res.status(500).json({ error: { message: "Invalid data", data: resultData } });
+  }
+
+  if (contentType) {
+    res.setHeader("Content-Type", contentType);
+  }
+
+  if (status === 204 || status === 304) {
+    return res.status(status).end();
+  }
+
+  return res.status(status).send(resultData);
+}

--- a/src/widgets/navidrome/proxy.js
+++ b/src/widgets/navidrome/proxy.js
@@ -68,7 +68,7 @@ function getTokenTtl(sessionToken) {
 async function login(widget, cacheKey) {
   const user = getWidgetUser(widget);
   if (!user || !widget.password) {
-    return createErrorResponse("Navidrome library stats require widget.user and widget.password.");
+    return createErrorResponse("Navidrome library stats require widget.user or widget.username and widget.password.");
   }
 
   const loginUrl = new URL(`${widget.url.replace(/\/+$/, "")}/auth/login`);
@@ -122,7 +122,7 @@ function buildSubsonicToken(widget) {
 async function proxyNowPlaying(widget) {
   const user = getWidgetUser(widget);
   if (!user) {
-    return createErrorResponse("Navidrome now playing requires widget.user.");
+    return createErrorResponse("Navidrome now playing requires widget.user or widget.username.");
   }
 
   const credentials = buildSubsonicToken(widget);
@@ -160,9 +160,9 @@ function aggregateLibraryData(libraries) {
 async function proxyLibrary(widget, cacheKey) {
   let sessionToken = cache.get(cacheKey);
   if (!sessionToken) {
-    const [loginStatus, , loginData] = await login(widget, cacheKey);
+    const [loginStatus, loginContentType, loginData] = await login(widget, cacheKey);
     if (loginStatus !== 200) {
-      return [loginStatus, "application/json", loginData];
+      return [loginStatus, loginContentType ?? "application/json", loginData];
     }
     sessionToken = loginData.token;
   }
@@ -174,9 +174,9 @@ async function proxyLibrary(widget, cacheKey) {
   });
 
   if (status === 401 || status === 403) {
-    const [loginStatus, , loginData] = await login(widget, cacheKey);
+    const [loginStatus, loginContentType, loginData] = await login(widget, cacheKey);
     if (loginStatus !== 200) {
-      return [loginStatus, "application/json", loginData];
+      return [loginStatus, loginContentType ?? "application/json", loginData];
     }
 
     [status, contentType, data] = await httpProxy(libraryUrl, {

--- a/src/widgets/navidrome/proxy.test.js
+++ b/src/widgets/navidrome/proxy.test.js
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import createMockRes from "test-utils/create-mock-res";
+
+const { httpProxy, getServiceWidget, validateWidgetData, cache, logger } = vi.hoisted(() => {
+  const store = new Map();
+
+  return {
+    httpProxy: vi.fn(),
+    getServiceWidget: vi.fn(),
+    validateWidgetData: vi.fn(() => true),
+    cache: {
+      get: vi.fn((key) => store.get(key)),
+      put: vi.fn((key, value) => store.set(key, value)),
+      del: vi.fn((key) => store.delete(key)),
+      _reset: () => store.clear(),
+    },
+    logger: {
+      debug: vi.fn(),
+      error: vi.fn(),
+    },
+  };
+});
+
+vi.mock("utils/logger", () => ({
+  default: () => logger,
+}));
+
+vi.mock("utils/config/service-helpers", () => ({
+  default: getServiceWidget,
+}));
+
+vi.mock("utils/proxy/http", () => ({
+  httpProxy,
+}));
+
+vi.mock("utils/proxy/validate-widget-data", () => ({
+  default: validateWidgetData,
+}));
+
+vi.mock("memory-cache", () => ({
+  default: cache,
+  ...cache,
+}));
+
+import navidromeProxyHandler from "./proxy";
+
+describe("widgets/navidrome/proxy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    validateWidgetData.mockReturnValue(true);
+    cache._reset();
+  });
+
+  it("uses Subsonic token auth for getNowPlaying", async () => {
+    getServiceWidget.mockResolvedValue({
+      type: "navidrome",
+      url: "http://nd",
+      user: "alice",
+      token: "subsonic-token",
+      salt: "subsonic-salt",
+    });
+
+    httpProxy.mockResolvedValueOnce([
+      200,
+      "application/json",
+      Buffer.from(JSON.stringify({ "subsonic-response": { status: "ok", nowPlaying: {} } })),
+    ]);
+
+    const req = { query: { group: "media", service: "navidrome", endpoint: "getNowPlaying", index: "0" } };
+    const res = createMockRes();
+
+    await navidromeProxyHandler(req, res);
+
+    expect(httpProxy).toHaveBeenCalledTimes(1);
+    expect(httpProxy.mock.calls[0][0].toString()).toBe(
+      "http://nd/rest/getNowPlaying?u=alice&t=subsonic-token&s=subsonic-salt&v=1.16.1&c=homepage&f=json",
+    );
+    expect(validateWidgetData).toHaveBeenCalledWith(expect.objectContaining({ type: "navidrome" }), "getNowPlaying", {
+      "subsonic-response": { status: "ok", nowPlaying: {} },
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("logs in and aggregates library totals", async () => {
+    getServiceWidget.mockResolvedValue({
+      type: "navidrome",
+      url: "http://nd",
+      user: "alice",
+      password: "secret",
+    });
+
+    httpProxy
+      .mockResolvedValueOnce([200, "application/json", Buffer.from(JSON.stringify({ token: "jwt-token" }))])
+      .mockResolvedValueOnce([
+        200,
+        "application/json",
+        Buffer.from(
+          JSON.stringify([
+            { totalSongs: 100, totalAlbums: 20, totalArtists: 10 },
+            { totalSongs: 25, totalAlbums: 5, totalArtists: 3 },
+          ]),
+        ),
+      ]);
+
+    const req = { query: { group: "media", service: "navidrome", endpoint: "Library", index: "0" } };
+    const res = createMockRes();
+
+    await navidromeProxyHandler(req, res);
+
+    expect(httpProxy).toHaveBeenCalledTimes(2);
+    expect(httpProxy.mock.calls[0][0].toString()).toBe("http://nd/auth/login");
+    expect(httpProxy.mock.calls[0][1]).toMatchObject({
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+    });
+    expect(httpProxy.mock.calls[0][1].body).toBe(JSON.stringify({ username: "alice", password: "secret" }));
+    expect(httpProxy.mock.calls[1][0].toString()).toBe("http://nd/api/library");
+    expect(httpProxy.mock.calls[1][1].headers["X-ND-Authorization"]).toBe("Bearer jwt-token");
+    expect(validateWidgetData).toHaveBeenCalledWith(expect.objectContaining({ type: "navidrome" }), "Library", {
+      totalSongs: 125,
+      totalAlbums: 25,
+      totalArtists: 13,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      totalSongs: 125,
+      totalAlbums: 25,
+      totalArtists: 13,
+    });
+  });
+});

--- a/src/widgets/navidrome/proxy.test.js
+++ b/src/widgets/navidrome/proxy.test.js
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import createMockRes from "test-utils/create-mock-res";
 
@@ -45,6 +45,24 @@ vi.mock("memory-cache", () => ({
 
 import navidromeProxyHandler from "./proxy";
 
+const cacheKey = "navidromeProxyHandler__session.media.navidrome.0";
+
+function createReq(endpoint, overrides = {}) {
+  return {
+    query: {
+      group: "media",
+      service: "navidrome",
+      index: "0",
+      endpoint,
+      ...overrides,
+    },
+  };
+}
+
+function createJwt(payload) {
+  return `header.${Buffer.from(JSON.stringify(payload)).toString("base64url")}.signature`;
+}
+
 describe("widgets/navidrome/proxy", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -52,7 +70,380 @@ describe("widgets/navidrome/proxy", () => {
     cache._reset();
   });
 
-  it("uses Subsonic token auth for getNowPlaying", async () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("uses widget.username with Subsonic token auth for getNowPlaying", async () => {
+    getServiceWidget.mockResolvedValue({
+      type: "navidrome",
+      url: "http://nd",
+      username: "alice",
+      token: "subsonic-token",
+      salt: "subsonic-salt",
+    });
+
+    httpProxy.mockResolvedValueOnce([
+      200,
+      "application/json",
+      Buffer.from(JSON.stringify({ "subsonic-response": { status: "ok", nowPlaying: {} } })),
+    ]);
+
+    const res = createMockRes();
+
+    await navidromeProxyHandler(createReq("getNowPlaying"), res);
+
+    expect(httpProxy).toHaveBeenCalledTimes(1);
+    expect(httpProxy.mock.calls[0][0].toString()).toBe(
+      "http://nd/rest/getNowPlaying?u=alice&t=subsonic-token&s=subsonic-salt&v=1.16.1&c=homepage&f=json",
+    );
+    expect(validateWidgetData).toHaveBeenCalledWith(expect.objectContaining({ type: "navidrome" }), "getNowPlaying", {
+      "subsonic-response": { status: "ok", nowPlaying: {} },
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("builds a Subsonic token from widget.password when token credentials are missing", async () => {
+    getServiceWidget.mockResolvedValue({
+      type: "navidrome",
+      url: "http://nd",
+      user: "alice",
+      password: "secret",
+    });
+
+    httpProxy.mockResolvedValueOnce([
+      200,
+      "application/json",
+      Buffer.from(JSON.stringify({ "subsonic-response": { status: "ok", nowPlaying: {} } })),
+    ]);
+
+    const res = createMockRes();
+
+    await navidromeProxyHandler(createReq("getNowPlaying"), res);
+
+    const url = new URL(httpProxy.mock.calls[0][0]);
+    expect(url.searchParams.get("u")).toBe("alice");
+    expect(url.searchParams.get("t")).toHaveLength(32);
+    expect(url.searchParams.get("s")).toMatch(/^[a-f0-9]{8}$/);
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("returns a descriptive error when now playing is missing widget.user and widget.username", async () => {
+    getServiceWidget.mockResolvedValue({
+      type: "navidrome",
+      url: "http://nd",
+      password: "secret",
+    });
+
+    const res = createMockRes();
+
+    await navidromeProxyHandler(createReq("getNowPlaying"), res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error.message).toBe("Navidrome now playing requires widget.user or widget.username.");
+  });
+
+  it("returns a descriptive error when now playing credentials are missing", async () => {
+    getServiceWidget.mockResolvedValue({
+      type: "navidrome",
+      url: "http://nd",
+      user: "alice",
+    });
+
+    const res = createMockRes();
+
+    await navidromeProxyHandler(createReq("getNowPlaying"), res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error.message).toBe("Navidrome now playing requires widget.token/widget.salt or widget.password.");
+  });
+
+  it("logs in with widget.username and aggregates library totals", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-25T12:00:00Z"));
+
+    getServiceWidget.mockResolvedValue({
+      type: "navidrome",
+      url: "http://nd",
+      username: "alice",
+      password: "secret",
+    });
+
+    const exp = Math.floor(Date.now() / 1000) + 20 * 60;
+    httpProxy
+      .mockResolvedValueOnce([200, "application/json", Buffer.from(JSON.stringify({ token: createJwt({ exp }) }))])
+      .mockResolvedValueOnce([
+        200,
+        "application/json",
+        Buffer.from(
+          JSON.stringify([
+            { totalSongs: 100, totalAlbums: 20, totalArtists: 10 },
+            { totalSongs: 25, totalAlbums: 5, totalArtists: 3 },
+          ]),
+        ),
+      ]);
+
+    const res = createMockRes();
+
+    await navidromeProxyHandler(createReq("Library"), res);
+
+    expect(httpProxy).toHaveBeenCalledTimes(2);
+    expect(httpProxy.mock.calls[0][0].toString()).toBe("http://nd/auth/login");
+    expect(httpProxy.mock.calls[0][1].body).toBe(JSON.stringify({ username: "alice", password: "secret" }));
+    expect(httpProxy.mock.calls[1][0].toString()).toBe("http://nd/api/library");
+    expect(httpProxy.mock.calls[1][1].headers["X-ND-Authorization"]).toBe(`Bearer ${createJwt({ exp })}`);
+    expect(cache.put).toHaveBeenCalledWith(cacheKey, createJwt({ exp }), 900000);
+    expect(validateWidgetData).toHaveBeenCalledWith(expect.objectContaining({ type: "navidrome" }), "Library", {
+      totalSongs: 125,
+      totalAlbums: 25,
+      totalArtists: 13,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      totalSongs: 125,
+      totalAlbums: 25,
+      totalArtists: 13,
+    });
+  });
+
+  it("falls back to the default session TTL when the JWT payload has no exp", async () => {
+    getServiceWidget.mockResolvedValue({
+      type: "navidrome",
+      url: "http://nd",
+      user: "alice",
+      password: "secret",
+    });
+
+    httpProxy
+      .mockResolvedValueOnce([200, "application/json", Buffer.from(JSON.stringify({ token: createJwt({ sub: "a" }) }))])
+      .mockResolvedValueOnce([
+        200,
+        "application/json",
+        Buffer.from(JSON.stringify([{ totalSongs: 1, totalAlbums: 2, totalArtists: 3 }])),
+      ]);
+
+    const res = createMockRes();
+
+    await navidromeProxyHandler(createReq("Library"), res);
+
+    expect(cache.put).toHaveBeenCalledWith(cacheKey, createJwt({ sub: "a" }), 55 * 60 * 1000);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ totalSongs: 1, totalAlbums: 2, totalArtists: 3 });
+  });
+
+  it("retries the library request after a 401 with a refreshed token", async () => {
+    cache.put(cacheKey, "stale-token");
+
+    getServiceWidget.mockResolvedValue({
+      type: "navidrome",
+      url: "http://nd",
+      user: "alice",
+      password: "secret",
+    });
+
+    httpProxy
+      .mockResolvedValueOnce([401, "application/json", Buffer.from(JSON.stringify({ error: "expired" }))])
+      .mockResolvedValueOnce([200, "application/json", Buffer.from(JSON.stringify({ token: "header.!.signature" }))])
+      .mockResolvedValueOnce([
+        200,
+        "application/json",
+        Buffer.from(JSON.stringify([{ totalSongs: 9, totalAlbums: 8, totalArtists: 7 }])),
+      ]);
+
+    const res = createMockRes();
+
+    await navidromeProxyHandler(createReq("Library"), res);
+
+    expect(httpProxy).toHaveBeenCalledTimes(3);
+    expect(httpProxy.mock.calls[0][1].headers["X-ND-Authorization"]).toBe("Bearer stale-token");
+    expect(httpProxy.mock.calls[2][1].headers["X-ND-Authorization"]).toBe("Bearer header.!.signature");
+    expect(cache.put).toHaveBeenLastCalledWith(cacheKey, "header.!.signature", 55 * 60 * 1000);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ totalSongs: 9, totalAlbums: 8, totalArtists: 7 });
+  });
+
+  it("returns the retry login error when refreshing the library token fails", async () => {
+    cache.put(cacheKey, "stale-token");
+
+    getServiceWidget.mockResolvedValue({
+      type: "navidrome",
+      url: "http://nd",
+      user: "alice",
+      password: "secret",
+    });
+
+    httpProxy
+      .mockResolvedValueOnce([401, "application/json", Buffer.from(JSON.stringify({ error: "expired" }))])
+      .mockResolvedValueOnce([
+        503,
+        "application/json",
+        Buffer.from(JSON.stringify({ error: { message: "login down" } })),
+      ]);
+
+    const res = createMockRes();
+
+    await navidromeProxyHandler(createReq("Library"), res);
+
+    expect(res.statusCode).toBe(503);
+    expect(res.body).toEqual({ error: { message: "login down" } });
+  });
+
+  it("returns a descriptive error when library credentials are missing", async () => {
+    getServiceWidget.mockResolvedValue({
+      type: "navidrome",
+      url: "http://nd",
+    });
+
+    const res = createMockRes();
+
+    await navidromeProxyHandler(createReq("Library"), res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error.message).toBe(
+      "Navidrome library stats require widget.user or widget.username and widget.password.",
+    );
+  });
+
+  it("passes through unsuccessful login responses", async () => {
+    getServiceWidget.mockResolvedValue({
+      type: "navidrome",
+      url: "http://nd",
+      user: "alice",
+      password: "secret",
+    });
+
+    httpProxy.mockResolvedValueOnce([503, "text/plain", Buffer.from("down")]);
+
+    const res = createMockRes();
+
+    await navidromeProxyHandler(createReq("Library"), res);
+
+    expect(res.statusCode).toBe(503);
+    expect(res.body).toBe("down");
+    expect(res.headers["Content-Type"]).toBe("text/plain");
+  });
+
+  it("returns 500 when login succeeds without a token", async () => {
+    getServiceWidget.mockResolvedValue({
+      type: "navidrome",
+      url: "http://nd",
+      user: "alice",
+      password: "secret",
+    });
+
+    httpProxy.mockResolvedValueOnce([200, "application/json", Buffer.from(JSON.stringify({ nope: true }))]);
+
+    const res = createMockRes();
+
+    await navidromeProxyHandler(createReq("Library"), res);
+
+    expect(logger.error).toHaveBeenCalledWith("Invalid Navidrome login response: %s", JSON.stringify({ nope: true }));
+    expect(res.statusCode).toBe(500);
+    expect(res.body.error.message).toBe("Invalid data received from Navidrome auth/login.");
+  });
+
+  it("passes through unsuccessful library responses after login", async () => {
+    getServiceWidget.mockResolvedValue({
+      type: "navidrome",
+      url: "http://nd",
+      user: "alice",
+      password: "secret",
+    });
+
+    httpProxy
+      .mockResolvedValueOnce([200, "application/json", Buffer.from(JSON.stringify({ token: "jwt-token" }))])
+      .mockResolvedValueOnce([502, "application/json", Buffer.from(JSON.stringify({ error: { message: "down" } }))]);
+
+    const res = createMockRes();
+
+    await navidromeProxyHandler(createReq("Library"), res);
+
+    expect(res.statusCode).toBe(502);
+    expect(res.body).toEqual({ error: { message: "down" } });
+  });
+
+  it("returns 500 when the library response is not an array", async () => {
+    getServiceWidget.mockResolvedValue({
+      type: "navidrome",
+      url: "http://nd",
+      user: "alice",
+      password: "secret",
+    });
+
+    httpProxy
+      .mockResolvedValueOnce([200, "application/json", Buffer.from(JSON.stringify({ token: "jwt-token" }))])
+      .mockResolvedValueOnce([200, "application/json", Buffer.from(JSON.stringify({ nope: true }))]);
+
+    const res = createMockRes();
+
+    await navidromeProxyHandler(createReq("Library"), res);
+
+    expect(logger.error).toHaveBeenCalledWith("Invalid Navidrome library response: %s", JSON.stringify({ nope: true }));
+    expect(res.statusCode).toBe(500);
+    expect(res.body.error.message).toBe("Invalid data received from Navidrome api/library.");
+  });
+
+  it("returns 400 when the proxy request is missing its group or service", async () => {
+    const res = createMockRes();
+
+    await navidromeProxyHandler({ query: { endpoint: "getNowPlaying" } }, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: "Invalid proxy service type" });
+  });
+
+  it("returns 400 when the Navidrome widget cannot be resolved", async () => {
+    getServiceWidget.mockResolvedValue(undefined);
+
+    const res = createMockRes();
+
+    await navidromeProxyHandler(createReq("getNowPlaying"), res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: "Invalid proxy service type" });
+  });
+
+  it("returns 400 for unsupported Navidrome endpoints", async () => {
+    getServiceWidget.mockResolvedValue({
+      type: "navidrome",
+      url: "http://nd",
+      user: "alice",
+      password: "secret",
+    });
+
+    const res = createMockRes();
+
+    await navidromeProxyHandler(createReq("Nope"), res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error.message).toBe("Unsupported Navidrome endpoint 'Nope'.");
+  });
+
+  it("sanitizes upstream error URLs before returning them", async () => {
+    getServiceWidget.mockResolvedValue({
+      type: "navidrome",
+      url: "http://nd",
+      user: "alice",
+      token: "subsonic-token",
+      salt: "subsonic-salt",
+    });
+
+    httpProxy.mockResolvedValueOnce([
+      502,
+      "application/json",
+      { error: { message: "down", url: "http://nd/rest/getNowPlaying?u=alice&token=secret" } },
+    ]);
+
+    const res = createMockRes();
+
+    await navidromeProxyHandler(createReq("getNowPlaying"), res);
+
+    expect(res.statusCode).toBe(502);
+    expect(res.body.error.url).toBe("http://nd/rest/getNowPlaying?u=alice&token=***");
+  });
+
+  it("returns 500 when response validation fails", async () => {
+    validateWidgetData.mockReturnValue(false);
     getServiceWidget.mockResolvedValue({
       type: "navidrome",
       url: "http://nd",
@@ -67,69 +458,35 @@ describe("widgets/navidrome/proxy", () => {
       Buffer.from(JSON.stringify({ "subsonic-response": { status: "ok", nowPlaying: {} } })),
     ]);
 
-    const req = { query: { group: "media", service: "navidrome", endpoint: "getNowPlaying", index: "0" } };
     const res = createMockRes();
 
-    await navidromeProxyHandler(req, res);
+    await navidromeProxyHandler(createReq("getNowPlaying"), res);
 
-    expect(httpProxy).toHaveBeenCalledTimes(1);
-    expect(httpProxy.mock.calls[0][0].toString()).toBe(
-      "http://nd/rest/getNowPlaying?u=alice&t=subsonic-token&s=subsonic-salt&v=1.16.1&c=homepage&f=json",
-    );
-    expect(validateWidgetData).toHaveBeenCalledWith(expect.objectContaining({ type: "navidrome" }), "getNowPlaying", {
-      "subsonic-response": { status: "ok", nowPlaying: {} },
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({
+      error: {
+        message: "Invalid data",
+        data: { "subsonic-response": { status: "ok", nowPlaying: {} } },
+      },
     });
-    expect(res.statusCode).toBe(200);
   });
 
-  it("logs in and aggregates library totals", async () => {
+  it("ends the response for 204 upstream responses", async () => {
     getServiceWidget.mockResolvedValue({
       type: "navidrome",
       url: "http://nd",
       user: "alice",
-      password: "secret",
+      token: "subsonic-token",
+      salt: "subsonic-salt",
     });
 
-    httpProxy
-      .mockResolvedValueOnce([200, "application/json", Buffer.from(JSON.stringify({ token: "jwt-token" }))])
-      .mockResolvedValueOnce([
-        200,
-        "application/json",
-        Buffer.from(
-          JSON.stringify([
-            { totalSongs: 100, totalAlbums: 20, totalArtists: 10 },
-            { totalSongs: 25, totalAlbums: 5, totalArtists: 3 },
-          ]),
-        ),
-      ]);
+    httpProxy.mockResolvedValueOnce([204, "application/json", {}]);
 
-    const req = { query: { group: "media", service: "navidrome", endpoint: "Library", index: "0" } };
     const res = createMockRes();
 
-    await navidromeProxyHandler(req, res);
+    await navidromeProxyHandler(createReq("getNowPlaying"), res);
 
-    expect(httpProxy).toHaveBeenCalledTimes(2);
-    expect(httpProxy.mock.calls[0][0].toString()).toBe("http://nd/auth/login");
-    expect(httpProxy.mock.calls[0][1]).toMatchObject({
-      method: "POST",
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/json",
-      },
-    });
-    expect(httpProxy.mock.calls[0][1].body).toBe(JSON.stringify({ username: "alice", password: "secret" }));
-    expect(httpProxy.mock.calls[1][0].toString()).toBe("http://nd/api/library");
-    expect(httpProxy.mock.calls[1][1].headers["X-ND-Authorization"]).toBe("Bearer jwt-token");
-    expect(validateWidgetData).toHaveBeenCalledWith(expect.objectContaining({ type: "navidrome" }), "Library", {
-      totalSongs: 125,
-      totalAlbums: 25,
-      totalArtists: 13,
-    });
-    expect(res.statusCode).toBe(200);
-    expect(res.body).toEqual({
-      totalSongs: 125,
-      totalAlbums: 25,
-      totalArtists: 13,
-    });
+    expect(res.statusCode).toBe(204);
+    expect(res.end).toHaveBeenCalled();
   });
 });

--- a/src/widgets/navidrome/widget.js
+++ b/src/widgets/navidrome/widget.js
@@ -1,12 +1,16 @@
-import genericProxyHandler from "utils/proxy/handlers/generic";
+import navidromeProxyHandler from "./proxy";
 
 const widget = {
-  api: "{url}/rest/{endpoint}?u={user}&t={token}&s={salt}&v=1.16.1&c=homepage&f=json",
-  proxyHandler: genericProxyHandler,
+  api: "{url}",
+  proxyHandler: navidromeProxyHandler,
 
   mappings: {
     getNowPlaying: {
       endpoint: "getNowPlaying",
+    },
+    Library: {
+      endpoint: "Library",
+      validate: ["totalSongs", "totalAlbums", "totalArtists"],
     },
   },
 };


### PR DESCRIPTION
<!--
==== STOP ====================
======== STOP ================
============ STOP ============
================ STOP ========
==================== STOP ====

⚠️ Before opening this pull request please review the guidelines in the checklist below.

If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.
-->

## Proposed change

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

This updates the existing Navidrome widget so it can show library statistics in the same style as Jellyfin, while preserving the current now playing behavior. The change adds optional blocks for:

- songs
- albums
- artists

It also adds an `enableNowPlaying` toggle so users can choose between:

- library stats only
- library stats plus now playing
- now playing only

<img width="1038" height="228" alt="image" src="https://github.com/user-attachments/assets/b850d4dc-93ea-4262-b3dd-4f5a7c51d027" />

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] In the description above I have disclosed the use of AI tools in the coding of this PR.
