### PR TITLE
Fix: Seerr widget incorrectly injecting "available" field

### DIFF
--- a/src/widgets/seerr/component.jsx
+++ b/src/widgets/seerr/component.jsx
@@ -30,11 +30,12 @@ export default function Component({ service }) {
     );
   }
 
-  if (statsData.completed === undefined) {
-    // Newer versions added "completed", fallback to available
-    widget.fields = widget.fields.filter((field) => field !== "completed");
-    widget.fields.push("available");
-  }
+if (statsData.completed === undefined && widget.fields.includes("completed")) {
+  // Fallback to "available" if "completed" requested but not available
+  widget.fields = widget.fields.map((field) =>
+    field === "completed" ? "available" : field,
+  );
+}
 
   return (
     <Container service={service}>


### PR DESCRIPTION
## Proposed change

This fixes an issue where the Seerr/Jellyseerr widget injects the `available` field even when it was not requested in the widget configuration.

Previously, if the API response did not contain `completed`, the widget would mutate the configured field list by removing `completed` and appending `available`.

This caused configurations such as:

```yaml
fields:
  - pending
  - issues
```

to unexpectedly render an `Available` block.

This change limits the fallback behavior to only cases where the user explicitly requested `completed`.

**Disclosure: This patch was created with the use of ChatGPT**

## Type of change

- [ ] New service widget
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [X] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [X] In the description above I have disclosed the use of AI tools in the coding of this PR.