### PR TITLE
Add support for Grimmory, community fork of Booklore

### DIFF
--- a/docs/widgets/services/grimmory.md
+++ b/docs/widgets/services/grimmory.md
@@ -1,0 +1,16 @@
+---
+title: Grimmory
+description: Grimmory Widget Configuration
+---
+
+Learn more about [Grimmory](https://github.com/grimmory-tools/grimmory/).
+
+The widget authenticates with your Grimmory credentials to surface total libraries, books, and reading progress counts for your account.
+
+```yaml
+widget:
+  type: grimmory
+  url: https://grimmory.host.or.ip
+  username: username
+  password: password
+```

--- a/docs/widgets/services/index.md
+++ b/docs/widgets/services/index.md
@@ -55,6 +55,7 @@ You can also find a list of all available service widgets in the sidebar navigat
 - [Gluetun](gluetun.md)
 - [Gotify](gotify.md)
 - [Grafana](grafana.md)
+- [Grimmory](grimmory.md)
 - [HDHomeRun](hdhomerun.md)
 - [Headscale](headscale.md)
 - [Healthchecks](healthchecks.md)

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -52,6 +52,7 @@ const components = {
   gluetun: dynamic(() => import("./gluetun/component")),
   gotify: dynamic(() => import("./gotify/component")),
   grafana: dynamic(() => import("./grafana/component")),
+  grimmory: dynamic(() => import("./booklore/component")),
   hdhomerun: dynamic(() => import("./hdhomerun/component")),
   headscale: dynamic(() => import("./headscale/component")),
   hoarder: dynamic(() => import("./karakeep/component")),

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -200,6 +200,7 @@ const widgets = {
   gluetun,
   gotify,
   grafana,
+  grimmory: booklore,
   hdhomerun,
   headscale,
   hoarder: karakeep,


### PR DESCRIPTION
## Proposed change

I'm adding references to Grimmory which is a community fork of Booklore an already supported widget, so as of now that means same code.
Icon is already available in selfh.st/icons and soon to be available in dashboard icons

Closes # (issue)

## Type of change

- [x] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [ ] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] In the description above I have disclosed the use of AI tools in the coding of this PR.
