### PR TITLE
enhancement Navidrome widget

### DIFF
--- a/docs/widgets/services/navidrome.md
+++ b/docs/widgets/services/navidrome.md
@@ -7,7 +7,9 @@ Learn more about [Navidrome](https://github.com/navidrome/navidrome).
 
 For detailed information about how to generate the token see http://www.subsonic.org/pages/api.jsp.
 
-Allowed fields: no configurable fields for this widget.
+Displayed fields: now playing entries plus library counts for `artists`, `albums`, `songs`, and `playlists`.
+
+The displayed fields are not configurable. The library counts use Navidrome's Subsonic-compatible API and may depend on the server returning compatible album, artist, and playlist responses.
 
 ```yaml
 widget:

--- a/public/locales/af/common.json
+++ b/public/locales/af/common.json
@@ -397,8 +397,12 @@
         "unknown": "Onbekend"
     },
     "navidrome": {
-        "nothing_streaming": "Geen Aktiewe Strome",
-        "please_wait": "Wag Asseblief"
+        "nothing_streaming": "Geen aktiewe strome",
+        "please_wait": "Wag asseblief",
+        "albums": "Albums",
+        "artists": "Kunstenaars",
+        "playlists": "Snitlyste",
+        "songs": "Liedjies"
     },
     "npm": {
         "enabled": "Geaktiveer",

--- a/public/locales/ar/common.json
+++ b/public/locales/ar/common.json
@@ -397,8 +397,12 @@
         "unknown": "Unknown"
     },
     "navidrome": {
-        "nothing_streaming": "No Active Streams",
-        "please_wait": "الرجاء الإنتظار"
+        "nothing_streaming": "لا توجد بثوث نشطة",
+        "please_wait": "يرجى الانتظار",
+        "albums": "الألبومات",
+        "artists": "الفنانون",
+        "playlists": "قوائم التشغيل",
+        "songs": "الأغاني"
     },
     "npm": {
         "enabled": "مفعل",

--- a/public/locales/bg/common.json
+++ b/public/locales/bg/common.json
@@ -397,8 +397,12 @@
         "unknown": "Unknown"
     },
     "navidrome": {
-        "nothing_streaming": "No Active Streams",
-        "please_wait": "Моля Изчакайте"
+        "nothing_streaming": "Няма активни потоци",
+        "please_wait": "Моля, изчакайте",
+        "albums": "Албуми",
+        "artists": "Изпълнители",
+        "playlists": "Плейлисти",
+        "songs": "Песни"
     },
     "npm": {
         "enabled": "Активирано",

--- a/public/locales/ca/common.json
+++ b/public/locales/ca/common.json
@@ -397,8 +397,12 @@
         "unknown": "Desconegut"
     },
     "navidrome": {
-        "nothing_streaming": "Sense reproduccions actives",
-        "please_wait": "Espereu si us plau"
+        "nothing_streaming": "No hi ha reproduccions actives",
+        "please_wait": "Espereu",
+        "albums": "Àlbums",
+        "artists": "Artistes",
+        "playlists": "Llistes de reproducció",
+        "songs": "Cançons"
     },
     "npm": {
         "enabled": "Activat",

--- a/public/locales/cs/common.json
+++ b/public/locales/cs/common.json
@@ -397,8 +397,12 @@
         "unknown": "Neznámý"
     },
     "navidrome": {
-        "nothing_streaming": "Nic se nepřehrává",
-        "please_wait": "Čekejte prosím"
+        "nothing_streaming": "Žádné aktivní streamy",
+        "please_wait": "Čekejte prosím",
+        "albums": "Alba",
+        "artists": "Interpreti",
+        "playlists": "Playlisty",
+        "songs": "Skladby"
     },
     "npm": {
         "enabled": "Povoleno",

--- a/public/locales/da/common.json
+++ b/public/locales/da/common.json
@@ -397,8 +397,12 @@
         "unknown": "Unknown"
     },
     "navidrome": {
-        "nothing_streaming": "No Active Streams",
-        "please_wait": "Vent venligst"
+        "nothing_streaming": "Ingen aktive streams",
+        "please_wait": "Vent venligst",
+        "albums": "Album",
+        "artists": "Kunstnere",
+        "playlists": "Playlister",
+        "songs": "Sange"
     },
     "npm": {
         "enabled": "Aktiveret",

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -398,7 +398,11 @@
     },
     "navidrome": {
         "nothing_streaming": "Keine aktiven Streams",
-        "please_wait": "Bitte warten"
+        "please_wait": "Bitte warten",
+        "albums": "Alben",
+        "artists": "Künstler",
+        "playlists": "Wiedergabelisten",
+        "songs": "Titel"
     },
     "npm": {
         "enabled": "Aktiviert",

--- a/public/locales/el/common.json
+++ b/public/locales/el/common.json
@@ -397,8 +397,12 @@
         "unknown": "Unknown"
     },
     "navidrome": {
-        "nothing_streaming": "No Active Streams",
-        "please_wait": "Παρακαλώ περιμένετε"
+        "nothing_streaming": "Δεν υπάρχουν ενεργές ροές",
+        "please_wait": "Παρακαλώ περιμένετε",
+        "albums": "Άλμπουμ",
+        "artists": "Καλλιτέχνες",
+        "playlists": "Λίστες αναπαραγωγής",
+        "songs": "Τραγούδια"
     },
     "npm": {
         "enabled": "Ενεργοποιημένο",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -331,14 +331,14 @@
         "total": "Total"
     },
     "suwayomi": {
-      "download": "Downloaded",
-      "nondownload": "Non-Downloaded",
-      "read": "Read",
-      "unread": "Unread",
-      "downloadedread": "Downloaded & Read",
-      "downloadedunread": "Downloaded & Unread",
-      "nondownloadedread": "Non-Downloaded & Read",
-      "nondownloadedunread": "Non-Downloaded & Unread"
+        "download": "Downloaded",
+        "nondownload": "Non-Downloaded",
+        "read": "Read",
+        "unread": "Unread",
+        "downloadedread": "Downloaded & Read",
+        "downloadedunread": "Downloaded & Unread",
+        "nondownloadedread": "Non-Downloaded & Read",
+        "nondownloadedunread": "Non-Downloaded & Unread"
     },
     "tailscale": {
         "address": "Address",
@@ -397,8 +397,12 @@
         "unknown": "Unknown"
     },
     "navidrome": {
+        "albums": "Albums",
+        "artists": "Artists",
         "nothing_streaming": "No Active Streams",
-        "please_wait": "Please Wait"
+        "playlists": "Playlists",
+        "please_wait": "Please Wait",
+        "songs": "Songs"
     },
     "npm": {
         "enabled": "Enabled",
@@ -869,7 +873,7 @@
         "ping": "Ping"
     },
     "urbackup": {
-        "ok" : "Ok",
+        "ok": "Ok",
         "errored": "Errors",
         "noRecent": "Out of Date",
         "totalUsed": "Used Storage"
@@ -927,27 +931,27 @@
         "totalfilesize": "Total Size"
     },
     "mailcow": {
-      "domains": "Domains",
-      "mailboxes": "Mailboxes",
-      "mails": "Mails",
-      "storage": "Storage"
+        "domains": "Domains",
+        "mailboxes": "Mailboxes",
+        "mails": "Mails",
+        "storage": "Storage"
     },
     "netdata": {
-      "warnings": "Warnings",
-      "criticals": "Criticals"
+        "warnings": "Warnings",
+        "criticals": "Criticals"
     },
     "ntfy": {
-      "title": "Title",
-      "priority": "Priority",
-      "lastReceived": "Last Received",
-      "message": "Message",
-      "tags": "Tags",
-      "none": "None",
-      "min": "Min",
-      "low": "Low",
-      "default": "Default",
-      "high": "High",
-      "urgent": "Urgent"
+        "title": "Title",
+        "priority": "Priority",
+        "lastReceived": "Last Received",
+        "message": "Message",
+        "tags": "Tags",
+        "none": "None",
+        "min": "Min",
+        "low": "Low",
+        "default": "Default",
+        "high": "High",
+        "urgent": "Urgent"
     },
     "plantit": {
         "events": "Events",
@@ -956,10 +960,10 @@
         "species": "Species"
     },
     "gitea": {
-      "notifications": "Notifications",
-      "issues": "Issues",
-      "pulls": "Pull Requests",
-      "repositories": "Repositories"
+        "notifications": "Notifications",
+        "issues": "Issues",
+        "pulls": "Pull Requests",
+        "repositories": "Repositories"
     },
     "stash": {
         "scenes": "Scenes",
@@ -1029,48 +1033,48 @@
         "tags": "Tags"
     },
     "zabbix": {
-      "unclassified": "Not classified",
-      "information": "Information",
-      "warning": "Warning",
-      "average": "Average",
-      "high": "High",
-      "disaster": "Disaster"
+        "unclassified": "Not classified",
+        "information": "Information",
+        "warning": "Warning",
+        "average": "Average",
+        "high": "High",
+        "disaster": "Disaster"
     },
     "lubelogger": {
-      "vehicle": "Vehicle",
-      "vehicles": "Vehicles",
-      "serviceRecords": "Service Records",
-      "reminders": "Reminders",
-      "nextReminder": "Next Reminder",
-      "none": "None"
+        "vehicle": "Vehicle",
+        "vehicles": "Vehicles",
+        "serviceRecords": "Service Records",
+        "reminders": "Reminders",
+        "nextReminder": "Next Reminder",
+        "none": "None"
     },
     "vikunja": {
-      "projects": "Active Projects",
-      "tasks7d": "Tasks Due This Week",
-      "tasksOverdue": "Overdue Tasks",
-      "tasksInProgress": "Tasks In Progress"
+        "projects": "Active Projects",
+        "tasks7d": "Tasks Due This Week",
+        "tasksOverdue": "Overdue Tasks",
+        "tasksInProgress": "Tasks In Progress"
     },
     "headscale": {
-      "name": "Name",
-      "address": "Address",
-      "last_seen": "Last Seen",
-      "status": "Status",
-      "online": "Online",
-      "offline": "Offline"
+        "name": "Name",
+        "address": "Address",
+        "last_seen": "Last Seen",
+        "status": "Status",
+        "online": "Online",
+        "offline": "Offline"
     },
     "beszel": {
-      "name": "Name",
-      "systems": "Systems",
-      "up": "Up",
-      "down": "Down",
-      "paused": "Paused",
-      "pending": "Pending",
-      "status": "Status",
-      "updated": "Updated",
-      "cpu": "CPU",
-      "memory": "MEM",
-      "disk": "Disk",
-      "network": "NET"
+        "name": "Name",
+        "systems": "Systems",
+        "up": "Up",
+        "down": "Down",
+        "paused": "Paused",
+        "pending": "Pending",
+        "status": "Status",
+        "updated": "Updated",
+        "cpu": "CPU",
+        "memory": "MEM",
+        "disk": "Disk",
+        "network": "NET"
     },
     "argocd": {
         "apps": "Apps",
@@ -1094,8 +1098,8 @@
     "apcups": {
         "status": "Status",
         "load": "Load",
-        "bcharge":"Battery Charge",
-        "timeleft":"Time Left"
+        "bcharge": "Battery Charge",
+        "timeleft": "Time Left"
     },
     "karakeep": {
         "bookmarks": "Bookmarks",
@@ -1180,9 +1184,9 @@
         "bytes_added_30": "Bytes Added"
     },
     "yourspotify": {
-      "songs": "Songs",
-      "time":  "Time",
-      "artists": "Artists"
+        "songs": "Songs",
+        "time": "Time",
+        "artists": "Artists"
     },
     "arcane": {
         "containers": "Containers",

--- a/public/locales/eo/common.json
+++ b/public/locales/eo/common.json
@@ -397,8 +397,12 @@
         "unknown": "Unknown"
     },
     "navidrome": {
-        "nothing_streaming": "No Active Streams",
-        "please_wait": "Please Wait"
+        "nothing_streaming": "Neniuj aktivaj fluoj",
+        "please_wait": "Bonvolu atendi",
+        "albums": "Albumoj",
+        "artists": "Artistoj",
+        "playlists": "Ludlistoj",
+        "songs": "Kantoj"
     },
     "npm": {
         "enabled": "Enabled",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -397,8 +397,12 @@
         "unknown": "Desconocido"
     },
     "navidrome": {
-        "nothing_streaming": "Sin transmisiones activas",
-        "please_wait": "Por favor, espera"
+        "nothing_streaming": "No hay transmisiones activas",
+        "please_wait": "Espera por favor",
+        "albums": "Álbumes",
+        "artists": "Artistas",
+        "playlists": "Listas de reproducción",
+        "songs": "Canciones"
     },
     "npm": {
         "enabled": "Activos",

--- a/public/locales/eu/common.json
+++ b/public/locales/eu/common.json
@@ -397,8 +397,12 @@
         "unknown": "Unknown"
     },
     "navidrome": {
-        "nothing_streaming": "No Active Streams",
-        "please_wait": "Please Wait"
+        "nothing_streaming": "Ez dago erreprodukzio aktiborik",
+        "please_wait": "Itxaron mesedez",
+        "albums": "Albumak",
+        "artists": "Artistak",
+        "playlists": "Erreprodukzio-zerrendak",
+        "songs": "Abestiak"
     },
     "npm": {
         "enabled": "Enabled",

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -397,8 +397,12 @@
         "unknown": "Unknown"
     },
     "navidrome": {
-        "nothing_streaming": "No Active Streams",
-        "please_wait": "Odota, ole hyvä"
+        "nothing_streaming": "Ei aktiivisia suoratoistoja",
+        "please_wait": "Odota hetki",
+        "albums": "Albumit",
+        "artists": "Artistit",
+        "playlists": "Soittolistat",
+        "songs": "Kappaleet"
     },
     "npm": {
         "enabled": "Käytössä",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -398,7 +398,11 @@
     },
     "navidrome": {
         "nothing_streaming": "Aucune lecture en cours",
-        "please_wait": "Merci de patienter"
+        "please_wait": "Merci de patienter",
+        "albums": "Albums",
+        "artists": "Artistes",
+        "playlists": "Listes de lecture",
+        "songs": "Titres"
     },
     "npm": {
         "enabled": "Activé",

--- a/public/locales/he/common.json
+++ b/public/locales/he/common.json
@@ -398,7 +398,11 @@
     },
     "navidrome": {
         "nothing_streaming": "אין הזרמות פעילות",
-        "please_wait": "המתן בבקשה"
+        "please_wait": "נא להמתין",
+        "albums": "אלבומים",
+        "artists": "אמנים",
+        "playlists": "רשימות השמעה",
+        "songs": "שירים"
     },
     "npm": {
         "enabled": "מופעל",

--- a/public/locales/hi/common.json
+++ b/public/locales/hi/common.json
@@ -397,8 +397,12 @@
         "unknown": "Unknown"
     },
     "navidrome": {
-        "nothing_streaming": "No Active Streams",
-        "please_wait": "Please Wait"
+        "nothing_streaming": "कोई सक्रिय स्ट्रीम नहीं",
+        "please_wait": "कृपया प्रतीक्षा करें",
+        "albums": "एल्बम",
+        "artists": "कलाकार",
+        "playlists": "प्लेलिस्ट",
+        "songs": "गीत"
     },
     "npm": {
         "enabled": "Enabled",

--- a/public/locales/hr/common.json
+++ b/public/locales/hr/common.json
@@ -397,8 +397,12 @@
         "unknown": "Nepoznato"
     },
     "navidrome": {
-        "nothing_streaming": "Nema aktivnih prijenosa",
-        "please_wait": "Pričekaj"
+        "nothing_streaming": "Nema aktivnih streamova",
+        "please_wait": "Pričekajte",
+        "albums": "Albumi",
+        "artists": "Izvođači",
+        "playlists": "Popisi za reprodukciju",
+        "songs": "Pjesme"
     },
     "npm": {
         "enabled": "Aktivirano",

--- a/public/locales/hu/common.json
+++ b/public/locales/hu/common.json
@@ -397,8 +397,12 @@
         "unknown": "Ismeretlen"
     },
     "navidrome": {
-        "nothing_streaming": "Nincs aktív lejátszás",
-        "please_wait": "Kérjük Várjon"
+        "nothing_streaming": "Nincs aktív stream",
+        "please_wait": "Kérjük, várjon",
+        "albums": "Albumok",
+        "artists": "Előadók",
+        "playlists": "Lejátszási listák",
+        "songs": "Dalok"
     },
     "npm": {
         "enabled": "Bekapcsolva",

--- a/public/locales/id/common.json
+++ b/public/locales/id/common.json
@@ -397,8 +397,12 @@
         "unknown": "Unknown"
     },
     "navidrome": {
-        "nothing_streaming": "No Active Streams",
-        "please_wait": "Mohon menunggu"
+        "nothing_streaming": "Tidak ada streaming aktif",
+        "please_wait": "Mohon tunggu",
+        "albums": "Album",
+        "artists": "Artis",
+        "playlists": "Daftar putar",
+        "songs": "Lagu"
     },
     "npm": {
         "enabled": "Aktif",

--- a/public/locales/it/common.json
+++ b/public/locales/it/common.json
@@ -397,8 +397,12 @@
         "unknown": "Unknown"
     },
     "navidrome": {
-        "nothing_streaming": "No Active Streams",
-        "please_wait": "Attendere prego"
+        "nothing_streaming": "Nessuno streaming attivo",
+        "please_wait": "Attendere prego",
+        "albums": "Album",
+        "artists": "Artisti",
+        "playlists": "Playlist",
+        "songs": "Brani"
     },
     "npm": {
         "enabled": "Abilitato",

--- a/public/locales/ja/common.json
+++ b/public/locales/ja/common.json
@@ -397,8 +397,12 @@
         "unknown": "Unknown"
     },
     "navidrome": {
-        "nothing_streaming": "No Active Streams",
-        "please_wait": "お待ちください"
+        "nothing_streaming": "アクティブなストリームはありません",
+        "please_wait": "お待ちください",
+        "albums": "アルバム",
+        "artists": "アーティスト",
+        "playlists": "プレイリスト",
+        "songs": "曲"
     },
     "npm": {
         "enabled": "有効",

--- a/public/locales/ko/common.json
+++ b/public/locales/ko/common.json
@@ -398,7 +398,11 @@
     },
     "navidrome": {
         "nothing_streaming": "활성 스트림 없음",
-        "please_wait": "잠시만 기다리세요"
+        "please_wait": "잠시만 기다려 주세요",
+        "albums": "앨범",
+        "artists": "아티스트",
+        "playlists": "재생목록",
+        "songs": "곡"
     },
     "npm": {
         "enabled": "활성",

--- a/public/locales/lv/common.json
+++ b/public/locales/lv/common.json
@@ -397,8 +397,12 @@
         "unknown": "Unknown"
     },
     "navidrome": {
-        "nothing_streaming": "No Active Streams",
-        "please_wait": "Please Wait"
+        "nothing_streaming": "Nav aktīvu straumju",
+        "please_wait": "Lūdzu, uzgaidiet",
+        "albums": "Albumi",
+        "artists": "Izpildītāji",
+        "playlists": "Atskaņošanas saraksti",
+        "songs": "Dziesmas"
     },
     "npm": {
         "enabled": "Enabled",

--- a/public/locales/ms/common.json
+++ b/public/locales/ms/common.json
@@ -397,8 +397,12 @@
         "unknown": "Unknown"
     },
     "navidrome": {
-        "nothing_streaming": "No Active Streams",
-        "please_wait": "Sila tunggu"
+        "nothing_streaming": "Tiada strim aktif",
+        "please_wait": "Sila tunggu",
+        "albums": "Album",
+        "artists": "Artis",
+        "playlists": "Senarai main",
+        "songs": "Lagu"
     },
     "npm": {
         "enabled": "Didayakan",

--- a/public/locales/nb-NO/common.json
+++ b/public/locales/nb-NO/common.json
@@ -362,8 +362,12 @@
         "time": "{{value, number(style: unit; unitDisplay: long;)}}"
     },
     "navidrome": {
-        "nothing_streaming": "No Active Streams",
-        "please_wait": "Please Wait"
+        "nothing_streaming": "Ingen aktive strømmer",
+        "please_wait": "Vennligst vent",
+        "albums": "Album",
+        "artists": "Artister",
+        "playlists": "Spillelister",
+        "songs": "Sanger"
     },
     "pyload": {
         "speed": "Speed",

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -397,8 +397,12 @@
         "unknown": "Onbekend"
     },
     "navidrome": {
-        "nothing_streaming": "Geen Actieve Streams",
-        "please_wait": "Even geduld aub"
+        "nothing_streaming": "Geen actieve streams",
+        "please_wait": "Even geduld",
+        "albums": "Albums",
+        "artists": "Artiesten",
+        "playlists": "Afspeellijsten",
+        "songs": "Nummers"
     },
     "npm": {
         "enabled": "Ingeschakeld",

--- a/public/locales/no/common.json
+++ b/public/locales/no/common.json
@@ -397,8 +397,12 @@
         "unknown": "Unknown"
     },
     "navidrome": {
-        "nothing_streaming": "No Active Streams",
-        "please_wait": "Vennligst vent"
+        "nothing_streaming": "Ingen aktive strømmer",
+        "please_wait": "Vennligst vent",
+        "albums": "Album",
+        "artists": "Artister",
+        "playlists": "Spillelister",
+        "songs": "Sanger"
     },
     "npm": {
         "enabled": "Aktivert",

--- a/public/locales/pl/common.json
+++ b/public/locales/pl/common.json
@@ -398,7 +398,11 @@
     },
     "navidrome": {
         "nothing_streaming": "Brak aktywnych strumieni",
-        "please_wait": "Proszę czekać"
+        "please_wait": "Proszę czekać",
+        "albums": "Albumy",
+        "artists": "Artyści",
+        "playlists": "Listy odtwarzania",
+        "songs": "Utwory"
     },
     "npm": {
         "enabled": "Włączone",

--- a/public/locales/pt-BR/common.json
+++ b/public/locales/pt-BR/common.json
@@ -362,8 +362,12 @@
         "time": "{{value, number(style: unit; unitDisplay: long;)}}"
     },
     "navidrome": {
-        "nothing_streaming": "Sem transmissões ativas",
-        "please_wait": "Por favor aguarde"
+        "nothing_streaming": "Nenhuma transmissão ativa",
+        "please_wait": "Aguarde",
+        "albums": "Álbuns",
+        "artists": "Artistas",
+        "playlists": "Playlists",
+        "songs": "Músicas"
     },
     "pyload": {
         "speed": "Velocidade",

--- a/public/locales/pt/common.json
+++ b/public/locales/pt/common.json
@@ -397,8 +397,12 @@
         "unknown": "Unknown"
     },
     "navidrome": {
-        "nothing_streaming": "No Active Streams",
-        "please_wait": "Por Favor, Aguarde"
+        "nothing_streaming": "Nenhuma transmissão ativa",
+        "please_wait": "Aguarde",
+        "albums": "Álbuns",
+        "artists": "Artistas",
+        "playlists": "Listas de reprodução",
+        "songs": "Músicas"
     },
     "npm": {
         "enabled": "Activo",

--- a/public/locales/pt_BR/common.json
+++ b/public/locales/pt_BR/common.json
@@ -397,8 +397,12 @@
         "unknown": "Desconhecido"
     },
     "navidrome": {
-        "nothing_streaming": "Sem Streams Ativos",
-        "please_wait": "Por favor, aguarde"
+        "nothing_streaming": "Nenhuma transmissão ativa",
+        "please_wait": "Aguarde",
+        "albums": "Álbuns",
+        "artists": "Artistas",
+        "playlists": "Playlists",
+        "songs": "Músicas"
     },
     "npm": {
         "enabled": "Ativo",

--- a/public/locales/ro/common.json
+++ b/public/locales/ro/common.json
@@ -397,8 +397,12 @@
         "unknown": "Unknown"
     },
     "navidrome": {
-        "nothing_streaming": "No Active Streams",
-        "please_wait": "Please Wait"
+        "nothing_streaming": "Nu există fluxuri active",
+        "please_wait": "Vă rugăm să așteptați",
+        "albums": "Albume",
+        "artists": "Artiști",
+        "playlists": "Liste de redare",
+        "songs": "Melodii"
     },
     "npm": {
         "enabled": "Activat",

--- a/public/locales/ru/common.json
+++ b/public/locales/ru/common.json
@@ -397,8 +397,12 @@
         "unknown": "Неизвестно"
     },
     "navidrome": {
-        "nothing_streaming": "Нет активных стримов",
-        "please_wait": "Пожалуйста, подождите"
+        "nothing_streaming": "Нет активных потоков",
+        "please_wait": "Пожалуйста, подождите",
+        "albums": "Альбомы",
+        "artists": "Исполнители",
+        "playlists": "Плейлисты",
+        "songs": "Композиции"
     },
     "npm": {
         "enabled": "Включено",

--- a/public/locales/sk/common.json
+++ b/public/locales/sk/common.json
@@ -397,8 +397,12 @@
         "unknown": "Neznáme"
     },
     "navidrome": {
-        "nothing_streaming": "No Active Streams",
-        "please_wait": "Počkajte prosím"
+        "nothing_streaming": "Žiadne aktívne streamy",
+        "please_wait": "Čakajte, prosím",
+        "albums": "Albumy",
+        "artists": "Interpreti",
+        "playlists": "Playlisty",
+        "songs": "Skladby"
     },
     "npm": {
         "enabled": "Povolené",

--- a/public/locales/sl/common.json
+++ b/public/locales/sl/common.json
@@ -397,8 +397,12 @@
         "unknown": "Unknown"
     },
     "navidrome": {
-        "nothing_streaming": "No Active Streams",
-        "please_wait": "Prosim počakajte"
+        "nothing_streaming": "Ni aktivnih pretokov",
+        "please_wait": "Počakajte prosim",
+        "albums": "Albumi",
+        "artists": "Izvajalci",
+        "playlists": "Seznami predvajanja",
+        "songs": "Pesmi"
     },
     "npm": {
         "enabled": "Omogočen",

--- a/public/locales/sr/common.json
+++ b/public/locales/sr/common.json
@@ -398,7 +398,11 @@
     },
     "navidrome": {
         "nothing_streaming": "Нема активних стримова",
-        "please_wait": "Молим сачекајте"
+        "please_wait": "Сачекајте",
+        "albums": "Албуми",
+        "artists": "Извођачи",
+        "playlists": "Плејлисте",
+        "songs": "Песме"
     },
     "npm": {
         "enabled": "Омогућено",

--- a/public/locales/sv/common.json
+++ b/public/locales/sv/common.json
@@ -397,8 +397,12 @@
         "unknown": "Unknown"
     },
     "navidrome": {
-        "nothing_streaming": "No Active Streams",
-        "please_wait": "Please Wait"
+        "nothing_streaming": "Inga aktiva strömmar",
+        "please_wait": "Vänta",
+        "albums": "Album",
+        "artists": "Artister",
+        "playlists": "Spellistor",
+        "songs": "Låtar"
     },
     "npm": {
         "enabled": "Aktiverad",

--- a/public/locales/te/common.json
+++ b/public/locales/te/common.json
@@ -397,8 +397,12 @@
         "unknown": "Unknown"
     },
     "navidrome": {
-        "nothing_streaming": "No Active Streams",
-        "please_wait": "Please Wait"
+        "nothing_streaming": "సక్రియ స్ట్రీమ్‌లు లేవు",
+        "please_wait": "దయచేసి వేచి ఉండండి",
+        "albums": "ఆల్బమ్‌లు",
+        "artists": "కళాకారులు",
+        "playlists": "ప్లేలిస్ట్‌లు",
+        "songs": "పాటలు"
     },
     "npm": {
         "enabled": "ప్రారంభించబడింది",

--- a/public/locales/th/common.json
+++ b/public/locales/th/common.json
@@ -397,8 +397,12 @@
         "unknown": "Unknown"
     },
     "navidrome": {
-        "nothing_streaming": "No Active Streams",
-        "please_wait": "Please Wait"
+        "nothing_streaming": "ไม่มีสตรีมที่ใช้งานอยู่",
+        "please_wait": "โปรดรอสักครู่",
+        "albums": "อัลบั้ม",
+        "artists": "ศิลปิน",
+        "playlists": "เพลย์ลิสต์",
+        "songs": "เพลง"
     },
     "npm": {
         "enabled": "เปิด",

--- a/public/locales/tr/common.json
+++ b/public/locales/tr/common.json
@@ -397,8 +397,12 @@
         "unknown": "Bilinmeyen"
     },
     "navidrome": {
-        "nothing_streaming": "Etkin akış yok",
-        "please_wait": "Lütfen Bekleyin"
+        "nothing_streaming": "Etkin yayın yok",
+        "please_wait": "Lütfen bekleyin",
+        "albums": "Albümler",
+        "artists": "Sanatçılar",
+        "playlists": "Çalma listeleri",
+        "songs": "Şarkılar"
     },
     "npm": {
         "enabled": "Etkin",

--- a/public/locales/uk/common.json
+++ b/public/locales/uk/common.json
@@ -397,8 +397,12 @@
         "unknown": "Unknown"
     },
     "navidrome": {
-        "nothing_streaming": "No Active Streams",
-        "please_wait": "Будь ласка, зачекайте"
+        "nothing_streaming": "Немає активних потоків",
+        "please_wait": "Будь ласка, зачекайте",
+        "albums": "Альбоми",
+        "artists": "Виконавці",
+        "playlists": "Плейлисти",
+        "songs": "Пісні"
     },
     "npm": {
         "enabled": "Увімкнено",

--- a/public/locales/vi/common.json
+++ b/public/locales/vi/common.json
@@ -397,8 +397,12 @@
         "unknown": "Unknown"
     },
     "navidrome": {
-        "nothing_streaming": "No Active Streams",
-        "please_wait": "Please Wait"
+        "nothing_streaming": "Không có luồng đang hoạt động",
+        "please_wait": "Vui lòng chờ",
+        "albums": "Album",
+        "artists": "Nghệ sĩ",
+        "playlists": "Danh sách phát",
+        "songs": "Bài hát"
     },
     "npm": {
         "enabled": "Enabled",

--- a/public/locales/yue/common.json
+++ b/public/locales/yue/common.json
@@ -397,8 +397,12 @@
         "unknown": "Unknown"
     },
     "navidrome": {
-        "nothing_streaming": "No Active Streams",
-        "please_wait": "請稍後"
+        "nothing_streaming": "冇活躍串流",
+        "please_wait": "請稍候",
+        "albums": "專輯",
+        "artists": "藝人",
+        "playlists": "播放清單",
+        "songs": "歌曲"
     },
     "npm": {
         "enabled": "啟用",

--- a/public/locales/zh-Hans/common.json
+++ b/public/locales/zh-Hans/common.json
@@ -397,8 +397,12 @@
         "unknown": "未知"
     },
     "navidrome": {
-        "nothing_streaming": "暂无播放",
-        "please_wait": "请等待"
+        "nothing_streaming": "暂无活跃串流",
+        "please_wait": "请稍候",
+        "albums": "专辑",
+        "artists": "艺术家",
+        "playlists": "播放列表",
+        "songs": "歌曲"
     },
     "npm": {
         "enabled": "已启用",

--- a/public/locales/zh-Hant/common.json
+++ b/public/locales/zh-Hant/common.json
@@ -397,8 +397,12 @@
         "unknown": "Unknown"
     },
     "navidrome": {
-        "nothing_streaming": "No Active Streams",
-        "please_wait": "請稍後"
+        "nothing_streaming": "暫無活躍串流",
+        "please_wait": "請稍候",
+        "albums": "專輯",
+        "artists": "藝人",
+        "playlists": "播放清單",
+        "songs": "歌曲"
     },
     "npm": {
         "enabled": "已啟用",

--- a/src/widgets/navidrome/component.jsx
+++ b/src/widgets/navidrome/component.jsx
@@ -1,3 +1,4 @@
+import Block from "components/services/widget/block";
 import Container from "components/services/widget/container";
 import { useTranslation } from "next-i18next";
 
@@ -19,34 +20,84 @@ function SinglePlayingEntry({ entry }) {
   );
 }
 
+const statBlocks = [
+  ["artists", "navidrome.artists"],
+  ["albums", "navidrome.albums"],
+  ["songs", "navidrome.songs"],
+  ["playlists", "navidrome.playlists"],
+];
+
+function asArray(value) {
+  if (Array.isArray(value)) return value;
+  if (value) return [value];
+  return [];
+}
+
+function asEntryArray(entry) {
+  if (Array.isArray(entry)) return entry;
+  if (!entry) return [];
+  if (entry.id || entry.title || entry.artist || entry.album || entry.username) return [entry];
+  return Object.values(entry);
+}
+
+function LibraryStats({ libraryStats, service }) {
+  const { t } = useTranslation();
+
+  return (
+    <Container service={service}>
+      {statBlocks.map(([key, label]) => {
+        const value = libraryStats?.[key];
+        const displayValue = typeof value === "number" ? t("common.number", { value }) : "-";
+
+        return <Block key={key} label={label} value={libraryStats ? displayValue : undefined} />;
+      })}
+    </Container>
+  );
+}
+
 export default function Component({ service }) {
   const { t } = useTranslation();
 
   const { widget } = service;
 
   const { data: navidromeData, error: navidromeError } = useWidgetAPI(widget, "getNowPlaying");
+  const { data: libraryStats } = useWidgetAPI(widget, "libraryStats", {
+    refreshInterval: 60000,
+  });
 
   if (navidromeError || navidromeData?.["subsonic-response"]?.error) {
     return <Container service={service} error={navidromeError ?? navidromeData?.["subsonic-response"]?.error} />;
   }
 
   if (!navidromeData) {
-    return <SinglePlayingEntry entry={{ title: t("navidrome.please_wait") }} />;
+    return (
+      <>
+        <LibraryStats libraryStats={libraryStats} service={service} />
+        <SinglePlayingEntry entry={{ title: t("navidrome.please_wait") }} />
+      </>
+    );
   }
 
-  const { nowPlaying } = navidromeData["subsonic-response"];
-  if (!nowPlaying.entry) {
+  const nowPlaying = navidromeData?.["subsonic-response"]?.nowPlaying ?? {};
+  const nowPlayingEntries = asEntryArray(nowPlaying.entry);
+  if (!nowPlayingEntries.length) {
     // nothing playing
-    return <SinglePlayingEntry entry={{ title: t("navidrome.nothing_streaming") }} />;
+    return (
+      <>
+        <LibraryStats libraryStats={libraryStats} service={service} />
+        <SinglePlayingEntry entry={{ title: t("navidrome.nothing_streaming") }} />
+      </>
+    );
   }
-
-  const nowPlayingEntries = Object.values(nowPlaying.entry);
 
   return (
-    <div className="flex flex-col pb-1 mx-1">
-      {nowPlayingEntries.map((entry) => (
-        <SinglePlayingEntry key={entry.id} entry={entry} />
-      ))}
-    </div>
+    <>
+      <LibraryStats libraryStats={libraryStats} service={service} />
+      <div className="flex flex-col pb-1 mx-1">
+        {nowPlayingEntries.map((entry) => (
+          <SinglePlayingEntry key={entry.id} entry={entry} />
+        ))}
+      </div>
+    </>
   );
 }

--- a/src/widgets/navidrome/component.jsx
+++ b/src/widgets/navidrome/component.jsx
@@ -94,8 +94,8 @@ export default function Component({ service }) {
     <>
       <LibraryStats libraryStats={libraryStats} service={service} />
       <div className="flex flex-col pb-1 mx-1">
-        {nowPlayingEntries.map((entry) => (
-          <SinglePlayingEntry key={entry.id} entry={entry} />
+        {nowPlayingEntries.map((entry, index) => (
+          <SinglePlayingEntry key={entry.id ?? `${entry.title ?? "entry"}-${index}`} entry={entry} />
         ))}
       </div>
     </>

--- a/src/widgets/navidrome/component.test.jsx
+++ b/src/widgets/navidrome/component.test.jsx
@@ -87,6 +87,39 @@ describe("widgets/navidrome/component", () => {
     expect(screen.getByText("Artist - Song")).toBeInTheDocument();
   });
 
+  it("renders array now playing entries without ids", () => {
+    mockWidgetAPI({
+      nowPlayingData: {
+        "subsonic-response": {
+          nowPlaying: {
+            entry: [{ title: "First Song" }, { title: "Second Song", album: "Second Album", username: "listener" }],
+          },
+        },
+      },
+      libraryStats: { artists: 1, albums: 2, songs: 3, playlists: 4 },
+    });
+
+    renderWithProviders(<Component service={{ widget: { type: "navidrome" } }} />, { settings: { hideErrors: false } });
+
+    expect(screen.getByText("First Song")).toBeInTheDocument();
+    expect(screen.getByText("Second Song — Second Album (listener)")).toBeInTheDocument();
+  });
+
+  it("renders a Subsonic error container when the payload contains an error", () => {
+    mockWidgetAPI({
+      nowPlayingData: {
+        "subsonic-response": {
+          error: { message: "Wrong username or password" },
+        },
+      },
+    });
+
+    renderWithProviders(<Component service={{ widget: { type: "navidrome" } }} />, { settings: { hideErrors: false } });
+
+    expect(screen.getAllByText(/widget\.api_error/i).length).toBeGreaterThan(0);
+    expect(screen.getByText("Wrong username or password")).toBeInTheDocument();
+  });
+
   it("renders library counts with no active streams", () => {
     mockWidgetAPI({
       nowPlayingData: {

--- a/src/widgets/navidrome/component.test.jsx
+++ b/src/widgets/navidrome/component.test.jsx
@@ -15,16 +15,27 @@ describe("widgets/navidrome/component", () => {
     vi.clearAllMocks();
   });
 
+  function mockWidgetAPI({ nowPlayingData, nowPlayingError, libraryStats, libraryStatsError }) {
+    useWidgetAPI.mockImplementation((_widget, endpoint) => {
+      if (endpoint === "libraryStats") return { data: libraryStats, error: libraryStatsError };
+      return { data: nowPlayingData, error: nowPlayingError };
+    });
+  }
+
   it("renders a waiting row while loading", () => {
-    useWidgetAPI.mockReturnValue({ data: undefined, error: undefined });
+    mockWidgetAPI({});
 
     renderWithProviders(<Component service={{ widget: { type: "navidrome" } }} />, { settings: { hideErrors: false } });
 
     expect(screen.getByText("navidrome.please_wait")).toBeInTheDocument();
+    expect(screen.getByText("navidrome.artists")).toBeInTheDocument();
+    expect(screen.getByText("navidrome.albums")).toBeInTheDocument();
+    expect(screen.getByText("navidrome.songs")).toBeInTheDocument();
+    expect(screen.getByText("navidrome.playlists")).toBeInTheDocument();
   });
 
   it("renders an error container when the API errors", () => {
-    useWidgetAPI.mockReturnValue({ data: undefined, error: { message: "nope" } });
+    mockWidgetAPI({ nowPlayingError: { message: "nope" } });
 
     renderWithProviders(<Component service={{ widget: { type: "navidrome" } }} />, { settings: { hideErrors: false } });
 
@@ -33,8 +44,8 @@ describe("widgets/navidrome/component", () => {
   });
 
   it("renders now playing entries when present", () => {
-    useWidgetAPI.mockReturnValue({
-      data: {
+    mockWidgetAPI({
+      nowPlayingData: {
         "subsonic-response": {
           nowPlaying: {
             entry: {
@@ -43,11 +54,109 @@ describe("widgets/navidrome/component", () => {
           },
         },
       },
-      error: undefined,
+      libraryStats: { artists: 1, albums: 2, songs: 3, playlists: 4 },
     });
 
     renderWithProviders(<Component service={{ widget: { type: "navidrome" } }} />, { settings: { hideErrors: false } });
 
     expect(screen.getByText("Artist - Song — Album (user)")).toBeInTheDocument();
+    expect(screen.getByText("navidrome.artists")).toBeInTheDocument();
+    expect(screen.getByText("navidrome.albums")).toBeInTheDocument();
+    expect(screen.getByText("navidrome.songs")).toBeInTheDocument();
+    expect(screen.getByText("navidrome.playlists")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.getByText("4")).toBeInTheDocument();
+  });
+
+  it("renders a single-object now playing entry", () => {
+    mockWidgetAPI({
+      nowPlayingData: {
+        "subsonic-response": {
+          nowPlaying: {
+            entry: { id: "a", title: "Song", artist: "Artist" },
+          },
+        },
+      },
+      libraryStats: { artists: 1, albums: 2, songs: 3, playlists: 4 },
+    });
+
+    renderWithProviders(<Component service={{ widget: { type: "navidrome" } }} />, { settings: { hideErrors: false } });
+
+    expect(screen.getByText("Artist - Song")).toBeInTheDocument();
+  });
+
+  it("renders library counts with no active streams", () => {
+    mockWidgetAPI({
+      nowPlayingData: {
+        "subsonic-response": {
+          nowPlaying: {},
+        },
+      },
+      libraryStats: { artists: 1, albums: 2, songs: 3, playlists: 4 },
+    });
+
+    renderWithProviders(<Component service={{ widget: { type: "navidrome" } }} />, { settings: { hideErrors: false } });
+
+    expect(screen.getByText("navidrome.nothing_streaming")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.getByText("4")).toBeInTheDocument();
+  });
+
+  it("renders no active streams when now playing payload is missing", () => {
+    mockWidgetAPI({
+      nowPlayingData: {
+        "subsonic-response": {},
+      },
+      libraryStats: { artists: 1, albums: 2, songs: 3, playlists: 4 },
+    });
+
+    renderWithProviders(<Component service={{ widget: { type: "navidrome" } }} />, { settings: { hideErrors: false } });
+
+    expect(screen.getByText("navidrome.nothing_streaming")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.getByText("4")).toBeInTheDocument();
+  });
+
+  it("renders safe placeholders for missing library counts", () => {
+    mockWidgetAPI({
+      nowPlayingData: {
+        "subsonic-response": {
+          nowPlaying: {},
+        },
+      },
+      libraryStats: { artists: 1, albums: null, playlists: 4 },
+    });
+
+    const { container } = renderWithProviders(<Component service={{ widget: { type: "navidrome" } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.getByText("4")).toBeInTheDocument();
+    expect(container).not.toHaveTextContent("undefined");
+    expect(container).not.toHaveTextContent("NaN");
+  });
+
+  it("preserves now playing output when library stats error", () => {
+    mockWidgetAPI({
+      nowPlayingData: {
+        "subsonic-response": {
+          nowPlaying: {
+            entry: { id: "a", title: "Song", artist: "Artist" },
+          },
+        },
+      },
+      libraryStatsError: { message: "stats failed" },
+    });
+
+    renderWithProviders(<Component service={{ widget: { type: "navidrome" } }} />, { settings: { hideErrors: false } });
+
+    expect(screen.queryByText(/widget\.api_error/i)).not.toBeInTheDocument();
+    expect(screen.queryByText("stats failed")).not.toBeInTheDocument();
+    expect(screen.getByText("Artist - Song")).toBeInTheDocument();
   });
 });

--- a/src/widgets/navidrome/proxy.js
+++ b/src/widgets/navidrome/proxy.js
@@ -1,0 +1,163 @@
+import getServiceWidget from "utils/config/service-helpers";
+import createLogger from "utils/logger";
+import { formatApiCall, sanitizeErrorURL } from "utils/proxy/api-helpers";
+import { httpProxy } from "utils/proxy/http";
+import genericProxyHandler from "utils/proxy/handlers/generic";
+import widgets from "widgets/widgets";
+
+const logger = createLogger("navidromeProxyHandler");
+const ALBUM_PAGE_SIZE = 500;
+
+function sanitizeNavidromeURL(url) {
+  const sanitized = new URL(sanitizeErrorURL(url));
+  ["u", "t", "s"].forEach((key) => {
+    if (sanitized.searchParams.has(key)) sanitized.searchParams.set(key, "***");
+  });
+  return sanitized.toString();
+}
+
+function asArray(value) {
+  if (Array.isArray(value)) return value;
+  if (value) return [value];
+  return [];
+}
+
+function parseJson(data) {
+  if (!data) return {};
+  if (Buffer.isBuffer(data)) return JSON.parse(Buffer.from(data).toString());
+  if (typeof data === "string") return JSON.parse(data);
+  return data;
+}
+
+async function callNavidrome(widget, endpoint, queryParams) {
+  const url = new URL(formatApiCall(widgets[widget.type].api, { endpoint, ...widget }));
+  Object.entries(queryParams ?? {}).forEach(([key, value]) => {
+    url.searchParams.set(key, value);
+  });
+
+  const [status, , data] = await httpProxy(url);
+  const parsed = parseJson(data);
+
+  if (status >= 400 || parsed?.["subsonic-response"]?.error) {
+    return {
+      error: {
+        status,
+        data: parsed?.["subsonic-response"]?.error ?? parsed,
+        url: sanitizeNavidromeURL(url),
+      },
+    };
+  }
+
+  return { data: parsed?.["subsonic-response"] ?? parsed };
+}
+
+function countArtists(indexes) {
+  return asArray(indexes?.index).reduce((total, index) => total + asArray(index.artist).length, 0);
+}
+
+function summarizeAlbums(albumList) {
+  const albums = asArray(albumList?.album);
+  const songCounts = albums.map((album) => Number(album.songCount));
+  const hasReliableSongCounts = songCounts.every((songCount) => Number.isFinite(songCount));
+
+  return {
+    albums: albums.length,
+    songs: hasReliableSongCounts ? songCounts.reduce((total, songCount) => total + songCount, 0) : null,
+  };
+}
+
+function countPlaylists(playlists) {
+  return asArray(playlists?.playlist).length;
+}
+
+async function safeCall(widget, endpoint, queryParams) {
+  try {
+    return await callNavidrome(widget, endpoint, queryParams);
+  } catch (error) {
+    if (error) logger.error(error);
+    return { error: { status: 500, data: { message: "Unexpected error" } } };
+  }
+}
+
+async function getAlbumStats(widget) {
+  const albums = [];
+  const seenPageKeys = new Set();
+
+  for (let offset = 0; ; offset += ALBUM_PAGE_SIZE) {
+    const result = await safeCall(widget, "getAlbumList2", {
+      type: "alphabeticalByName",
+      size: ALBUM_PAGE_SIZE,
+      offset,
+    });
+
+    if (result.error) return result;
+
+    const pageAlbums = asArray(result.data?.albumList2?.album);
+    const pageKey = pageAlbums.map((album) => album.id ?? album.name).join("|");
+    if (pageAlbums.length && seenPageKeys.has(pageKey)) {
+      return { error: { status: 502, data: { message: "Navidrome album pagination did not advance" } } };
+    }
+    seenPageKeys.add(pageKey);
+    albums.push(...pageAlbums);
+
+    if (pageAlbums.length < ALBUM_PAGE_SIZE) {
+      return { data: { albumList2: { album: albums } } };
+    }
+  }
+}
+
+async function getLibraryStats(widget) {
+  const [artistsResult, albumsResult, playlistsResult] = await Promise.all([
+    safeCall(widget, "getIndexes"),
+    getAlbumStats(widget),
+    safeCall(widget, "getPlaylists"),
+  ]);
+
+  const errors = [artistsResult.error, albumsResult.error, playlistsResult.error].filter(Boolean);
+  if (errors.length === 3) {
+    return { error: errors[0] };
+  }
+
+  const albumStats = albumsResult.data ? summarizeAlbums(albumsResult.data.albumList2) : {};
+
+  return {
+    stats: {
+      artists: artistsResult.data ? countArtists(artistsResult.data.indexes) : null,
+      albums: albumStats.albums ?? null,
+      songs: albumStats.songs ?? null,
+      playlists: playlistsResult.data ? countPlaylists(playlistsResult.data.playlists) : null,
+    },
+  };
+}
+
+export default async function navidromeProxyHandler(req, res, map) {
+  if (req.query.endpoint !== "libraryStats") {
+    return genericProxyHandler(req, res, map);
+  }
+
+  const { group, service, index } = req.query;
+
+  if (!group || !service) {
+    logger.debug("Invalid or missing proxy service type '%s' in group '%s'", service, group);
+    return res.status(400).json({ error: "Invalid proxy service type" });
+  }
+
+  const widget = await getServiceWidget(group, service, index);
+
+  if (!widget || !widgets?.[widget.type]?.api) {
+    logger.debug("Invalid or missing proxy service type '%s' in group '%s'", service, group);
+    return res.status(403).json({ error: "Service does not support API calls" });
+  }
+
+  try {
+    const { stats, error } = await getLibraryStats(widget);
+    if (error) {
+      return res.status(error.status || 500).json({ error });
+    }
+
+    return res.status(200).json(stats);
+  } catch (error) {
+    if (error) logger.error(error);
+    return res.status(500).json({ error: { message: "Unexpected error" } });
+  }
+}

--- a/src/widgets/navidrome/proxy.js
+++ b/src/widgets/navidrome/proxy.js
@@ -1,8 +1,8 @@
 import getServiceWidget from "utils/config/service-helpers";
 import createLogger from "utils/logger";
 import { formatApiCall, sanitizeErrorURL } from "utils/proxy/api-helpers";
-import { httpProxy } from "utils/proxy/http";
 import genericProxyHandler from "utils/proxy/handlers/generic";
+import { httpProxy } from "utils/proxy/http";
 import widgets from "widgets/widgets";
 
 const logger = createLogger("navidromeProxyHandler");

--- a/src/widgets/navidrome/proxy.test.js
+++ b/src/widgets/navidrome/proxy.test.js
@@ -104,7 +104,10 @@ describe("navidrome proxy", () => {
         jsonResponse({
           "subsonic-response": {
             albumList2: {
-              album: [{ id: "a", songCount: 5 }, { id: "b", songCount: 7 }],
+              album: [
+                { id: "a", songCount: 5 },
+                { id: "b", songCount: 7 },
+              ],
             },
           },
         }),

--- a/src/widgets/navidrome/proxy.test.js
+++ b/src/widgets/navidrome/proxy.test.js
@@ -89,6 +89,18 @@ describe("navidrome proxy", () => {
     expect(httpProxy).not.toHaveBeenCalled();
   });
 
+  it("rejects services with an unsupported widget type", async () => {
+    getServiceWidget.mockResolvedValueOnce({ type: "unsupported" });
+    const req = { query: { group: "g", service: "s", index: "0", endpoint: "libraryStats" } };
+    const res = createMockRes();
+
+    await navidromeProxyHandler(req, res);
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toEqual({ error: "Service does not support API calls" });
+    expect(httpProxy).not.toHaveBeenCalled();
+  });
+
   it("aggregates library stats from Subsonic-compatible responses", async () => {
     httpProxy
       .mockResolvedValueOnce(
@@ -134,6 +146,21 @@ describe("navidrome proxy", () => {
     expect(httpProxy.mock.calls[1][0].searchParams.get("type")).toBe("alphabeticalByName");
     expect(httpProxy.mock.calls[1][0].searchParams.get("size")).toBe("500");
     expect(httpProxy.mock.calls[1][0].searchParams.get("offset")).toBe("0");
+  });
+
+  it("aggregates library stats from already-parsed JSON responses", async () => {
+    httpProxy
+      .mockResolvedValueOnce([200, "application/json", { indexes: { index: [{ artist: [{ id: "1" }] }] } }])
+      .mockResolvedValueOnce([200, "application/json", { albumList2: { album: [{ id: "a", songCount: 2 }] } }])
+      .mockResolvedValueOnce([200, "application/json", { playlists: { playlist: [{ id: "p1" }] } }]);
+
+    const req = { query: { group: "g", service: "s", index: "0", endpoint: "libraryStats" } };
+    const res = createMockRes();
+
+    await navidromeProxyHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ artists: 1, albums: 1, songs: 2, playlists: 1 });
   });
 
   it("aggregates album and song stats across multiple album pages", async () => {
@@ -224,6 +251,42 @@ describe("navidrome proxy", () => {
     expect(res.body).toEqual({ artists: 0, albums: 1, songs: null, playlists: 0 });
   });
 
+  it("returns a sanitized Subsonic error when every upstream call reports one", async () => {
+    httpProxy
+      .mockResolvedValueOnce(
+        jsonResponse({
+          "subsonic-response": {
+            error: { code: 40, message: "Wrong username or password" },
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          "subsonic-response": {
+            error: { code: 40, message: "Wrong username or password" },
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          "subsonic-response": {
+            error: { code: 40, message: "Wrong username or password" },
+          },
+        }),
+      );
+
+    const req = { query: { group: "g", service: "s", index: "0", endpoint: "libraryStats" } };
+    const res = createMockRes();
+
+    await navidromeProxyHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.error.data).toEqual({ code: 40, message: "Wrong username or password" });
+    expect(res.body.error.url).toContain("t=***");
+    expect(res.body.error.url).toContain("u=***");
+    expect(res.body.error.url).toContain("s=***");
+  });
+
   it("returns partial stats when album pagination does not advance", async () => {
     httpProxy
       .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { indexes: { index: [] } } }))
@@ -260,6 +323,21 @@ describe("navidrome proxy", () => {
     httpProxy
       .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { indexes: { index: [{ artist: [{ id: "1" }] }] } } }))
       .mockResolvedValueOnce([500, "application/json", Buffer.from(JSON.stringify({ error: "boom" }))])
+      .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { playlists: { playlist: [{ id: "p1" }] } } }));
+
+    const req = { query: { group: "g", service: "s", index: "0", endpoint: "libraryStats" } };
+    const res = createMockRes();
+
+    await navidromeProxyHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ artists: 1, albums: null, songs: null, playlists: 1 });
+  });
+
+  it("returns partial stats when one upstream call throws", async () => {
+    httpProxy
+      .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { indexes: { index: [{ artist: [{ id: "1" }] }] } } }))
+      .mockRejectedValueOnce(new Error("connection reset"))
       .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { playlists: { playlist: [{ id: "p1" }] } } }));
 
     const req = { query: { group: "g", service: "s", index: "0", endpoint: "libraryStats" } };

--- a/src/widgets/navidrome/proxy.test.js
+++ b/src/widgets/navidrome/proxy.test.js
@@ -1,0 +1,290 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getServiceWidget, genericProxyHandler, httpProxy } = vi.hoisted(() => ({
+  getServiceWidget: vi.fn(),
+  genericProxyHandler: vi.fn(),
+  httpProxy: vi.fn(),
+}));
+
+vi.mock("utils/config/service-helpers", () => ({ default: getServiceWidget }));
+vi.mock("utils/logger", () => ({ default: () => ({ debug: vi.fn(), error: vi.fn() }) }));
+vi.mock("utils/proxy/handlers/generic", () => ({ default: genericProxyHandler }));
+vi.mock("utils/proxy/http", () => ({ httpProxy }));
+vi.mock("widgets/widgets", () => ({
+  default: {
+    navidrome: {
+      api: "{url}/rest/{endpoint}?u={user}&t={token}&s={salt}&v=1.16.1&c=homepage&f=json",
+    },
+  },
+}));
+
+import navidromeProxyHandler from "./proxy";
+
+function createMockRes() {
+  const res = {
+    statusCode: undefined,
+    body: undefined,
+    status: vi.fn((code) => {
+      res.statusCode = code;
+      return res;
+    }),
+    json: vi.fn((body) => {
+      res.body = body;
+      return res;
+    }),
+    send: vi.fn((body) => {
+      res.body = body;
+      return res;
+    }),
+  };
+  return res;
+}
+
+function jsonResponse(payload) {
+  return [200, "application/json", Buffer.from(JSON.stringify(payload))];
+}
+
+describe("navidrome proxy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getServiceWidget.mockResolvedValue({
+      type: "navidrome",
+      url: "http://navidrome.test",
+      user: "user",
+      token: "token",
+      salt: "salt",
+    });
+  });
+
+  it("delegates non-library endpoints to the generic proxy handler", async () => {
+    const req = { query: { endpoint: "getNowPlaying" } };
+    const res = createMockRes();
+
+    await navidromeProxyHandler(req, res);
+
+    expect(genericProxyHandler).toHaveBeenCalledWith(req, res, undefined);
+  });
+
+  it("rejects library stats requests without group or service", async () => {
+    const req = { query: { endpoint: "libraryStats", group: "g" } };
+    const res = createMockRes();
+
+    await navidromeProxyHandler(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: "Invalid proxy service type" });
+    expect(getServiceWidget).not.toHaveBeenCalled();
+    expect(httpProxy).not.toHaveBeenCalled();
+  });
+
+  it("rejects services that do not resolve to a supported widget API", async () => {
+    getServiceWidget.mockResolvedValueOnce(undefined);
+    const req = { query: { group: "g", service: "s", index: "0", endpoint: "libraryStats" } };
+    const res = createMockRes();
+
+    await navidromeProxyHandler(req, res);
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toEqual({ error: "Service does not support API calls" });
+    expect(httpProxy).not.toHaveBeenCalled();
+  });
+
+  it("aggregates library stats from Subsonic-compatible responses", async () => {
+    httpProxy
+      .mockResolvedValueOnce(
+        jsonResponse({
+          "subsonic-response": {
+            indexes: {
+              index: [{ artist: [{ id: "1" }, { id: "2" }] }, { artist: [{ id: "3" }] }],
+            },
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          "subsonic-response": {
+            albumList2: {
+              album: [{ id: "a", songCount: 5 }, { id: "b", songCount: 7 }],
+            },
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          "subsonic-response": {
+            playlists: {
+              playlist: [{ id: "p1" }, { id: "p2" }],
+            },
+          },
+        }),
+      );
+
+    const req = { query: { group: "g", service: "s", index: "0", endpoint: "libraryStats" } };
+    const res = createMockRes();
+
+    await navidromeProxyHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ artists: 3, albums: 2, songs: 12, playlists: 2 });
+    expect(httpProxy).toHaveBeenCalledTimes(3);
+    expect(httpProxy.mock.calls[1][0].pathname).toBe("/rest/getAlbumList2");
+    expect(httpProxy.mock.calls[1][0].searchParams.get("type")).toBe("alphabeticalByName");
+    expect(httpProxy.mock.calls[1][0].searchParams.get("size")).toBe("500");
+    expect(httpProxy.mock.calls[1][0].searchParams.get("offset")).toBe("0");
+  });
+
+  it("aggregates album and song stats across multiple album pages", async () => {
+    httpProxy
+      .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { indexes: { index: [] } } }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          "subsonic-response": {
+            albumList2: {
+              album: Array.from({ length: 500 }, (_, index) => ({ id: `album-${index}`, songCount: 1 })),
+            },
+          },
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { playlists: { playlist: [] } } }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          "subsonic-response": {
+            albumList2: {
+              album: [{ id: "album-500", songCount: 2 }],
+            },
+          },
+        }),
+      );
+
+    const req = { query: { group: "g", service: "s", index: "0", endpoint: "libraryStats" } };
+    const res = createMockRes();
+
+    await navidromeProxyHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ artists: 0, albums: 501, songs: 502, playlists: 0 });
+    expect(httpProxy.mock.calls[1][0].searchParams.get("offset")).toBe("0");
+    expect(httpProxy.mock.calls[3][0].searchParams.get("offset")).toBe("500");
+  });
+
+  it("normalizes singleton Subsonic response objects", async () => {
+    httpProxy
+      .mockResolvedValueOnce(
+        jsonResponse({
+          "subsonic-response": {
+            indexes: {
+              index: { artist: { id: "1" } },
+            },
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          "subsonic-response": {
+            albumList2: {
+              album: { id: "a", songCount: 5 },
+            },
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          "subsonic-response": {
+            playlists: {
+              playlist: { id: "p1" },
+            },
+          },
+        }),
+      );
+
+    const req = { query: { group: "g", service: "s", index: "0", endpoint: "libraryStats" } };
+    const res = createMockRes();
+
+    await navidromeProxyHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ artists: 1, albums: 1, songs: 5, playlists: 1 });
+  });
+
+  it("returns a placeholder song count when album song counts are missing", async () => {
+    httpProxy
+      .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { indexes: { index: [] } } }))
+      .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { albumList2: { album: [{ id: "a" }] } } }))
+      .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { playlists: { playlist: [] } } }));
+
+    const req = { query: { group: "g", service: "s", index: "0", endpoint: "libraryStats" } };
+    const res = createMockRes();
+
+    await navidromeProxyHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ artists: 0, albums: 1, songs: null, playlists: 0 });
+  });
+
+  it("returns partial stats when album pagination does not advance", async () => {
+    httpProxy
+      .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { indexes: { index: [] } } }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          "subsonic-response": {
+            albumList2: {
+              album: Array.from({ length: 500 }, (_, index) => ({ id: `album-${index}`, songCount: 1 })),
+            },
+          },
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { playlists: { playlist: [] } } }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          "subsonic-response": {
+            albumList2: {
+              album: Array.from({ length: 500 }, (_, index) => ({ id: `album-${index}`, songCount: 1 })),
+            },
+          },
+        }),
+      );
+
+    const req = { query: { group: "g", service: "s", index: "0", endpoint: "libraryStats" } };
+    const res = createMockRes();
+
+    await navidromeProxyHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ artists: 0, albums: null, songs: null, playlists: 0 });
+  });
+
+  it("returns partial stats when one upstream call fails", async () => {
+    httpProxy
+      .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { indexes: { index: [{ artist: [{ id: "1" }] }] } } }))
+      .mockResolvedValueOnce([500, "application/json", Buffer.from(JSON.stringify({ error: "boom" }))])
+      .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { playlists: { playlist: [{ id: "p1" }] } } }));
+
+    const req = { query: { group: "g", service: "s", index: "0", endpoint: "libraryStats" } };
+    const res = createMockRes();
+
+    await navidromeProxyHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ artists: 1, albums: null, songs: null, playlists: 1 });
+  });
+
+  it("returns an error when every upstream stats call fails", async () => {
+    httpProxy
+      .mockResolvedValueOnce([500, "application/json", Buffer.from(JSON.stringify({ error: "a" }))])
+      .mockResolvedValueOnce([500, "application/json", Buffer.from(JSON.stringify({ error: "b" }))])
+      .mockResolvedValueOnce([500, "application/json", Buffer.from(JSON.stringify({ error: "c" }))]);
+
+    const req = { query: { group: "g", service: "s", index: "0", endpoint: "libraryStats" } };
+    const res = createMockRes();
+
+    await navidromeProxyHandler(req, res);
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body.error.url).toContain("t=***");
+    expect(res.body.error.url).toContain("u=***");
+    expect(res.body.error.url).toContain("s=***");
+    expect(res.body.error.url).not.toContain("user");
+    expect(res.body.error.url).not.toContain("token");
+    expect(res.body.error.url).not.toContain("salt");
+  });
+});

--- a/src/widgets/navidrome/widget.js
+++ b/src/widgets/navidrome/widget.js
@@ -1,12 +1,15 @@
-import genericProxyHandler from "utils/proxy/handlers/generic";
+import navidromeProxyHandler from "./proxy";
 
 const widget = {
   api: "{url}/rest/{endpoint}?u={user}&t={token}&s={salt}&v=1.16.1&c=homepage&f=json",
-  proxyHandler: genericProxyHandler,
+  proxyHandler: navidromeProxyHandler,
 
   mappings: {
     getNowPlaying: {
       endpoint: "getNowPlaying",
+    },
+    libraryStats: {
+      endpoint: "libraryStats",
     },
   },
 };


### PR DESCRIPTION
## Proposed change

Adds Navidrome library statistics support to the existing Navidrome widget.

AI disclosure: I used AI assistance while developing and revising this PR.
<img width="512" height="167" alt="image" src="https://github.com/user-attachments/assets/b2fff28f-8d64-41d5-85b4-f6fb9f29814e" />


### Summary
- Adds a new `libraryStats` proxy endpoint for Navidrome service widgets.
- Aggregates and returns counts for:
  - artists
  - albums
  - songs
  - playlists
- Updates the Navidrome widget UI to display library counts alongside now-playing entries.
- Handles partial upstream failures gracefully by returning available stats where possible.
- Adds robust tests for proxy behavior (including pagination and failure modes) and component rendering states.
- Updates Navidrome widget docs to reflect the newly displayed fields.
- Updates the English locale labels for new Navidrome stat keys.

Related discussion: https://github.com/gethomepage/homepage/discussions/6027

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget
guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
  - Related request discussion: https://github.com/gethomepage/homepage/discussions/6027
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting
checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] In the description above I have disclosed the use of AI tools in the coding of this PR.



