### PR TITLE
Feat: add ArchiSteamFarm widget

### DIFF
--- a/docs/widgets/services/archisteamfarm.md
+++ b/docs/widgets/services/archisteamfarm.md
@@ -1,0 +1,17 @@
+---
+title: ArchiSteamFarm
+description: ArchiSteamFarm Widget Configuration
+---
+
+Learn more about [ArchiSteamFarm](https://github.com/JustArchiNET/ArchiSteamFarm).
+
+This widget uses the ASF IPC API and requires the configured IPC password.
+
+Allowed fields: `["bots", "version", "memory", "uptime"]`
+
+```yaml
+widget:
+  type: archisteamfarm
+  url: https://asf.host.or.ip
+  password: your_ipc_password
+```

--- a/docs/widgets/services/index.md
+++ b/docs/widgets/services/index.md
@@ -10,6 +10,7 @@ You can also find a list of all available service widgets in the sidebar navigat
 - [Adguard Home](adguard-home.md)
 - [APC UPS](apcups.md)
 - [Arcane](arcane.md)
+- [ArchiSteamFarm](archisteamfarm.md)
 - [ArgoCD](argocd.md)
 - [Atsumeru](atsumeru.md)
 - [Audiobookshelf](audiobookshelf.md)

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -71,6 +71,13 @@
         "degraded": "Degraded",
         "no_data": "No storage data available"
     },
+    "archisteamfarm": {
+        "bots": "Bots",
+        "version": "Version",
+        "memory": "Memory",
+        "uptime": "Uptime",
+        "unknown": "Unknown"
+    },
     "docker": {
         "rx": "RX",
         "tx": "TX",

--- a/src/widgets/archisteamfarm/component.jsx
+++ b/src/widgets/archisteamfarm/component.jsx
@@ -1,0 +1,100 @@
+import Block from "components/services/widget/block";
+import Container from "components/services/widget/container";
+import { useTranslation } from "next-i18next";
+
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+const DEFAULT_FIELDS = ["bots", "version", "memory", "uptime"];
+const MAX_ALLOWED_FIELDS = 4;
+
+function parseFields(fields) {
+  if (Array.isArray(fields)) {
+    return fields;
+  }
+
+  if (typeof fields === "string") {
+    try {
+      const parsedFields = JSON.parse(fields);
+      return Array.isArray(parsedFields) ? parsedFields : [];
+    } catch {
+      return [];
+    }
+  }
+
+  return [];
+}
+
+function getUptimeSeconds(processStartTime) {
+  if (!processStartTime) {
+    return null;
+  }
+
+  const startedAt = Date.parse(processStartTime);
+  if (Number.isNaN(startedAt)) {
+    return null;
+  }
+
+  return Math.max(0, Math.floor((Date.now() - startedAt) / 1000));
+}
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+  const { widget } = service;
+
+  const configuredFields = parseFields(widget.fields);
+  widget.fields = configuredFields.length ? configuredFields.slice(0, MAX_ALLOWED_FIELDS) : DEFAULT_FIELDS;
+
+  const needsBots = widget.fields.includes("bots");
+  const needsStats = widget.fields.some((field) => ["version", "memory", "uptime"].includes(field));
+
+  const { data: botsData, error: botsError } = useWidgetAPI(widget, needsBots ? "bots" : "", {
+    refreshInterval: 30000,
+  });
+  const { data: statsData, error: statsError } = useWidgetAPI(widget, needsStats ? "stats" : "", {
+    refreshInterval: 60000,
+  });
+
+  const error = botsError ?? statsError;
+  if (error) {
+    return <Container service={service} error={error} />;
+  }
+
+  if ((needsBots && !botsData) || (needsStats && !statsData)) {
+    return (
+      <Container service={service}>
+        <Block field="archisteamfarm.bots" label="archisteamfarm.bots" />
+        <Block field="archisteamfarm.version" label="archisteamfarm.version" />
+        <Block field="archisteamfarm.memory" label="archisteamfarm.memory" />
+        <Block field="archisteamfarm.uptime" label="archisteamfarm.uptime" />
+      </Container>
+    );
+  }
+
+  const memoryBytes = Number.isFinite(statsData?.memoryKiB) ? statsData.memoryKiB * 1024 : null;
+  const uptimeSeconds = getUptimeSeconds(statsData?.processStartTime);
+
+  return (
+    <Container service={service}>
+      <Block
+        field="archisteamfarm.bots"
+        label="archisteamfarm.bots"
+        value={t("common.number", { value: botsData?.count ?? 0 })}
+      />
+      <Block
+        field="archisteamfarm.version"
+        label="archisteamfarm.version"
+        value={statsData?.version ? `v${statsData.version}` : t("archisteamfarm.unknown")}
+      />
+      <Block
+        field="archisteamfarm.memory"
+        label="archisteamfarm.memory"
+        value={memoryBytes === null ? t("archisteamfarm.unknown") : t("common.bbytes", { value: memoryBytes })}
+      />
+      <Block
+        field="archisteamfarm.uptime"
+        label="archisteamfarm.uptime"
+        value={uptimeSeconds === null ? t("archisteamfarm.unknown") : t("common.duration", { value: uptimeSeconds })}
+      />
+    </Container>
+  );
+}

