### PR TITLE
Feature: ntfy widget

### DIFF
--- a/docs/widgets/services/ntfy.md
+++ b/docs/widgets/services/ntfy.md
@@ -1,0 +1,36 @@
+---
+title: ntfy
+description: ntfy Widget Configuration
+---
+
+Learn more about [ntfy](https://github.com/binwiederhier/ntfy).
+
+This widget shows the latest notification for a ntfy topic, including the title or body, priority level, and when it was received. Works with both self-hosted ntfy instances and the public [ntfy.sh](https://ntfy.sh) service.
+
+Allowed fields: `["title", "message", "priority", "lastReceived", "tags"]`.
+
+Default fields: `["title", "message", "priority", "lastReceived"]`.
+
+If more than 4 fields are provided, only the first 4 are displayed.
+
+## Authentication
+
+ntfy supports both public and private topics. For private instances or access-controlled topics, you can authenticate using either a **Bearer token** (ntfy access token) or **Basic auth** (username/password).
+
+| Auth Method  | Config Fields                  | Notes                             |
+| ------------ | ------------------------------ | --------------------------------- |
+| None         | _(omit key/username/password)_ | For public topics                 |
+| Bearer token | `key`                          | ntfy access tokens (`tk_` prefix) |
+| Basic auth   | `username` + `password`        | Username/password credentials     |
+
+See the [ntfy documentation](https://docs.ntfy.sh/config/#access-control) for details on access control.
+
+```yaml
+widget:
+  type: ntfy
+  url: http://ntfy.host.or.ip:port # required
+  topic: mytopic # required
+  # key: tk_accesstoken # optional — for token auth
+  # username: user # optional — for basic auth
+  # password: pass # optional — for basic auth
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,6 +116,7 @@ nav:
           - widgets/services/nextcloud.md
           - widgets/services/nextdns.md
           - widgets/services/nginx-proxy-manager.md
+          - widgets/services/ntfy.md
           - widgets/services/nzbget.md
           - widgets/services/octoprint.md
           - widgets/services/omada.md

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -942,7 +942,6 @@
       "lastReceived": "Last Received",
       "message": "Message",
       "tags": "Tags",
-      "noMessages": "None",
       "none": "None",
       "min": "Min",
       "low": "Low",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -936,6 +936,20 @@
       "warnings": "Warnings",
       "criticals": "Criticals"
     },
+    "ntfy": {
+      "title": "Title",
+      "priority": "Priority",
+      "lastReceived": "Last Received",
+      "message": "Message",
+      "tags": "Tags",
+      "noMessages": "None",
+      "none": "None",
+      "min": "Min",
+      "low": "Low",
+      "default": "Default",
+      "high": "High",
+      "urgent": "Urgent"
+    },
     "plantit": {
         "events": "Events",
         "plants": "Plants",

--- a/src/utils/proxy/handlers/credentialed.js
+++ b/src/utils/proxy/handlers/credentialed.js
@@ -77,6 +77,12 @@ export default async function credentialedProxyHandler(req, res, map) {
         } else {
           headers.Authorization = basicAuthHeader(widget);
         }
+      } else if (widget.type === "ntfy") {
+        if (widget.key) {
+          headers.Authorization = `Bearer ${widget.key}`;
+        } else if (widget.username && widget.password) {
+          headers.Authorization = basicAuthHeader(widget);
+        }
       } else if (widget.type === "proxmox") {
         headers.Authorization = `PVEAPIToken=${widget.username}=${widget.password}`;
       } else if (widget.type === "proxmoxbackupserver") {

--- a/src/utils/proxy/handlers/credentialed.test.js
+++ b/src/utils/proxy/handlers/credentialed.test.js
@@ -34,6 +34,7 @@ vi.mock("widgets/widgets", () => ({
     paperlessngx: { api: "{url}/api/{endpoint}" },
     proxmox: { api: "{url}/api2/json/{endpoint}" },
     truenas: { api: "{url}/api/v2.0/{endpoint}" },
+    ntfy: { api: "{url}/{endpoint}" },
     proxmoxbackupserver: { api: "{url}/api2/json/{endpoint}" },
     checkmk: { api: "{url}/{endpoint}" },
     stocks: { api: "{url}/{endpoint}" },
@@ -183,6 +184,51 @@ describe("utils/proxy/handlers/credentialed", () => {
 
     const [, params] = httpProxy.mock.calls.at(-1);
     expect(params.headers.Authorization).toBe("Bearer k");
+  });
+
+  it("uses Bearer auth for ntfy when key is provided", async () => {
+    getServiceWidget.mockResolvedValue({ type: "ntfy", url: "http://ntfy", topic: "alerts", key: "tk_test" });
+    httpProxy.mockResolvedValue([200, "application/json", { ok: true }]);
+
+    const req = { method: "GET", query: { group: "g", service: "s", endpoint: "alerts/json", index: 0 } };
+    const res = createMockRes();
+
+    await credentialedProxyHandler(req, res);
+
+    const [, params] = httpProxy.mock.calls.at(-1);
+    expect(params.headers.Authorization).toBe("Bearer tk_test");
+  });
+
+  it("uses Basic auth for ntfy when username/password are provided", async () => {
+    getServiceWidget.mockResolvedValue({
+      type: "ntfy",
+      url: "http://ntfy",
+      topic: "alerts",
+      username: "u",
+      password: "p",
+    });
+    httpProxy.mockResolvedValue([200, "application/json", { ok: true }]);
+
+    const req = { method: "GET", query: { group: "g", service: "s", endpoint: "alerts/json", index: 0 } };
+    const res = createMockRes();
+
+    await credentialedProxyHandler(req, res);
+
+    const [, params] = httpProxy.mock.calls.at(-1);
+    expect(params.headers.Authorization).toMatch(/^Basic /);
+  });
+
+  it("sends no auth header for ntfy when no credentials are configured", async () => {
+    getServiceWidget.mockResolvedValue({ type: "ntfy", url: "http://ntfy", topic: "alerts" });
+    httpProxy.mockResolvedValue([200, "application/json", { ok: true }]);
+
+    const req = { method: "GET", query: { group: "g", service: "s", endpoint: "alerts/json", index: 0 } };
+    const res = createMockRes();
+
+    await credentialedProxyHandler(req, res);
+
+    const [, params] = httpProxy.mock.calls.at(-1);
+    expect(params.headers.Authorization).toBeUndefined();
   });
 
   it.each([

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -91,6 +91,7 @@ const components = {
   nextcloud: dynamic(() => import("./nextcloud/component")),
   nextdns: dynamic(() => import("./nextdns/component")),
   npm: dynamic(() => import("./npm/component")),
+  ntfy: dynamic(() => import("./ntfy/component")),
   nzbget: dynamic(() => import("./nzbget/component")),
   octoprint: dynamic(() => import("./octoprint/component")),
   omada: dynamic(() => import("./omada/component")),

--- a/src/widgets/ntfy/component.jsx
+++ b/src/widgets/ntfy/component.jsx
@@ -32,39 +32,32 @@ export default function Component({ service }) {
 
   if (!widget.fields || widget.fields.length === 0) {
     widget.fields = ["title", "message", "priority", "lastReceived"];
-  } else if (widget.fields.length > 4) {
+  } else if (widget.fields?.length > 4) {
     widget.fields = widget.fields.slice(0, 4);
   }
 
   if (!messagesData) {
     return (
       <Container service={service}>
-        {widget.fields.map((field) => (
-          <Block key={field} label={`ntfy.${field}`} />
-        ))}
+        <Block label="ntfy.title" />
+        <Block label="ntfy.message" />
+        <Block label="ntfy.priority" />
+        <Block label="ntfy.lastReceived" />
+        <Block label="ntfy.tags" />
       </Container>
     );
   }
 
-  const titleText = messagesData.title ?? t("ntfy.none");
-  const messageText = messagesData.message ?? t("ntfy.noMessages");
-  const tagsText = messagesData.tags?.length > 0 ? messagesData.tags.join(", ") : t("ntfy.none");
-
-  const fieldValues = {
-    title: <Truncated text={titleText} />,
-    message: <Truncated text={messageText} />,
-    priority: t(`ntfy.${priorityLabels[messagesData.priority] ?? "default"}`),
-    lastReceived: messagesData.time
-      ? t("common.relativeDate", { value: messagesData.time * 1000 })
-      : t("ntfy.noMessages"),
-    tags: <Truncated text={tagsText} />,
-  };
-
   return (
     <Container service={service}>
-      {widget.fields.map((field) => (
-        <Block key={field} label={`ntfy.${field}`} value={fieldValues[field]} />
-      ))}
+      <Block label="ntfy.title" value={<Truncated text={messagesData.title ?? t("ntfy.none")} />} />
+      <Block label="ntfy.message" value={<Truncated text={messagesData.message ?? t("ntfy.none")} />} />
+      <Block label="ntfy.priority" value={t(`ntfy.${priorityLabels[messagesData.priority] ?? "default"}`)} />
+      <Block
+        label="ntfy.lastReceived"
+        value={messagesData.time ? t("common.relativeDate", { value: messagesData.time * 1000 }) : t("ntfy.none")}
+      />
+      <Block label="ntfy.tags" value={messagesData.tags?.length > 0 ? messagesData.tags.join(", ") : t("ntfy.none")} />
     </Container>
   );
 }

--- a/src/widgets/ntfy/component.jsx
+++ b/src/widgets/ntfy/component.jsx
@@ -1,0 +1,58 @@
+import Block from "components/services/widget/block";
+import Container from "components/services/widget/container";
+import { useTranslation } from "next-i18next";
+
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+const priorityLabels = {
+  1: "min",
+  2: "low",
+  3: "default",
+  4: "high",
+  5: "urgent",
+};
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+  const { widget } = service;
+
+  const { data: messagesData, error: messagesError } = useWidgetAPI(widget, "messages");
+
+  if (messagesError) {
+    return <Container service={service} error={messagesError} />;
+  }
+
+  if (!widget.fields || widget.fields.length === 0) {
+    widget.fields = ["title", "message", "priority", "lastReceived"];
+  } else if (widget.fields.length > 4) {
+    widget.fields = widget.fields.slice(0, 4);
+  }
+
+  if (!messagesData) {
+    return (
+      <Container service={service}>
+        {widget.fields.map((field) => (
+          <Block key={field} label={`ntfy.${field}`} />
+        ))}
+      </Container>
+    );
+  }
+
+  const fieldValues = {
+    title: messagesData.title ?? t("ntfy.none"),
+    message: messagesData.message ?? t("ntfy.noMessages"),
+    priority: t(`ntfy.${priorityLabels[messagesData.priority] ?? "default"}`),
+    lastReceived: messagesData.time
+      ? t("common.relativeDate", { value: messagesData.time * 1000 })
+      : t("ntfy.noMessages"),
+    tags: messagesData.tags?.length > 0 ? messagesData.tags.join(", ") : t("ntfy.none"),
+  };
+
+  return (
+    <Container service={service}>
+      {widget.fields.map((field) => (
+        <Block key={field} label={`ntfy.${field}`} value={fieldValues[field]} />
+      ))}
+    </Container>
+  );
+}

--- a/src/widgets/ntfy/component.jsx
+++ b/src/widgets/ntfy/component.jsx
@@ -12,6 +12,14 @@ const priorityLabels = {
   5: "urgent",
 };
 
+function Truncated({ text }) {
+  return (
+    <span className="grid w-full" title={text}>
+      <span className="truncate">{text}</span>
+    </span>
+  );
+}
+
 export default function Component({ service }) {
   const { t } = useTranslation();
   const { widget } = service;
@@ -38,14 +46,18 @@ export default function Component({ service }) {
     );
   }
 
+  const titleText = messagesData.title ?? t("ntfy.none");
+  const messageText = messagesData.message ?? t("ntfy.noMessages");
+  const tagsText = messagesData.tags?.length > 0 ? messagesData.tags.join(", ") : t("ntfy.none");
+
   const fieldValues = {
-    title: messagesData.title ?? t("ntfy.none"),
-    message: messagesData.message ?? t("ntfy.noMessages"),
+    title: <Truncated text={titleText} />,
+    message: <Truncated text={messageText} />,
     priority: t(`ntfy.${priorityLabels[messagesData.priority] ?? "default"}`),
     lastReceived: messagesData.time
       ? t("common.relativeDate", { value: messagesData.time * 1000 })
       : t("ntfy.noMessages"),
-    tags: messagesData.tags?.length > 0 ? messagesData.tags.join(", ") : t("ntfy.none"),
+    tags: <Truncated text={tagsText} />,
   };
 
   return (

--- a/src/widgets/ntfy/component.test.jsx
+++ b/src/widgets/ntfy/component.test.jsx
@@ -167,6 +167,26 @@ describe("widgets/ntfy/component", () => {
     expect(container.querySelectorAll(".service-block")).toHaveLength(4);
   });
 
+  it("falls back to default priority label when priority is out of range", () => {
+    useWidgetAPI.mockImplementation(() => ({
+      data: {
+        title: "Alert",
+        message: "Body",
+        priority: 99,
+        time: 1700000000,
+        tags: [],
+      },
+      error: undefined,
+    }));
+
+    const { container } = renderWithProviders(
+      <Component service={{ widget: { type: "ntfy", url: "https://ntfy.example.com", topic: "alerts" } }} />,
+      { settings: { hideErrors: false } },
+    );
+
+    expectBlockValue(container, "ntfy.priority", "ntfy.default");
+  });
+
   it("renders optional message field when included", () => {
     useWidgetAPI.mockImplementation(() => ({
       data: {

--- a/src/widgets/ntfy/component.test.jsx
+++ b/src/widgets/ntfy/component.test.jsx
@@ -96,8 +96,8 @@ describe("widgets/ntfy/component", () => {
     );
 
     expectBlockValue(container, "ntfy.title", "ntfy.none");
-    expectBlockValue(container, "ntfy.message", "ntfy.noMessages");
-    expectBlockValue(container, "ntfy.lastReceived", "ntfy.noMessages");
+    expectBlockValue(container, "ntfy.message", "ntfy.none");
+    expectBlockValue(container, "ntfy.lastReceived", "ntfy.none");
   });
 
   it("renders error when API fails", () => {

--- a/src/widgets/ntfy/component.test.jsx
+++ b/src/widgets/ntfy/component.test.jsx
@@ -1,0 +1,196 @@
+// @vitest-environment jsdom
+
+import { screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "test-utils/render-with-providers";
+import { expectBlockValue } from "test-utils/widget-assertions";
+
+const { useWidgetAPI } = vi.hoisted(() => ({ useWidgetAPI: vi.fn() }));
+
+vi.mock("utils/proxy/use-widget-api", () => ({
+  default: useWidgetAPI,
+}));
+
+import Component from "./component";
+
+describe("widgets/ntfy/component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders placeholders while loading", () => {
+    useWidgetAPI.mockImplementation(() => ({ data: undefined, error: undefined }));
+
+    const { container } = renderWithProviders(<Component service={{ widget: { type: "ntfy" } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expect(container.querySelectorAll(".service-block")).toHaveLength(4);
+    expect(screen.getByText("ntfy.title")).toBeInTheDocument();
+    expect(screen.getByText("ntfy.message")).toBeInTheDocument();
+    expect(screen.getByText("ntfy.priority")).toBeInTheDocument();
+    expect(screen.getByText("ntfy.lastReceived")).toBeInTheDocument();
+  });
+
+  it("renders message data with default fields", () => {
+    useWidgetAPI.mockImplementation(() => ({
+      data: {
+        title: "Disk Alert",
+        message: "Disk usage at 90%",
+        priority: 4,
+        time: 1700000000,
+        tags: ["warning"],
+      },
+      error: undefined,
+    }));
+
+    const { container } = renderWithProviders(
+      <Component service={{ widget: { type: "ntfy", url: "https://ntfy.example.com", topic: "alerts" } }} />,
+      { settings: { hideErrors: false } },
+    );
+
+    expect(container.querySelectorAll(".service-block")).toHaveLength(4);
+    expectBlockValue(container, "ntfy.title", "Disk Alert");
+    expectBlockValue(container, "ntfy.message", "Disk usage at 90%");
+    expectBlockValue(container, "ntfy.priority", "ntfy.high");
+  });
+
+  it("shows placeholder for title when message has no title set", () => {
+    useWidgetAPI.mockImplementation(() => ({
+      data: {
+        title: null,
+        message: "Simple notification",
+        priority: 3,
+        time: 1700000000,
+        tags: [],
+      },
+      error: undefined,
+    }));
+
+    const { container } = renderWithProviders(
+      <Component service={{ widget: { type: "ntfy", url: "https://ntfy.example.com", topic: "alerts" } }} />,
+      { settings: { hideErrors: false } },
+    );
+
+    expectBlockValue(container, "ntfy.title", "ntfy.none");
+    expectBlockValue(container, "ntfy.message", "Simple notification");
+    expectBlockValue(container, "ntfy.priority", "ntfy.default");
+  });
+
+  it("renders no messages state", () => {
+    useWidgetAPI.mockImplementation(() => ({
+      data: {
+        title: null,
+        message: null,
+        priority: 3,
+        time: null,
+        tags: [],
+      },
+      error: undefined,
+    }));
+
+    const { container } = renderWithProviders(
+      <Component service={{ widget: { type: "ntfy", url: "https://ntfy.example.com", topic: "alerts" } }} />,
+      { settings: { hideErrors: false } },
+    );
+
+    expectBlockValue(container, "ntfy.title", "ntfy.none");
+    expectBlockValue(container, "ntfy.message", "ntfy.noMessages");
+    expectBlockValue(container, "ntfy.lastReceived", "ntfy.noMessages");
+  });
+
+  it("renders error when API fails", () => {
+    useWidgetAPI.mockImplementation(() => ({
+      data: undefined,
+      error: { message: "Request failed" },
+    }));
+
+    renderWithProviders(
+      <Component service={{ widget: { type: "ntfy", url: "https://ntfy.example.com", topic: "alerts" } }} />,
+      { settings: { hideErrors: false } },
+    );
+
+    expect(screen.getByText("Request failed")).toBeInTheDocument();
+  });
+
+  it("renders optional tags field when included", () => {
+    useWidgetAPI.mockImplementation(() => ({
+      data: {
+        title: "Alert",
+        message: "Test",
+        priority: 5,
+        time: 1700000000,
+        tags: ["warning", "skull"],
+      },
+      error: undefined,
+    }));
+
+    const service = {
+      widget: {
+        type: "ntfy",
+        url: "https://ntfy.example.com",
+        topic: "alerts",
+        fields: ["title", "priority", "lastReceived", "tags"],
+      },
+    };
+
+    const { container } = renderWithProviders(<Component service={service} />, { settings: { hideErrors: false } });
+
+    expectBlockValue(container, "ntfy.tags", "warning, skull");
+    expectBlockValue(container, "ntfy.priority", "ntfy.urgent");
+  });
+
+  it("caps visible blocks at 4 when more than 4 fields are configured", () => {
+    useWidgetAPI.mockImplementation(() => ({
+      data: {
+        title: "Alert",
+        message: "Body",
+        priority: 3,
+        time: 1700000000,
+        tags: ["a"],
+      },
+      error: undefined,
+    }));
+
+    const service = {
+      widget: {
+        type: "ntfy",
+        url: "https://ntfy.example.com",
+        topic: "alerts",
+        fields: ["title", "message", "priority", "lastReceived", "tags"],
+      },
+    };
+
+    const { container } = renderWithProviders(<Component service={service} />, { settings: { hideErrors: false } });
+
+    expect(container.querySelectorAll(".service-block")).toHaveLength(4);
+  });
+
+  it("renders optional message field when included", () => {
+    useWidgetAPI.mockImplementation(() => ({
+      data: {
+        title: "Disk Alert",
+        message: "Disk usage at 90%",
+        priority: 4,
+        time: 1700000000,
+        tags: [],
+      },
+      error: undefined,
+    }));
+
+    const service = {
+      widget: {
+        type: "ntfy",
+        url: "https://ntfy.example.com",
+        topic: "alerts",
+        fields: ["title", "priority", "message"],
+      },
+    };
+
+    const { container } = renderWithProviders(<Component service={service} />, { settings: { hideErrors: false } });
+
+    expectBlockValue(container, "ntfy.title", "Disk Alert");
+    expectBlockValue(container, "ntfy.message", "Disk usage at 90%");
+  });
+});

--- a/src/widgets/ntfy/widget.js
+++ b/src/widgets/ntfy/widget.js
@@ -1,0 +1,14 @@
+import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
+
+const widget = {
+  api: "{url}/{endpoint}",
+  proxyHandler: credentialedProxyHandler,
+
+  mappings: {
+    messages: {
+      endpoint: "{topic}/json?poll=1&since=latest",
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/ntfy/widget.test.js
+++ b/src/widgets/ntfy/widget.test.js
@@ -1,0 +1,11 @@
+import { describe, it } from "vitest";
+
+import { expectWidgetConfigShape } from "test-utils/widget-config";
+
+import widget from "./widget";
+
+describe("ntfy widget config", () => {
+  it("exports a valid widget config", () => {
+    expectWidgetConfigShape(widget);
+  });
+});

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -82,6 +82,7 @@ import netdata from "./netdata/widget";
 import nextcloud from "./nextcloud/widget";
 import nextdns from "./nextdns/widget";
 import npm from "./npm/widget";
+import ntfy from "./ntfy/widget";
 import nzbget from "./nzbget/widget";
 import octoprint from "./octoprint/widget";
 import omada from "./omada/widget";
@@ -239,6 +240,7 @@ const widgets = {
   nextcloud,
   nextdns,
   npm,
+  ntfy,
   nzbget,
   octoprint,
   omada,


### PR DESCRIPTION
## Proposed change

Adds a new `ntfy` service widget that displays the latest notification from a configured topic. Works with both self-hosted ntfy instances and the public `ntfy.sh` service.

The widget polls ntfy's JSON subscribe endpoint with `poll=1&since=latest`, so each refresh is a single, finite, read-only request that returns just the most recent cached message. There is no attempt to track unread state, since ntfy read state is client-side.

Related discussion: <https://github.com/gethomepage/homepage/discussions/4392>

**Fields**

- Allowed: `["title", "message", "priority", "lastReceived", "tags"]`
- Default: `["title", "message", "priority", "lastReceived"]`
- If more than 4 fields are configured, only the first 4 are shown.

**Authentication**

- None (omit credentials) for public topics
- Bearer token via `key` (ntfy access tokens with the `tk_` prefix)
- Basic auth via `username` + `password`

The widget reuses the existing `credentialedProxyHandler` with a small ntfy auth block following the standard pattern (none / Bearer / Basic). No custom proxy handler is introduced.

**Example ntfy API response** (`GET /{topic}/json?poll=1&since=latest`):

```json
{
  "id": "def",
  "time": 1700001000,
  "event": "message",
  "topic": "alerts",
  "title": "Disk Alert",
  "message": "Disk usage at 90%",
  "priority": 4,
  "tags": ["warning"]
}
```

**Example widget configuration**

```yaml
widget:
  type: ntfy
  url: http://ntfy.host.or.ip:port
  topic: mytopic
  # key: tk_accesstoken         # optional — Bearer token auth
  # username: user              # optional — Basic auth
  # password: pass              # optional — Basic auth
  # fields: ["title", "message", "priority", "lastReceived"]   # optional
```

**AI Disclosure**

GitHub Copilot was used to aid development, including scaffolding, test coverage, and review passes.

**Screenshot**

<img width="995" height="214" alt="image" src="https://github.com/user-attachments/assets/38cd411c-ed98-4aed-8dd0-350e5d1dbc82" />

_Widget showing the latest message from a self-hosted ntfy topic with title, message, priority, and last received fields._

## Type of change

- [x] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] In the description above I have disclosed the use of AI tools in the coding of this PR.