### PR TITLE
Feat/open all

### DIFF
--- a/src/components/services/group.jsx
+++ b/src/components/services/group.jsx
@@ -64,7 +64,7 @@ export default function ServicesGroup({
                     className="cursor-pointer bg-slate-500 rounded-md px-2 text-sm text-center"
                     onClick={openAll}
                   >
-                      Open All
+                    Open All
                   </span>
                   <MdKeyboardArrowDown
                     className={classNames(

--- a/src/components/services/group.jsx
+++ b/src/components/services/group.jsx
@@ -25,6 +25,15 @@ export default function ServicesGroup({
   let groupPadding = layout?.header === false ? "px-1" : "p-1 pb-0";
   if (isSubgroup) groupPadding = "";
 
+  const openAll = (e) => {
+    e.stopPropagation();
+    if (!panel.current) return;
+    const links = panel.current.querySelectorAll("a");
+    links.forEach((link) => {
+      window.open(link.href, "_blank", "noopener,noreferrer");
+    });
+  };
+
   return (
     <div
       key={group.name}
@@ -49,13 +58,16 @@ export default function ServicesGroup({
                 <h2 className="flex text-theme-800 dark:text-theme-300 text-xl font-medium service-group-name">
                   {group.name}
                 </h2>
-                <MdKeyboardArrowDown
-                  className={classNames(
-                    disableCollapse ? "hidden" : "",
-                    "transition-all opacity-0 group-hover:opacity-100 ml-auto text-theme-800 dark:text-theme-300 text-xl",
-                    open ? "" : "rotate-180",
-                  )}
-                />
+                <div className="flex ml-auto">
+                  <span role="button" className="cursor-pointer bg-slate-500 rounded-md px-2 text-sm text-center" onClick={openAll} >Open All</span>
+                  <MdKeyboardArrowDown
+                    className={classNames(
+                      disableCollapse ? "hidden" : "",
+                      "transition-all opacity-0 group-hover:opacity-100 ml-auto text-theme-800 dark:text-theme-300 text-xl",
+                      open ? "" : "rotate-180",
+                    )}
+                  />
+                </div>
               </Disclosure.Button>
             )}
             <Transition
@@ -88,9 +100,8 @@ export default function ServicesGroup({
                 />
                 {group.groups?.length > 0 && (
                   <div
-                    className={`grid ${
-                      layout?.style === "row" ? `grid ${columnMap[layout?.columns]} gap-x-2` : "flex flex-col"
-                    } gap-2`}
+                    className={`grid ${layout?.style === "row" ? `grid ${columnMap[layout?.columns]} gap-x-2` : "flex flex-col"
+                      } gap-2`}
                   >
                     {group.groups.map((subgroup) => (
                       <ServicesGroup

--- a/src/components/services/group.jsx
+++ b/src/components/services/group.jsx
@@ -59,7 +59,13 @@ export default function ServicesGroup({
                   {group.name}
                 </h2>
                 <div className="flex ml-auto">
-                  <span role="button" className="cursor-pointer bg-slate-500 rounded-md px-2 text-sm text-center" onClick={openAll} >Open All</span>
+                  <span
+                    role="button"
+                    className="cursor-pointer bg-slate-500 rounded-md px-2 text-sm text-center"
+                    onClick={openAll}
+                  >
+                      Open All
+                  </span>
                   <MdKeyboardArrowDown
                     className={classNames(
                       disableCollapse ? "hidden" : "",

--- a/src/components/services/group.jsx
+++ b/src/components/services/group.jsx
@@ -100,8 +100,9 @@ export default function ServicesGroup({
                 />
                 {group.groups?.length > 0 && (
                   <div
-                    className={`grid ${layout?.style === "row" ? `grid ${columnMap[layout?.columns]} gap-x-2` : "flex flex-col"
-                      } gap-2`}
+                    className={`grid ${
+                      layout?.style === "row" ? `grid ${columnMap[layout?.columns]} gap-x-2` : "flex flex-col"
+                    } gap-2`}
                   >
                     {group.groups.map((subgroup) => (
                       <ServicesGroup

--- a/src/components/services/group.test.jsx
+++ b/src/components/services/group.test.jsx
@@ -42,11 +42,17 @@ vi.mock("components/services/list", () => ({
     return (
       <div data-testid="services-list-mock">
         {groupName}:{services?.length ?? 0}
+        {services?.map((s, i) => (
+          <a key={i} href={s.url}>
+            {s.name}
+          </a>
+        ))}
       </div>
     );
   },
 }));
 
+import { fireEvent } from "@testing-library/react";
 import ServicesGroup from "./group";
 
 describe("components/services/group", () => {
@@ -55,7 +61,7 @@ describe("components/services/group", () => {
       <ServicesGroup
         group={{
           name: "Main",
-          services: [{ name: "svc" }],
+          services: [{ name: "svc", url: "https://example.com" }],
           groups: [{ name: "Sub", services: [], groups: [] }],
         }}
         layout={{ icon: "mdi:test" }}
@@ -83,5 +89,40 @@ describe("components/services/group", () => {
     await waitFor(() => {
       expect(panel.style.height).toBe("0px");
     });
+  });
+
+  it("opens all links when 'Open All' is clicked", () => {
+    const windowOpenSpy = vi.spyOn(window, "open").mockImplementation(() => ({}));
+    const stopPropagationSpy = vi.fn();
+
+    render(
+      <ServicesGroup
+        group={{
+          name: "Main",
+          services: [
+            { name: "S1", url: "https://s1.com" },
+            { name: "S2", url: "https://s2.com" },
+          ],
+          groups: [
+            {
+              name: "Sub",
+              services: [{ name: "S3", url: "https://s3.com" }],
+              groups: [],
+            },
+          ],
+        }}
+        groupsInitiallyCollapsed={false}
+      />,
+    );
+
+    const openAllBtn = screen.getAllByText("Open All")[0];
+    fireEvent.click(openAllBtn, { stopPropagation: stopPropagationSpy });
+
+    expect(windowOpenSpy).toHaveBeenCalledTimes(3);
+    expect(windowOpenSpy).toHaveBeenCalledWith("https://s1.com/", "_blank", "noopener,noreferrer");
+    expect(windowOpenSpy).toHaveBeenCalledWith("https://s2.com/", "_blank", "noopener,noreferrer");
+    expect(windowOpenSpy).toHaveBeenCalledWith("https://s3.com/", "_blank", "noopener,noreferrer");
+
+    windowOpenSpy.mockRestore();
   });
 });

--- a/src/components/services/item.jsx
+++ b/src/components/services/item.jsx
@@ -85,9 +85,8 @@ export default function Item({ service, groupName, useEqualHeights }) {
           )}
 
           <div
-            className={`absolute top-0 right-0 flex flex-row justify-end ${
-              statusStyle === "dot" ? "gap-0" : "gap-2 mr-2"
-            } z-10 service-tags`}
+            className={`absolute top-0 right-0 flex flex-row justify-end ${statusStyle === "dot" ? "gap-0" : "gap-2 mr-2"
+              } z-10 service-tags`}
           >
             {service.ping && (
               <div className="shrink-0 flex items-center justify-center service-tag service-ping">

--- a/src/components/services/item.jsx
+++ b/src/components/services/item.jsx
@@ -85,8 +85,9 @@ export default function Item({ service, groupName, useEqualHeights }) {
           )}
 
           <div
-            className={`absolute top-0 right-0 flex flex-row justify-end ${statusStyle === "dot" ? "gap-0" : "gap-2 mr-2"
-              } z-10 service-tags`}
+            className={`absolute top-0 right-0 flex flex-row justify-end ${
+              statusStyle === "dot" ? "gap-0" : "gap-2 mr-2"
+            } z-10 service-tags`}
           >
             {service.ping && (
               <div className="shrink-0 flex items-center justify-center service-tag service-ping">


### PR DESCRIPTION
<!--
==== STOP ====================
======== STOP ================
============ STOP ============
================ STOP ========
==================== STOP ====

⚠️ Before opening this pull request please review the guidelines in the checklist below.

If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.
-->

## Proposed change

Added 'open all' button to groups to open all services within the group (including sub-groups), including additional tests.
<img width="591" height="280" alt="image" src="https://github.com/user-attachments/assets/7680e36f-c922-4a0b-8b66-8358383d4f3f" />
<img width="392" height="46" alt="image" src="https://github.com/user-attachments/assets/f7bc5a93-7dc5-4f28-9be1-47d785734e80" />

**AI tool (antigravity) used to generate function to detect and open relevant links - validated logic.** 

Closes #6669 

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] In the description above I have disclosed the use of AI tools in the coding of this PR.
