### PR TITLE
Fix: whitelist query params for Proxmox Backup Server widget

### DIFF
--- a/src/widgets/proxmoxbackupserver/widget.js
+++ b/src/widgets/proxmoxbackupserver/widget.js
@@ -10,7 +10,7 @@ const widget = {
     },
     "nodes/localhost/tasks": {
       endpoint: "nodes/localhost/tasks",
-      params: ["errors","limit","since"],
+      params: ["errors", "limit", "since"],
     },
     "nodes/localhost/status": {
       endpoint: "nodes/localhost/status",

--- a/src/widgets/proxmoxbackupserver/widget.js
+++ b/src/widgets/proxmoxbackupserver/widget.js
@@ -10,6 +10,7 @@ const widget = {
     },
     "nodes/localhost/tasks": {
       endpoint: "nodes/localhost/tasks",
+      params: ["errors","limit","since"],
     },
     "nodes/localhost/status": {
       endpoint: "nodes/localhost/status",


### PR DESCRIPTION
<!--
==== STOP ====================
======== STOP ================
============ STOP ============
================ STOP ========
==================== STOP ====

⚠️ Before opening this pull request please review the guidelines in the checklist below.

If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.
-->

## Proposed change

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

This PR adds the query parameters "errors", "limit" and "since" to the metadata object for the tasks endpoint in `widget.js` - without this the params are not passed to the API, resulting in the output always being 51.

Closes #6648 

No AI used.

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] In the description above I have disclosed the use of AI tools in the coding of this PR.