--- a/src/widgets/archisteamfarm/component.test.jsx
+++ b/src/widgets/archisteamfarm/component.test.jsx
@@ -34,6 +34,30 @@ describe("widgets/archisteamfarm/component", () => {
     expect(screen.getByText("archisteamfarm.uptime")).toBeInTheDocument();
   });
 
+  it("falls back to default fields when widget.fields is invalid JSON", () => {
+    useWidgetAPI.mockReturnValue({ data: undefined, error: undefined });
+
+    const { container } = renderWithProviders(
+      <Component service={{ widget: { type: "archisteamfarm", fields: "not-json" } }} />,
+      {
+        settings: { hideErrors: false },
+      },
+    );
+
+    expect(container.querySelectorAll(".service-block")).toHaveLength(4);
+  });
+
+  it("renders an error container when the API errors", () => {
+    useWidgetAPI.mockReturnValue({ data: undefined, error: { message: "boom" } });
+
+    renderWithProviders(<Component service={{ widget: { type: "archisteamfarm" } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expect(screen.getAllByText(/widget\.api_error/i).length).toBeGreaterThan(0);
+    expect(screen.getByText("boom")).toBeInTheDocument();
+  });
+
   it("renders ASF stats when loaded", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-25T16:19:32.210Z"));
@@ -65,6 +89,86 @@ describe("widgets/archisteamfarm/component", () => {
     expectBlockValue(container, "archisteamfarm.version", "v6.3.4.2");
     expectBlockValue(container, "archisteamfarm.memory", String(24865 * 1024));
     expectBlockValue(container, "archisteamfarm.uptime", "3600");
+  });
+
+  it("parses JSON string fields and only renders the selected blocks", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-25T16:19:32.210Z"));
+
+    useWidgetAPI.mockImplementation((widget, endpoint) => {
+      if (endpoint === "stats") {
+        return {
+          data: {
+            version: "6.3.4.2",
+            memoryKiB: 24865,
+            processStartTime: "2026-04-25T15:19:32.210Z",
+          },
+          error: undefined,
+        };
+      }
+
+      return { data: undefined, error: undefined };
+    });
+
+    const { container } = renderWithProviders(
+      <Component service={{ widget: { type: "archisteamfarm", fields: '["version","uptime"]' } }} />,
+      {
+        settings: { hideErrors: false },
+      },
+    );
+
+    expect(container.querySelectorAll(".service-block")).toHaveLength(2);
+    expect(screen.getByText("archisteamfarm.version")).toBeInTheDocument();
+    expect(screen.getByText("archisteamfarm.uptime")).toBeInTheDocument();
+    expect(screen.queryByText("archisteamfarm.bots")).not.toBeInTheDocument();
+    expect(screen.queryByText("archisteamfarm.memory")).not.toBeInTheDocument();
+  });
+
+  it("renders unknown for missing uptime", () => {
+    useWidgetAPI.mockImplementation((widget, endpoint) => {
+      if (endpoint === "stats") {
+        return {
+          data: {
+            processStartTime: undefined,
+          },
+          error: undefined,
+        };
+      }
+
+      return { data: undefined, error: undefined };
+    });
+
+    renderWithProviders(<Component service={{ widget: { type: "archisteamfarm", fields: ["uptime"] } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expect(screen.getByText("archisteamfarm.unknown")).toBeInTheDocument();
+  });
+
+  it("renders unknown values when stats are invalid", () => {
+    useWidgetAPI.mockImplementation((widget, endpoint) => {
+      if (endpoint === "stats") {
+        return {
+          data: {
+            version: "",
+            memoryKiB: Number.NaN,
+            processStartTime: "not-a-date",
+          },
+          error: undefined,
+        };
+      }
+
+      return { data: undefined, error: undefined };
+    });
+
+    renderWithProviders(
+      <Component service={{ widget: { type: "archisteamfarm", fields: ["version", "memory", "uptime"] } }} />,
+      {
+        settings: { hideErrors: false },
+      },
+    );
+
+    expect(screen.getAllByText("archisteamfarm.unknown")).toHaveLength(3);
   });
 
   it("honors selected fields", () => {

--- a/src/widgets/archisteamfarm/component.test.jsx
+++ b/src/widgets/archisteamfarm/component.test.jsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+
+import { screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "test-utils/render-with-providers";
+import { expectBlockValue } from "test-utils/widget-assertions";
+
+const { useWidgetAPI } = vi.hoisted(() => ({ useWidgetAPI: vi.fn() }));
+vi.mock("utils/proxy/use-widget-api", () => ({ default: useWidgetAPI }));
+
+import Component from "./component";
+
+describe("widgets/archisteamfarm/component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders placeholders while loading", () => {
+    useWidgetAPI.mockReturnValue({ data: undefined, error: undefined });
+
+    const { container } = renderWithProviders(<Component service={{ widget: { type: "archisteamfarm" } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expect(container.querySelectorAll(".service-block")).toHaveLength(4);
+    expect(screen.getByText("archisteamfarm.bots")).toBeInTheDocument();
+    expect(screen.getByText("archisteamfarm.version")).toBeInTheDocument();
+    expect(screen.getByText("archisteamfarm.memory")).toBeInTheDocument();
+    expect(screen.getByText("archisteamfarm.uptime")).toBeInTheDocument();
+  });
+
+  it("renders ASF stats when loaded", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-25T16:19:32.210Z"));
+
+    useWidgetAPI.mockImplementation((widget, endpoint) => {
+      if (endpoint === "bots") {
+        return { data: { count: 3 }, error: undefined };
+      }
+
+      if (endpoint === "stats") {
+        return {
+          data: {
+            version: "6.3.4.2",
+            memoryKiB: 24865,
+            processStartTime: "2026-04-25T15:19:32.210Z",
+          },
+          error: undefined,
+        };
+      }
+
+      return { data: undefined, error: undefined };
+    });
+
+    const { container } = renderWithProviders(<Component service={{ widget: { type: "archisteamfarm" } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expectBlockValue(container, "archisteamfarm.bots", "3");
+    expectBlockValue(container, "archisteamfarm.version", "v6.3.4.2");
+    expectBlockValue(container, "archisteamfarm.memory", String(24865 * 1024));
+    expectBlockValue(container, "archisteamfarm.uptime", "3600");
+  });
+
+  it("honors selected fields", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-25T16:19:32.210Z"));
+
+    useWidgetAPI.mockImplementation((widget, endpoint) => {
+      if (endpoint === "bots") {
+        return { data: { count: 3 }, error: undefined };
+      }
+
+      if (endpoint === "stats") {
+        return {
+          data: {
+            version: "6.3.4.2",
+            memoryKiB: 24865,
+            processStartTime: "2026-04-25T15:19:32.210Z",
+          },
+          error: undefined,
+        };
+      }
+
+      return { data: undefined, error: undefined };
+    });
+
+    const { container } = renderWithProviders(
+      <Component service={{ widget: { type: "archisteamfarm", fields: ["bots", "memory"] } }} />,
+      {
+        settings: { hideErrors: false },
+      },
+    );
+
+    expect(container.querySelectorAll(".service-block")).toHaveLength(2);
+    expect(screen.getByText("archisteamfarm.bots")).toBeInTheDocument();
+    expect(screen.getByText("archisteamfarm.memory")).toBeInTheDocument();
+    expect(screen.queryByText("archisteamfarm.version")).not.toBeInTheDocument();
+    expect(screen.queryByText("archisteamfarm.uptime")).not.toBeInTheDocument();
+  });
+});

--- a/src/widgets/archisteamfarm/proxy.js
+++ b/src/widgets/archisteamfarm/proxy.js
@@ -22,12 +22,17 @@ export default async function archisteamfarmProxyHandler(req, res, map) {
     return res.status(403).json({ error: "Service does not support API calls" });
   }
 
+  const password = widget.password?.toString().trim();
+  if (!password) {
+    return res.status(400).json({ error: { message: "ArchiSteamFarm widget requires widget.password." } });
+  }
+
   const url = new URL(formatApiCall(widgets[widget.type].api, { endpoint, ...widget }));
   const headers = {
     ...(widgets[widget.type].headers ?? {}),
     ...(widget.headers ?? {}),
     ...(req.extraHeaders ?? {}),
-    Authentication: widget.password,
+    Authentication: password,
   };
 
   const [status, contentType, data] = await httpProxy(url, {

--- a/src/widgets/archisteamfarm/proxy.js
+++ b/src/widgets/archisteamfarm/proxy.js
@@ -1,0 +1,69 @@
+import getServiceWidget from "utils/config/service-helpers";
+import createLogger from "utils/logger";
+import { formatApiCall, sanitizeErrorURL } from "utils/proxy/api-helpers";
+import { httpProxy } from "utils/proxy/http";
+import validateWidgetData from "utils/proxy/validate-widget-data";
+import widgets from "widgets/widgets";
+
+const logger = createLogger("archisteamfarmProxyHandler");
+
+export default async function archisteamfarmProxyHandler(req, res, map) {
+  const { group, service, endpoint, index } = req.query;
+
+  if (!group || !service) {
+    logger.debug("Invalid or missing proxy service type '%s' in group '%s'", service, group);
+    return res.status(400).json({ error: "Invalid proxy service type" });
+  }
+
+  const widget = await getServiceWidget(group, service, index);
+
+  if (!widget || !widgets?.[widget.type]?.api) {
+    logger.debug("Invalid or missing proxy service type '%s' in group '%s'", service, group);
+    return res.status(403).json({ error: "Service does not support API calls" });
+  }
+
+  const url = new URL(formatApiCall(widgets[widget.type].api, { endpoint, ...widget }));
+  const headers = {
+    ...(widgets[widget.type].headers ?? {}),
+    ...(widget.headers ?? {}),
+    ...(req.extraHeaders ?? {}),
+    Authentication: widget.password,
+  };
+
+  const [status, contentType, data] = await httpProxy(url, {
+    method: req.method,
+    withCredentials: true,
+    credentials: "include",
+    headers,
+  });
+
+  let resultData = data;
+
+  if (resultData?.error?.url) {
+    resultData.error.url = sanitizeErrorURL(url);
+  }
+
+  if (status === 204 || status === 304) {
+    return res.status(status).end();
+  }
+
+  if (status >= 400) {
+    logger.error("HTTP Error %d calling %s", status, url.toString());
+  }
+
+  if (status === 200) {
+    if (!validateWidgetData(widget, endpoint, resultData)) {
+      return res.status(500).json({ error: { message: "Invalid data", url: sanitizeErrorURL(url), data: resultData } });
+    }
+
+    if (map) {
+      resultData = map(resultData);
+    }
+  }
+
+  if (contentType) {
+    res.setHeader("Content-Type", contentType);
+  }
+
+  return res.status(status).send(resultData);
+}

--- a/src/widgets/archisteamfarm/proxy.test.js
+++ b/src/widgets/archisteamfarm/proxy.test.js
@@ -2,13 +2,18 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import createMockRes from "test-utils/create-mock-res";
 
-const { httpProxy, getServiceWidget, validateWidgetData, logger } = vi.hoisted(() => ({
+const { httpProxy, getServiceWidget, validateWidgetData, logger, widgets } = vi.hoisted(() => ({
   httpProxy: vi.fn(),
   getServiceWidget: vi.fn(),
   validateWidgetData: vi.fn(() => true),
   logger: {
     debug: vi.fn(),
     error: vi.fn(),
+  },
+  widgets: {
+    archisteamfarm: {
+      api: "{url}/Api/{endpoint}",
+    },
   },
 }));
 
@@ -29,11 +34,7 @@ vi.mock("utils/proxy/validate-widget-data", () => ({
 }));
 
 vi.mock("widgets/widgets", () => ({
-  default: {
-    archisteamfarm: {
-      api: "{url}/Api/{endpoint}",
-    },
-  },
+  default: widgets,
 }));
 
 import archisteamfarmProxyHandler from "./proxy";
@@ -42,13 +43,61 @@ describe("widgets/archisteamfarm/proxy", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     validateWidgetData.mockReturnValue(true);
+    widgets.archisteamfarm.api = "{url}/Api/{endpoint}";
+  });
+
+  it("returns 400 when the request is missing a group or service", async () => {
+    const res = createMockRes();
+
+    await archisteamfarmProxyHandler({ method: "GET", query: { endpoint: "ASF", index: "0" } }, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: "Invalid proxy service type" });
+  });
+
+  it("returns 403 when the resolved widget does not expose an API", async () => {
+    getServiceWidget.mockResolvedValue({
+      type: "archisteamfarm",
+      url: "https://asf.example.com",
+      password: "secret",
+    });
+
+    widgets.archisteamfarm.api = undefined;
+
+    const res = createMockRes();
+
+    await archisteamfarmProxyHandler(
+      { method: "GET", query: { group: "g", service: "svc", endpoint: "ASF", index: "0" } },
+      res,
+    );
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toEqual({ error: "Service does not support API calls" });
+  });
+
+  it("returns 400 when widget.password is missing", async () => {
+    getServiceWidget.mockResolvedValue({
+      type: "archisteamfarm",
+      url: "https://asf.example.com",
+      password: "   ",
+    });
+
+    const res = createMockRes();
+
+    await archisteamfarmProxyHandler(
+      { method: "GET", query: { group: "g", service: "svc", endpoint: "ASF", index: "0" } },
+      res,
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: { message: "ArchiSteamFarm widget requires widget.password." } });
   });
 
   it("adds the ASF authentication header and applies an optional mapping function", async () => {
     getServiceWidget.mockResolvedValue({
       type: "archisteamfarm",
       url: "https://asf.example.com",
-      password: "secret",
+      password: 123456,
     });
 
     httpProxy.mockResolvedValueOnce([
@@ -64,7 +113,7 @@ describe("widgets/archisteamfarm/proxy", () => {
 
     expect(httpProxy).toHaveBeenCalledTimes(1);
     expect(httpProxy.mock.calls[0][0].toString()).toBe("https://asf.example.com/Api/Bot/ASF");
-    expect(httpProxy.mock.calls[0][1].headers.Authentication).toBe("secret");
+    expect(httpProxy.mock.calls[0][1].headers.Authentication).toBe("123456");
     expect(validateWidgetData).toHaveBeenCalledWith(
       expect.objectContaining({ type: "archisteamfarm" }),
       "Bot/ASF",
@@ -93,6 +142,38 @@ describe("widgets/archisteamfarm/proxy", () => {
     expect(res.body.error.message).toBe("Invalid data");
   });
 
+  it("logs upstream HTTP errors and sanitizes the returned URL", async () => {
+    getServiceWidget.mockResolvedValue({
+      type: "archisteamfarm",
+      url: "https://asf.example.com",
+      password: "secret",
+    });
+
+    httpProxy.mockResolvedValueOnce([
+      502,
+      "application/json",
+      { error: { message: "down", url: "https://example.com/raw?token=secret" } },
+    ]);
+
+    const req = { method: "GET", query: { group: "g", service: "svc", endpoint: "ASF?token=secret", index: "0" } };
+    const res = createMockRes();
+
+    await archisteamfarmProxyHandler(req, res);
+
+    expect(logger.error).toHaveBeenCalledWith(
+      "HTTP Error %d calling %s",
+      502,
+      "https://asf.example.com/Api/ASF?token=secret",
+    );
+    expect(res.statusCode).toBe(502);
+    expect(res.body).toEqual({
+      error: {
+        message: "down",
+        url: "https://asf.example.com/Api/ASF?token=***",
+      },
+    });
+  });
+
   it("ends the response for 204 responses", async () => {
     getServiceWidget.mockResolvedValue({
       type: "archisteamfarm",
@@ -108,5 +189,24 @@ describe("widgets/archisteamfarm/proxy", () => {
 
     expect(res.statusCode).toBe(204);
     expect(res.end).toHaveBeenCalled();
+  });
+
+  it("sets the content type only when one is returned", async () => {
+    getServiceWidget.mockResolvedValue({
+      type: "archisteamfarm",
+      url: "https://asf.example.com",
+      password: "secret",
+    });
+    httpProxy.mockResolvedValueOnce([200, undefined, Buffer.from(JSON.stringify({ Result: { a: {} } }))]);
+
+    const res = createMockRes();
+
+    await archisteamfarmProxyHandler(
+      { method: "GET", query: { group: "g", service: "svc", endpoint: "Bot/ASF", index: "0" } },
+      res,
+    );
+
+    expect(res.setHeader).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(200);
   });
 });

--- a/src/widgets/archisteamfarm/proxy.test.js
+++ b/src/widgets/archisteamfarm/proxy.test.js
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import createMockRes from "test-utils/create-mock-res";
+
+const { httpProxy, getServiceWidget, validateWidgetData, logger } = vi.hoisted(() => ({
+  httpProxy: vi.fn(),
+  getServiceWidget: vi.fn(),
+  validateWidgetData: vi.fn(() => true),
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("utils/logger", () => ({
+  default: () => logger,
+}));
+
+vi.mock("utils/config/service-helpers", () => ({
+  default: getServiceWidget,
+}));
+
+vi.mock("utils/proxy/http", () => ({
+  httpProxy,
+}));
+
+vi.mock("utils/proxy/validate-widget-data", () => ({
+  default: validateWidgetData,
+}));
+
+vi.mock("widgets/widgets", () => ({
+  default: {
+    archisteamfarm: {
+      api: "{url}/Api/{endpoint}",
+    },
+  },
+}));
+
+import archisteamfarmProxyHandler from "./proxy";
+
+describe("widgets/archisteamfarm/proxy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    validateWidgetData.mockReturnValue(true);
+  });
+
+  it("adds the ASF authentication header and applies an optional mapping function", async () => {
+    getServiceWidget.mockResolvedValue({
+      type: "archisteamfarm",
+      url: "https://asf.example.com",
+      password: "secret",
+    });
+
+    httpProxy.mockResolvedValueOnce([
+      200,
+      "application/json",
+      Buffer.from(JSON.stringify({ Result: { a: {}, b: {} } })),
+    ]);
+
+    const req = { method: "GET", query: { group: "g", service: "svc", endpoint: "Bot/ASF", index: "0" } };
+    const res = createMockRes();
+
+    await archisteamfarmProxyHandler(req, res, () => ({ count: 2 }));
+
+    expect(httpProxy).toHaveBeenCalledTimes(1);
+    expect(httpProxy.mock.calls[0][0].toString()).toBe("https://asf.example.com/Api/Bot/ASF");
+    expect(httpProxy.mock.calls[0][1].headers.Authentication).toBe("secret");
+    expect(validateWidgetData).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "archisteamfarm" }),
+      "Bot/ASF",
+      expect.any(Buffer),
+    );
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ count: 2 });
+    expect(res.setHeader).toHaveBeenCalledWith("Content-Type", "application/json");
+  });
+
+  it("returns 500 when data validation fails", async () => {
+    validateWidgetData.mockReturnValue(false);
+    getServiceWidget.mockResolvedValue({
+      type: "archisteamfarm",
+      url: "https://asf.example.com",
+      password: "secret",
+    });
+    httpProxy.mockResolvedValueOnce([200, "application/json", Buffer.from(JSON.stringify({ nope: true }))]);
+
+    const req = { method: "GET", query: { group: "g", service: "svc", endpoint: "ASF", index: "0" } };
+    const res = createMockRes();
+
+    await archisteamfarmProxyHandler(req, res);
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body.error.message).toBe("Invalid data");
+  });
+
+  it("ends the response for 204 responses", async () => {
+    getServiceWidget.mockResolvedValue({
+      type: "archisteamfarm",
+      url: "https://asf.example.com",
+      password: "secret",
+    });
+    httpProxy.mockResolvedValueOnce([204, "application/json", {}]);
+
+    const req = { method: "GET", query: { group: "g", service: "svc", endpoint: "ASF", index: "0" } };
+    const res = createMockRes();
+
+    await archisteamfarmProxyHandler(req, res);
+
+    expect(res.statusCode).toBe(204);
+    expect(res.end).toHaveBeenCalled();
+  });
+});

--- a/src/widgets/archisteamfarm/widget.js
+++ b/src/widgets/archisteamfarm/widget.js
@@ -1,0 +1,33 @@
+import { asJson } from "utils/proxy/api-helpers";
+
+import archisteamfarmProxyHandler from "./proxy";
+
+const widget = {
+  api: "{url}/Api/{endpoint}",
+  proxyHandler: archisteamfarmProxyHandler,
+
+  mappings: {
+    bots: {
+      endpoint: "Bot/ASF",
+      validate: ["Result"],
+      map: (data) => ({
+        count: Object.keys(asJson(data).Result ?? {}).length,
+      }),
+    },
+    stats: {
+      endpoint: "ASF",
+      validate: ["Result"],
+      map: (data) => {
+        const result = asJson(data).Result ?? {};
+
+        return {
+          version: result.Version,
+          memoryKiB: Number.isFinite(result.MemoryUsage) ? result.MemoryUsage : Number(result.MemoryUsage ?? NaN),
+          processStartTime: result.ProcessStartTime,
+        };
+      },
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/archisteamfarm/widget.js
+++ b/src/widgets/archisteamfarm/widget.js
@@ -1,5 +1,4 @@
 import { asJson } from "utils/proxy/api-helpers";
-
 import archisteamfarmProxyHandler from "./proxy";
 
 const widget = {

--- a/src/widgets/archisteamfarm/widget.js
+++ b/src/widgets/archisteamfarm/widget.js
@@ -1,5 +1,6 @@
-import { asJson } from "utils/proxy/api-helpers";
 import archisteamfarmProxyHandler from "./proxy";
+
+import { asJson } from "utils/proxy/api-helpers";
 
 const widget = {
   api: "{url}/Api/{endpoint}",

--- a/src/widgets/archisteamfarm/widget.test.js
+++ b/src/widgets/archisteamfarm/widget.test.js
@@ -1,4 +1,4 @@
-import { describe, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { expectWidgetConfigShape } from "test-utils/widget-config";
 
@@ -7,5 +7,39 @@ import widget from "./widget";
 describe("archisteamfarm widget config", () => {
   it("exports a valid widget config", () => {
     expectWidgetConfigShape(widget);
+  });
+
+  it("maps bot and stats responses into widget values", () => {
+    expect(widget.mappings.bots.map(Buffer.from(JSON.stringify({ Result: { alpha: {}, beta: {} } })))).toEqual({
+      count: 2,
+    });
+
+    expect(
+      widget.mappings.stats.map(
+        Buffer.from(
+          JSON.stringify({
+            Result: {
+              Version: "6.3.4.2",
+              MemoryUsage: "24865",
+              ProcessStartTime: "2026-04-25T15:19:32.210Z",
+            },
+          }),
+        ),
+      ),
+    ).toEqual({
+      version: "6.3.4.2",
+      memoryKiB: 24865,
+      processStartTime: "2026-04-25T15:19:32.210Z",
+    });
+  });
+
+  it("handles missing ASF result fields", () => {
+    expect(widget.mappings.bots.map(Buffer.from(JSON.stringify({ nope: true })))).toEqual({ count: 0 });
+
+    expect(widget.mappings.stats.map(Buffer.from(JSON.stringify({ Result: {} })))).toEqual({
+      version: undefined,
+      memoryKiB: Number.NaN,
+      processStartTime: undefined,
+    });
   });
 });

--- a/src/widgets/archisteamfarm/widget.test.js
+++ b/src/widgets/archisteamfarm/widget.test.js
@@ -1,0 +1,11 @@
+import { describe, it } from "vitest";
+
+import { expectWidgetConfigShape } from "test-utils/widget-config";
+
+import widget from "./widget";
+
+describe("archisteamfarm widget config", () => {
+  it("exports a valid widget config", () => {
+    expectWidgetConfigShape(widget);
+  });
+});

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -4,6 +4,7 @@ const components = {
   adguard: dynamic(() => import("./adguard/component")),
   apcups: dynamic(() => import("./apcups/component")),
   arcane: dynamic(() => import("./arcane/component")),
+  archisteamfarm: dynamic(() => import("./archisteamfarm/component")),
   argocd: dynamic(() => import("./argocd/component")),
   atsumeru: dynamic(() => import("./atsumeru/component")),
   audiobookshelf: dynamic(() => import("./audiobookshelf/component")),

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -1,6 +1,7 @@
 import adguard from "./adguard/widget";
 import apcups from "./apcups/widget";
 import arcane from "./arcane/widget";
+import archisteamfarm from "./archisteamfarm/widget";
 import argocd from "./argocd/widget";
 import atsumeru from "./atsumeru/widget";
 import audiobookshelf from "./audiobookshelf/widget";
@@ -156,6 +157,7 @@ const widgets = {
   adguard,
   apcups,
   arcane,
+  archisteamfarm,
   argocd,
   atsumeru,
   audiobookshelf,


### PR DESCRIPTION
<!--
==== STOP ====================
======== STOP ================
============ STOP ============
================ STOP ========
==================== STOP ====

⚠️ Before opening this pull request please review the guidelines in the checklist below.

If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.
-->

## Proposed change

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

This PR adds a native `archisteamfarm` service widget backed by the ASF IPC API. It exposes the ASF information that is usually more useful on a Homepage service card:

- bot count
- ASF version
- process memory usage
- process uptime

<img width="683" height="196" alt="5aef24e82a26acb903bcd830229b1393" src="https://github.com/user-attachments/assets/0a296884-9b76-48f9-9c60-e0c0302fb349" />


## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [x] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] In the description above I have disclosed the use of AI tools in the coding of this PR.
