### PR TITLE
Fix: allow empty data for ntfy widget

### DIFF
--- a/src/utils/proxy/validate-widget-data.js
+++ b/src/utils/proxy/validate-widget-data.js
@@ -8,6 +8,13 @@ export default function validateWidgetData(widget, endpoint, data) {
   let dataParsed = data;
   let error;
   let mapping;
+  const mappings = widgets[widget.type]?.mappings;
+  if (mappings) {
+    mapping = Object.values(mappings).find((m) => m.endpoint === endpoint);
+  }
+
+  if (mapping?.allowEmpty && Buffer.isBuffer(data) && data.length === 0) return true;
+
   if (Buffer.isBuffer(data)) {
     try {
       dataParsed = JSON.parse(data);
@@ -23,15 +30,11 @@ export default function validateWidgetData(widget, endpoint, data) {
   }
 
   if (dataParsed && Object.entries(dataParsed).length) {
-    const mappings = widgets[widget.type]?.mappings;
-    if (mappings) {
-      mapping = Object.values(mappings).find((m) => m.endpoint === endpoint);
-      mapping?.validate?.forEach((key) => {
-        if (dataParsed[key] === undefined) {
-          valid = false;
-        }
-      });
-    }
+    mapping?.validate?.forEach((key) => {
+      if (dataParsed[key] === undefined) {
+        valid = false;
+      }
+    });
   }
 
   if (!valid) {

--- a/src/utils/proxy/validate-widget-data.test.js
+++ b/src/utils/proxy/validate-widget-data.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { loggerError } = vi.hoisted(() => ({
   loggerError: vi.fn(),
@@ -18,6 +18,10 @@ vi.mock("widgets/widgets", () => ({
           endpoint: "foo",
           validate: ["a", "b"],
         },
+        empty: {
+          endpoint: "empty",
+          allowEmpty: true,
+        },
       },
     },
   },
@@ -26,6 +30,10 @@ vi.mock("widgets/widgets", () => ({
 import validateWidgetData from "./validate-widget-data";
 
 describe("utils/proxy/validate-widget-data", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("returns false when buffer JSON cannot be parsed", () => {
     expect(validateWidgetData({ type: "test" }, "foo", Buffer.from("not json"))).toBe(false);
     expect(loggerError).toHaveBeenCalled();
@@ -40,5 +48,10 @@ describe("utils/proxy/validate-widget-data", () => {
   it("returns false when required validate keys are missing", () => {
     expect(validateWidgetData({ type: "test" }, "foo", Buffer.from(JSON.stringify({ a: 1 })))).toBe(false);
     expect(loggerError).toHaveBeenCalled();
+  });
+
+  it("allows empty buffer responses for mappings that explicitly allow them", () => {
+    expect(validateWidgetData({ type: "test" }, "empty", Buffer.from(""))).toBe(true);
+    expect(loggerError).not.toHaveBeenCalled();
   });
 });

--- a/src/widgets/ntfy/widget.js
+++ b/src/widgets/ntfy/widget.js
@@ -1,4 +1,13 @@
+import { asJson } from "utils/proxy/api-helpers";
 import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
+
+const noMessages = {
+  title: null,
+  message: null,
+  priority: 3,
+  time: null,
+  tags: [],
+};
 
 const widget = {
   api: "{url}/{endpoint}",
@@ -7,6 +16,14 @@ const widget = {
   mappings: {
     messages: {
       endpoint: "{topic}/json?poll=1&since=latest",
+      allowEmpty: true,
+      map: (data) => {
+        if (Buffer.isBuffer(data) && data.length === 0) {
+          return noMessages;
+        }
+
+        return asJson(data);
+      },
     },
   },
 };

--- a/src/widgets/ntfy/widget.test.js
+++ b/src/widgets/ntfy/widget.test.js
@@ -1,4 +1,4 @@
-import { describe, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { expectWidgetConfigShape } from "test-utils/widget-config";
 
@@ -7,5 +7,19 @@ import widget from "./widget";
 describe("ntfy widget config", () => {
   it("exports a valid widget config", () => {
     expectWidgetConfigShape(widget);
+  });
+
+  it("maps an empty latest message response to the no messages state", () => {
+    expect(widget.mappings.messages.map(Buffer.from(""))).toEqual({
+      title: null,
+      message: null,
+      priority: 3,
+      time: null,
+      tags: [],
+    });
+  });
+
+  it("parses latest message responses", () => {
+    expect(widget.mappings.messages.map(Buffer.from('{"message":"hello"}'))).toEqual({ message: "hello" });
   });
 });


### PR DESCRIPTION
<!--
==== STOP ====================
======== STOP ================
============ STOP ============
================ STOP ========
==================== STOP ====

⚠️ Before opening this pull request please review the guidelines in the checklist below.

If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.
-->

## Proposed change

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

Closes #6649

<img width="322" height="146" alt="Screenshot 2026-05-10 at 7 04 24 AM" src="https://github.com/user-attachments/assets/357c5bbd-a2e7-4c2d-9a41-ef728dc555d5" />

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [ ] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] In the description above I have disclosed the use of AI tools in the coding of this PR.
