### PR TITLE
Fix: allow explicit cookie header overwrite

### DIFF
--- a/src/utils/proxy/cookie-jar.js
+++ b/src/utils/proxy/cookie-jar.js
@@ -2,13 +2,13 @@ import { Cookie, CookieJar } from "tough-cookie";
 
 const cookieJar = new CookieJar();
 
-export function setCookieHeader(url, params) {
+export function setCookieHeader(url, params, { overwrite = false } = {}) {
   // add cookie header, if we have one in the jar
   const existingCookie = cookieJar.getCookieStringSync(url.toString());
   if (existingCookie) {
     params.headers = params.headers ?? {};
     const cookieHeader = params.cookieHeader ?? "Cookie";
-    if (!params.headers[cookieHeader]) {
+    if (overwrite || !params.headers[cookieHeader]) {
       params.headers[cookieHeader] = existingCookie;
     }
   }

--- a/src/utils/proxy/cookie-jar.test.js
+++ b/src/utils/proxy/cookie-jar.test.js
@@ -54,4 +54,17 @@ describe("utils/proxy/cookie-jar", () => {
 
     expect(params.headers.Cookie).toBe("manual=1");
   });
+
+  it("overwrites an existing cookie header when requested", async () => {
+    const { addCookieToJar, setCookieHeader } = await import("./cookie-jar");
+
+    const url = new URL("http://example5.test/path");
+    addCookieToJar(url, { "set-cookie": ["sid=1; Path=/"] });
+
+    const params = { headers: { Cookie: "stale=1" } };
+    setCookieHeader(url, params, { overwrite: true });
+
+    expect(params.headers.Cookie).toContain("sid=1");
+    expect(params.headers.Cookie).not.toContain("stale=1");
+  });
 });

--- a/src/utils/proxy/handlers/unifi.js
+++ b/src/utils/proxy/handlers/unifi.js
@@ -97,7 +97,7 @@ export default function createUnifiProxyHandler({
       }
 
       addCookieToJar(url, responseHeaders);
-      setCookieHeader(url, params);
+      setCookieHeader(url, params, { overwrite: true });
 
       [status, contentType, data, responseHeaders] = await httpProxy(url, params);
     }

--- a/src/utils/proxy/http.js
+++ b/src/utils/proxy/http.js
@@ -18,7 +18,7 @@ function addCookieHandler(url, params) {
   // handle cookies during redirects
   params.beforeRedirect = (options, responseInfo) => {
     addCookieToJar(options.href, responseInfo.headers);
-    setCookieHeader(options.href, options);
+    setCookieHeader(options.href, options, { overwrite: true });
   };
 }
 

--- a/src/utils/proxy/http.test.js
+++ b/src/utils/proxy/http.test.js
@@ -348,7 +348,9 @@ describe("utils/proxy/http httpProxy", () => {
     );
 
     expect(cookieJar.addCookieToJar).toHaveBeenCalledWith("http://example.com/redirect", { "set-cookie": ["a=b"] });
-    expect(cookieJar.setCookieHeader).toHaveBeenCalledWith("http://example.com/redirect", expect.any(Object));
+    expect(cookieJar.setCookieHeader).toHaveBeenCalledWith("http://example.com/redirect", expect.any(Object), {
+      overwrite: true,
+    });
   });
 
   it("supports gzip-compressed responses", async () => {

--- a/src/widgets/frigate/proxy.js
+++ b/src/widgets/frigate/proxy.js
@@ -1,7 +1,7 @@
 import getServiceWidget from "utils/config/service-helpers";
 import createLogger from "utils/logger";
 import { asJson, formatApiCall, sanitizeErrorURL } from "utils/proxy/api-helpers";
-import { addCookieToJar } from "utils/proxy/cookie-jar";
+import { addCookieToJar, setCookieHeader } from "utils/proxy/cookie-jar";
 import { httpProxy } from "utils/proxy/http";
 import widgets from "widgets/widgets";
 
@@ -57,6 +57,7 @@ export default async function frigateProxyHandler(req, res, map) {
         }
 
         addCookieToJar(url, loginResponseHeaders);
+        setCookieHeader(url, params, { overwrite: true });
         // Retry original request with cookie set
         [status, , data] = await httpProxy(url, params);
       }

--- a/src/widgets/frigate/proxy.test.js
+++ b/src/widgets/frigate/proxy.test.js
@@ -7,6 +7,7 @@ const { httpProxy, getServiceWidget, cookieJar, logger } = vi.hoisted(() => ({
   getServiceWidget: vi.fn(),
   cookieJar: {
     addCookieToJar: vi.fn(),
+    setCookieHeader: vi.fn(),
   },
   logger: {
     debug: vi.fn(),
@@ -130,6 +131,9 @@ describe("widgets/frigate/proxy", () => {
     await frigateProxyHandler(req, res);
 
     expect(cookieJar.addCookieToJar).toHaveBeenCalled();
+    expect(cookieJar.setCookieHeader).toHaveBeenCalledWith("http://frigate/api/stats", expect.any(Object), {
+      overwrite: true,
+    });
     expect(res.statusCode).toBe(200);
     expect(res.body).toEqual({ num_cameras: 2, uptime: 123, version: "1.0" });
   });

--- a/src/widgets/unifi/proxy.test.js
+++ b/src/widgets/unifi/proxy.test.js
@@ -86,6 +86,9 @@ describe("widgets/unifi/proxy", () => {
     expect(httpProxy).toHaveBeenCalledTimes(4);
     expect(httpProxy.mock.calls[1][0].toString()).toContain("/proxy/network/api/self");
     expect(cookieJar.addCookieToJar).toHaveBeenCalled();
+    expect(cookieJar.setCookieHeader).toHaveBeenLastCalledWith(expect.any(URL), expect.any(Object), {
+      overwrite: true,
+    });
     expect(res.statusCode).toBe(200);
     expect(res.body).toEqual(Buffer.from("data"));
   });


### PR DESCRIPTION
<!--
==== STOP ====================
======== STOP ================
============ STOP ============
================ STOP ========
==================== STOP ====

⚠️ Before opening this pull request please review the guidelines in the checklist below.

If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.
-->

## Proposed change

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->

See #6646, #6658

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [ ] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] In the description above I have disclosed the use of AI tools in the coding of this PR.
