### PR TITLE
Add Navidrome library stats

### DIFF
--- a/docs/widgets/services/navidrome.md
+++ b/docs/widgets/services/navidrome.md
@@ -7,7 +7,9 @@ Learn more about [Navidrome](https://github.com/navidrome/navidrome).
 
 For detailed information about how to generate the token see http://www.subsonic.org/pages/api.jsp.
 
-Allowed fields: no configurable fields for this widget.
+Displayed fields: now playing entries plus library counts for `artists`, `albums`, `songs`, and `playlists`.
+
+The displayed fields are not configurable. The library counts use Navidrome's Subsonic-compatible API and may depend on the server returning compatible artist, album, scan status, and playlist responses.
 
 ```yaml
 widget:

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -331,14 +331,14 @@
         "total": "Total"
     },
     "suwayomi": {
-      "download": "Downloaded",
-      "nondownload": "Non-Downloaded",
-      "read": "Read",
-      "unread": "Unread",
-      "downloadedread": "Downloaded & Read",
-      "downloadedunread": "Downloaded & Unread",
-      "nondownloadedread": "Non-Downloaded & Read",
-      "nondownloadedunread": "Non-Downloaded & Unread"
+        "download": "Downloaded",
+        "nondownload": "Non-Downloaded",
+        "read": "Read",
+        "unread": "Unread",
+        "downloadedread": "Downloaded & Read",
+        "downloadedunread": "Downloaded & Unread",
+        "nondownloadedread": "Non-Downloaded & Read",
+        "nondownloadedunread": "Non-Downloaded & Unread"
     },
     "tailscale": {
         "address": "Address",
@@ -397,8 +397,12 @@
         "unknown": "Unknown"
     },
     "navidrome": {
+        "albums": "Albums",
+        "artists": "Artists",
         "nothing_streaming": "No Active Streams",
-        "please_wait": "Please Wait"
+        "playlists": "Playlists",
+        "please_wait": "Please Wait",
+        "songs": "Songs"
     },
     "npm": {
         "enabled": "Enabled",
@@ -869,7 +873,7 @@
         "ping": "Ping"
     },
     "urbackup": {
-        "ok" : "Ok",
+        "ok": "Ok",
         "errored": "Errors",
         "noRecent": "Out of Date",
         "totalUsed": "Used Storage"
@@ -927,27 +931,27 @@
         "totalfilesize": "Total Size"
     },
     "mailcow": {
-      "domains": "Domains",
-      "mailboxes": "Mailboxes",
-      "mails": "Mails",
-      "storage": "Storage"
+        "domains": "Domains",
+        "mailboxes": "Mailboxes",
+        "mails": "Mails",
+        "storage": "Storage"
     },
     "netdata": {
-      "warnings": "Warnings",
-      "criticals": "Criticals"
+        "warnings": "Warnings",
+        "criticals": "Criticals"
     },
     "ntfy": {
-      "title": "Title",
-      "priority": "Priority",
-      "lastReceived": "Last Received",
-      "message": "Message",
-      "tags": "Tags",
-      "none": "None",
-      "min": "Min",
-      "low": "Low",
-      "default": "Default",
-      "high": "High",
-      "urgent": "Urgent"
+        "title": "Title",
+        "priority": "Priority",
+        "lastReceived": "Last Received",
+        "message": "Message",
+        "tags": "Tags",
+        "none": "None",
+        "min": "Min",
+        "low": "Low",
+        "default": "Default",
+        "high": "High",
+        "urgent": "Urgent"
     },
     "plantit": {
         "events": "Events",
@@ -956,10 +960,10 @@
         "species": "Species"
     },
     "gitea": {
-      "notifications": "Notifications",
-      "issues": "Issues",
-      "pulls": "Pull Requests",
-      "repositories": "Repositories"
+        "notifications": "Notifications",
+        "issues": "Issues",
+        "pulls": "Pull Requests",
+        "repositories": "Repositories"
     },
     "stash": {
         "scenes": "Scenes",
@@ -1029,48 +1033,48 @@
         "tags": "Tags"
     },
     "zabbix": {
-      "unclassified": "Not classified",
-      "information": "Information",
-      "warning": "Warning",
-      "average": "Average",
-      "high": "High",
-      "disaster": "Disaster"
+        "unclassified": "Not classified",
+        "information": "Information",
+        "warning": "Warning",
+        "average": "Average",
+        "high": "High",
+        "disaster": "Disaster"
     },
     "lubelogger": {
-      "vehicle": "Vehicle",
-      "vehicles": "Vehicles",
-      "serviceRecords": "Service Records",
-      "reminders": "Reminders",
-      "nextReminder": "Next Reminder",
-      "none": "None"
+        "vehicle": "Vehicle",
+        "vehicles": "Vehicles",
+        "serviceRecords": "Service Records",
+        "reminders": "Reminders",
+        "nextReminder": "Next Reminder",
+        "none": "None"
     },
     "vikunja": {
-      "projects": "Active Projects",
-      "tasks7d": "Tasks Due This Week",
-      "tasksOverdue": "Overdue Tasks",
-      "tasksInProgress": "Tasks In Progress"
+        "projects": "Active Projects",
+        "tasks7d": "Tasks Due This Week",
+        "tasksOverdue": "Overdue Tasks",
+        "tasksInProgress": "Tasks In Progress"
     },
     "headscale": {
-      "name": "Name",
-      "address": "Address",
-      "last_seen": "Last Seen",
-      "status": "Status",
-      "online": "Online",
-      "offline": "Offline"
+        "name": "Name",
+        "address": "Address",
+        "last_seen": "Last Seen",
+        "status": "Status",
+        "online": "Online",
+        "offline": "Offline"
     },
     "beszel": {
-      "name": "Name",
-      "systems": "Systems",
-      "up": "Up",
-      "down": "Down",
-      "paused": "Paused",
-      "pending": "Pending",
-      "status": "Status",
-      "updated": "Updated",
-      "cpu": "CPU",
-      "memory": "MEM",
-      "disk": "Disk",
-      "network": "NET"
+        "name": "Name",
+        "systems": "Systems",
+        "up": "Up",
+        "down": "Down",
+        "paused": "Paused",
+        "pending": "Pending",
+        "status": "Status",
+        "updated": "Updated",
+        "cpu": "CPU",
+        "memory": "MEM",
+        "disk": "Disk",
+        "network": "NET"
     },
     "argocd": {
         "apps": "Apps",
@@ -1094,8 +1098,8 @@
     "apcups": {
         "status": "Status",
         "load": "Load",
-        "bcharge":"Battery Charge",
-        "timeleft":"Time Left"
+        "bcharge": "Battery Charge",
+        "timeleft": "Time Left"
     },
     "karakeep": {
         "bookmarks": "Bookmarks",
@@ -1180,9 +1184,9 @@
         "bytes_added_30": "Bytes Added"
     },
     "yourspotify": {
-      "songs": "Songs",
-      "time":  "Time",
-      "artists": "Artists"
+        "songs": "Songs",
+        "time": "Time",
+        "artists": "Artists"
     },
     "arcane": {
         "containers": "Containers",

--- a/src/widgets/navidrome/component.jsx
+++ b/src/widgets/navidrome/component.jsx
@@ -1,3 +1,4 @@
+import Block from "components/services/widget/block";
 import Container from "components/services/widget/container";
 import { useTranslation } from "next-i18next";
 
@@ -19,34 +20,78 @@ function SinglePlayingEntry({ entry }) {
   );
 }
 
+const statBlocks = [
+  ["artists", "navidrome.artists"],
+  ["albums", "navidrome.albums"],
+  ["songs", "navidrome.songs"],
+  ["playlists", "navidrome.playlists"],
+];
+
+function asEntryArray(entry) {
+  if (Array.isArray(entry)) return entry;
+  if (!entry) return [];
+  if (entry.id || entry.title || entry.artist || entry.album || entry.username) return [entry];
+  return Object.values(entry);
+}
+
+function LibraryStats({ libraryStats, service }) {
+  const { t } = useTranslation();
+
+  return (
+    <Container service={service}>
+      {statBlocks.map(([key, label]) => {
+        const value = libraryStats?.[key];
+        const displayValue = typeof value === "number" ? t("common.number", { value }) : "-";
+
+        return <Block key={key} label={label} value={libraryStats ? displayValue : undefined} />;
+      })}
+    </Container>
+  );
+}
+
 export default function Component({ service }) {
   const { t } = useTranslation();
 
   const { widget } = service;
 
   const { data: navidromeData, error: navidromeError } = useWidgetAPI(widget, "getNowPlaying");
+  const { data: libraryStats } = useWidgetAPI(widget, "libraryStats", {
+    refreshInterval: 60000,
+  });
 
   if (navidromeError || navidromeData?.["subsonic-response"]?.error) {
     return <Container service={service} error={navidromeError ?? navidromeData?.["subsonic-response"]?.error} />;
   }
 
   if (!navidromeData) {
-    return <SinglePlayingEntry entry={{ title: t("navidrome.please_wait") }} />;
+    return (
+      <>
+        <LibraryStats libraryStats={libraryStats} service={service} />
+        <SinglePlayingEntry entry={{ title: t("navidrome.please_wait") }} />
+      </>
+    );
   }
 
-  const { nowPlaying } = navidromeData["subsonic-response"];
-  if (!nowPlaying.entry) {
+  const nowPlaying = navidromeData?.["subsonic-response"]?.nowPlaying ?? {};
+  const nowPlayingEntries = asEntryArray(nowPlaying.entry);
+  if (!nowPlayingEntries.length) {
     // nothing playing
-    return <SinglePlayingEntry entry={{ title: t("navidrome.nothing_streaming") }} />;
+    return (
+      <>
+        <LibraryStats libraryStats={libraryStats} service={service} />
+        <SinglePlayingEntry entry={{ title: t("navidrome.nothing_streaming") }} />
+      </>
+    );
   }
-
-  const nowPlayingEntries = Object.values(nowPlaying.entry);
 
   return (
-    <div className="flex flex-col pb-1 mx-1">
-      {nowPlayingEntries.map((entry) => (
-        <SinglePlayingEntry key={entry.id} entry={entry} />
-      ))}
-    </div>
+    <>
+      <LibraryStats libraryStats={libraryStats} service={service} />
+      <div className="flex flex-col pb-1 mx-1">
+        {nowPlayingEntries.map((entry, index) => (
+          <SinglePlayingEntry key={entry.id ?? `${entry.title ?? "entry"}-${index}`} entry={entry} />
+        ))}
+      </div>
+    </>
   );
 }

--- a/src/widgets/navidrome/component.test.jsx
+++ b/src/widgets/navidrome/component.test.jsx
@@ -15,16 +15,27 @@ describe("widgets/navidrome/component", () => {
     vi.clearAllMocks();
   });
 
+  function mockWidgetAPI({ nowPlayingData, nowPlayingError, libraryStats, libraryStatsError }) {
+    useWidgetAPI.mockImplementation((_widget, endpoint) => {
+      if (endpoint === "libraryStats") return { data: libraryStats, error: libraryStatsError };
+      return { data: nowPlayingData, error: nowPlayingError };
+    });
+  }
+
   it("renders a waiting row while loading", () => {
-    useWidgetAPI.mockReturnValue({ data: undefined, error: undefined });
+    mockWidgetAPI({});
 
     renderWithProviders(<Component service={{ widget: { type: "navidrome" } }} />, { settings: { hideErrors: false } });
 
     expect(screen.getByText("navidrome.please_wait")).toBeInTheDocument();
+    expect(screen.getByText("navidrome.playlists")).toBeInTheDocument();
+    expect(screen.getByText("navidrome.artists")).toBeInTheDocument();
+    expect(screen.getByText("navidrome.albums")).toBeInTheDocument();
+    expect(screen.getByText("navidrome.songs")).toBeInTheDocument();
   });
 
   it("renders an error container when the API errors", () => {
-    useWidgetAPI.mockReturnValue({ data: undefined, error: { message: "nope" } });
+    mockWidgetAPI({ nowPlayingError: { message: "nope" } });
 
     renderWithProviders(<Component service={{ widget: { type: "navidrome" } }} />, { settings: { hideErrors: false } });
 
@@ -33,8 +44,8 @@ describe("widgets/navidrome/component", () => {
   });
 
   it("renders now playing entries when present", () => {
-    useWidgetAPI.mockReturnValue({
-      data: {
+    mockWidgetAPI({
+      nowPlayingData: {
         "subsonic-response": {
           nowPlaying: {
             entry: {
@@ -43,11 +54,164 @@ describe("widgets/navidrome/component", () => {
           },
         },
       },
-      error: undefined,
+      libraryStats: { playlists: 1, artists: 2, albums: 3, songs: 4 },
     });
 
     renderWithProviders(<Component service={{ widget: { type: "navidrome" } }} />, { settings: { hideErrors: false } });
 
     expect(screen.getByText("Artist - Song — Album (user)")).toBeInTheDocument();
+    expect(screen.getByText("navidrome.playlists")).toBeInTheDocument();
+    expect(screen.getByText("navidrome.artists")).toBeInTheDocument();
+    expect(screen.getByText("navidrome.albums")).toBeInTheDocument();
+    expect(screen.getByText("navidrome.songs")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.getByText("4")).toBeInTheDocument();
+  });
+
+  it("renders a single-object now playing entry", () => {
+    mockWidgetAPI({
+      nowPlayingData: {
+        "subsonic-response": {
+          nowPlaying: {
+            entry: { id: "a", title: "Song", artist: "Artist" },
+          },
+        },
+      },
+      libraryStats: { playlists: 1, artists: 2, albums: 3, songs: 4 },
+    });
+
+    renderWithProviders(<Component service={{ widget: { type: "navidrome" } }} />, { settings: { hideErrors: false } });
+
+    expect(screen.getByText("Artist - Song")).toBeInTheDocument();
+  });
+
+  it("renders array now playing entries without ids", () => {
+    mockWidgetAPI({
+      nowPlayingData: {
+        "subsonic-response": {
+          nowPlaying: {
+            entry: [{ title: "First Song" }, { title: "Second Song", album: "Second Album", username: "listener" }],
+          },
+        },
+      },
+      libraryStats: { playlists: 1, artists: 2, albums: 3, songs: 4 },
+    });
+
+    renderWithProviders(<Component service={{ widget: { type: "navidrome" } }} />, { settings: { hideErrors: false } });
+
+    expect(screen.getByText("First Song")).toBeInTheDocument();
+    expect(screen.getByText("Second Song — Second Album (listener)")).toBeInTheDocument();
+  });
+
+  it("renders now playing entries with fallback labels and keys", () => {
+    mockWidgetAPI({
+      nowPlayingData: {
+        "subsonic-response": {
+          nowPlaying: {
+            entry: [{ artist: "First Artist" }, { album: "Second Album" }, { username: "listener" }],
+          },
+        },
+      },
+      libraryStats: {},
+    });
+
+    const { container } = renderWithProviders(<Component service={{ widget: { type: "navidrome" } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expect(screen.getByText("First Artist - undefined")).toBeInTheDocument();
+    expect(screen.getByText("undefined — Second Album")).toBeInTheDocument();
+    expect(screen.getByText("undefined (listener)")).toBeInTheDocument();
+    expect(container).toHaveTextContent("navidrome.artists");
+  });
+
+  it("renders a Subsonic error container when the payload contains an error", () => {
+    mockWidgetAPI({
+      nowPlayingData: {
+        "subsonic-response": {
+          error: { message: "Wrong username or password" },
+        },
+      },
+    });
+
+    renderWithProviders(<Component service={{ widget: { type: "navidrome" } }} />, { settings: { hideErrors: false } });
+
+    expect(screen.getAllByText(/widget\.api_error/i).length).toBeGreaterThan(0);
+    expect(screen.getByText("Wrong username or password")).toBeInTheDocument();
+  });
+
+  it("renders library counts with no active streams", () => {
+    mockWidgetAPI({
+      nowPlayingData: {
+        "subsonic-response": {
+          nowPlaying: {},
+        },
+      },
+      libraryStats: { playlists: 1, artists: 2, albums: 3, songs: 4 },
+    });
+
+    renderWithProviders(<Component service={{ widget: { type: "navidrome" } }} />, { settings: { hideErrors: false } });
+
+    expect(screen.getByText("navidrome.nothing_streaming")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.getByText("4")).toBeInTheDocument();
+  });
+
+  it("renders no active streams when now playing payload is missing", () => {
+    mockWidgetAPI({
+      nowPlayingData: {
+        "subsonic-response": {},
+      },
+      libraryStats: { playlists: 1, artists: 2, albums: 3, songs: 4 },
+    });
+
+    renderWithProviders(<Component service={{ widget: { type: "navidrome" } }} />, { settings: { hideErrors: false } });
+
+    expect(screen.getByText("navidrome.nothing_streaming")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.getByText("4")).toBeInTheDocument();
+  });
+
+  it("renders safe placeholders for missing library counts", () => {
+    mockWidgetAPI({
+      nowPlayingData: {
+        "subsonic-response": {
+          nowPlaying: {},
+        },
+      },
+      libraryStats: { playlists: 1, albums: null, songs: 4 },
+    });
+
+    const { container } = renderWithProviders(<Component service={{ widget: { type: "navidrome" } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.getByText("4")).toBeInTheDocument();
+    expect(container).not.toHaveTextContent("undefined");
+    expect(container).not.toHaveTextContent("NaN");
+  });
+
+  it("preserves now playing output when library stats error", () => {
+    mockWidgetAPI({
+      nowPlayingData: {
+        "subsonic-response": {
+          nowPlaying: {
+            entry: { id: "a", title: "Song", artist: "Artist" },
+          },
+        },
+      },
+      libraryStatsError: { message: "stats failed" },
+    });
+
+    renderWithProviders(<Component service={{ widget: { type: "navidrome" } }} />, { settings: { hideErrors: false } });
+
+    expect(screen.queryByText(/widget\.api_error/i)).not.toBeInTheDocument();
+    expect(screen.queryByText("stats failed")).not.toBeInTheDocument();
+    expect(screen.getByText("Artist - Song")).toBeInTheDocument();
   });
 });

--- a/src/widgets/navidrome/proxy.js
+++ b/src/widgets/navidrome/proxy.js
@@ -1,0 +1,168 @@
+import getServiceWidget from "utils/config/service-helpers";
+import createLogger from "utils/logger";
+import { formatApiCall, sanitizeErrorURL } from "utils/proxy/api-helpers";
+import genericProxyHandler from "utils/proxy/handlers/generic";
+import { httpProxy } from "utils/proxy/http";
+import widgets from "widgets/widgets";
+
+const logger = createLogger("navidromeProxyHandler");
+const ALBUM_PAGE_SIZE = 500;
+
+function sanitizeNavidromeURL(url) {
+  const sanitized = new URL(sanitizeErrorURL(url));
+  ["u", "t", "s"].forEach((key) => {
+    if (sanitized.searchParams.has(key)) sanitized.searchParams.set(key, "***");
+  });
+  return sanitized.toString();
+}
+
+function asArray(value) {
+  if (Array.isArray(value)) return value;
+  if (value) return [value];
+  return [];
+}
+
+function parseJson(data) {
+  if (!data) return {};
+  if (Buffer.isBuffer(data)) return JSON.parse(Buffer.from(data).toString());
+  if (typeof data === "string") return JSON.parse(data);
+  return data;
+}
+
+async function callNavidrome(widget, endpoint, queryParams) {
+  const url = new URL(formatApiCall(widgets[widget.type].api, { endpoint, ...widget }));
+  Object.entries(queryParams ?? {}).forEach(([key, value]) => {
+    url.searchParams.set(key, value);
+  });
+
+  const [status, , data] = await httpProxy(url);
+  const parsed = parseJson(data);
+
+  if (status >= 400 || parsed?.["subsonic-response"]?.error) {
+    return {
+      error: {
+        status,
+        data: parsed?.["subsonic-response"]?.error ?? parsed,
+        url: sanitizeNavidromeURL(url),
+      },
+    };
+  }
+
+  return { data: parsed?.["subsonic-response"] ?? parsed };
+}
+
+function countArtists(indexes) {
+  return asArray(indexes?.index).reduce((total, index) => total + asArray(index.artist).length, 0);
+}
+
+function summarizeAlbums(albumList) {
+  const albums = asArray(albumList?.album);
+
+  return {
+    albums: albums.length,
+  };
+}
+
+function countScannedSongs(scanStatus) {
+  const count = Number(scanStatus?.count);
+  return Number.isFinite(count) ? count : null;
+}
+
+function countPlaylists(playlists) {
+  return asArray(playlists?.playlist).length;
+}
+
+async function safeCall(widget, endpoint, queryParams) {
+  try {
+    return await callNavidrome(widget, endpoint, queryParams);
+  } catch (error) {
+    if (error) logger.error(error);
+    return { error: { status: 500, data: { message: "Unexpected error" } } };
+  }
+}
+
+async function getAlbumStats(widget) {
+  const albums = [];
+  const seenPageKeys = new Set();
+
+  for (let offset = 0; ; offset += ALBUM_PAGE_SIZE) {
+    const result = await safeCall(widget, "getAlbumList2", {
+      type: "alphabeticalByName",
+      size: ALBUM_PAGE_SIZE,
+      offset,
+    });
+
+    if (result.error) return result;
+
+    const pageAlbums = asArray(result.data?.albumList2?.album);
+    const pageKey = pageAlbums.map((album) => album.id ?? album.name).join("|");
+    if (pageAlbums.length && seenPageKeys.has(pageKey)) {
+      return { error: { status: 502, data: { message: "Navidrome album pagination did not advance" } } };
+    }
+    seenPageKeys.add(pageKey);
+    albums.push(...pageAlbums);
+
+    if (pageAlbums.length < ALBUM_PAGE_SIZE) {
+      return { data: { albumList2: { album: albums } } };
+    }
+  }
+}
+
+async function getLibraryStats(widget) {
+  const [artistsResult, albumsResult, scanStatusResult, playlistsResult] = await Promise.all([
+    safeCall(widget, "getIndexes"),
+    getAlbumStats(widget),
+    safeCall(widget, "getScanStatus"),
+    safeCall(widget, "getPlaylists"),
+  ]);
+
+  const errors = [artistsResult.error, albumsResult.error, scanStatusResult.error, playlistsResult.error].filter(
+    Boolean,
+  );
+  if (errors.length === 4) {
+    return { error: errors[0] };
+  }
+
+  const albumStats = albumsResult.data ? summarizeAlbums(albumsResult.data.albumList2) : {};
+
+  return {
+    stats: {
+      artists: artistsResult.data ? countArtists(artistsResult.data.indexes) : null,
+      albums: albumStats.albums ?? null,
+      songs: scanStatusResult.data ? countScannedSongs(scanStatusResult.data.scanStatus) : null,
+      playlists: playlistsResult.data ? countPlaylists(playlistsResult.data.playlists) : null,
+    },
+  };
+}
+
+export default async function navidromeProxyHandler(req, res, map) {
+  if (req.query.endpoint !== "libraryStats") {
+    return genericProxyHandler(req, res, map);
+  }
+
+  const { group, service, index } = req.query;
+
+  if (!group || !service) {
+    logger.debug("Invalid or missing proxy service type '%s' in group '%s'", service, group);
+    return res.status(400).json({ error: "Invalid proxy service type" });
+  }
+
+  const widget = await getServiceWidget(group, service, index);
+
+  if (!widget || !widgets?.[widget.type]?.api) {
+    logger.debug("Invalid or missing proxy service type '%s' in group '%s'", service, group);
+    return res.status(403).json({ error: "Service does not support API calls" });
+  }
+
+  try {
+    const { stats, error } = await getLibraryStats(widget);
+    if (error) {
+      return res.status(error.status || 500).json({ error });
+    }
+
+    return res.status(200).json(stats);
+  } catch (error) {
+    if (error) logger.error(error);
+    return res.status(500).json({ error: { message: "Unexpected error" } });
+  }
+}

--- a/src/widgets/navidrome/proxy.test.js
+++ b/src/widgets/navidrome/proxy.test.js
@@ -1,0 +1,422 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getServiceWidget, genericProxyHandler, httpProxy } = vi.hoisted(() => ({
+  getServiceWidget: vi.fn(),
+  genericProxyHandler: vi.fn(),
+  httpProxy: vi.fn(),
+}));
+
+vi.mock("utils/config/service-helpers", () => ({ default: getServiceWidget }));
+vi.mock("utils/logger", () => ({ default: () => ({ debug: vi.fn(), error: vi.fn() }) }));
+vi.mock("utils/proxy/handlers/generic", () => ({ default: genericProxyHandler }));
+vi.mock("utils/proxy/http", () => ({ httpProxy }));
+vi.mock("widgets/widgets", () => ({
+  default: {
+    navidrome: {
+      api: "{url}/rest/{endpoint}?u={user}&t={token}&s={salt}&v=1.16.1&c=homepage&f=json",
+    },
+  },
+}));
+
+import navidromeProxyHandler from "./proxy";
+
+function createMockRes() {
+  const res = {
+    statusCode: undefined,
+    body: undefined,
+    status: vi.fn((code) => {
+      res.statusCode = code;
+      return res;
+    }),
+    json: vi.fn((body) => {
+      res.body = body;
+      return res;
+    }),
+    send: vi.fn((body) => {
+      res.body = body;
+      return res;
+    }),
+  };
+  return res;
+}
+
+function jsonResponse(payload) {
+  return [200, "application/json", Buffer.from(JSON.stringify(payload))];
+}
+
+describe("navidrome proxy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getServiceWidget.mockResolvedValue({
+      type: "navidrome",
+      url: "http://navidrome.test",
+      user: "user",
+      token: "token",
+      salt: "salt",
+    });
+  });
+
+  it("delegates non-library endpoints to the generic proxy handler", async () => {
+    const req = { query: { endpoint: "getNowPlaying" } };
+    const res = createMockRes();
+
+    await navidromeProxyHandler(req, res);
+
+    expect(genericProxyHandler).toHaveBeenCalledWith(req, res, undefined);
+  });
+
+  it("rejects library stats requests without group or service", async () => {
+    const req = { query: { endpoint: "libraryStats", group: "g" } };
+    const res = createMockRes();
+
+    await navidromeProxyHandler(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: "Invalid proxy service type" });
+    expect(getServiceWidget).not.toHaveBeenCalled();
+    expect(httpProxy).not.toHaveBeenCalled();
+  });
+
+  it("rejects services that do not resolve to a supported widget API", async () => {
+    getServiceWidget.mockResolvedValueOnce(undefined);
+    const req = { query: { group: "g", service: "s", index: "0", endpoint: "libraryStats" } };
+    const res = createMockRes();
+
+    await navidromeProxyHandler(req, res);
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toEqual({ error: "Service does not support API calls" });
+    expect(httpProxy).not.toHaveBeenCalled();
+  });
+
+  it("rejects services with an unsupported widget type", async () => {
+    getServiceWidget.mockResolvedValueOnce({ type: "unsupported" });
+    const req = { query: { group: "g", service: "s", index: "0", endpoint: "libraryStats" } };
+    const res = createMockRes();
+
+    await navidromeProxyHandler(req, res);
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toEqual({ error: "Service does not support API calls" });
+    expect(httpProxy).not.toHaveBeenCalled();
+  });
+
+  it("aggregates library stats from Subsonic-compatible responses", async () => {
+    httpProxy
+      .mockResolvedValueOnce(
+        jsonResponse({
+          "subsonic-response": {
+            indexes: {
+              index: [{ artist: [{ id: "1" }, { id: "2" }] }, { artist: [{ id: "3" }] }],
+            },
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          "subsonic-response": {
+            albumList2: {
+              album: [{ id: "a" }, { id: "b" }],
+            },
+          },
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { scanStatus: { count: 12 } } }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          "subsonic-response": {
+            playlists: {
+              playlist: [{ id: "p1" }, { id: "p2" }],
+            },
+          },
+        }),
+      );
+
+    const req = { query: { group: "g", service: "s", index: "0", endpoint: "libraryStats" } };
+    const res = createMockRes();
+
+    await navidromeProxyHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ artists: 3, albums: 2, songs: 12, playlists: 2 });
+    expect(httpProxy).toHaveBeenCalledTimes(4);
+    expect(httpProxy.mock.calls[1][0].pathname).toBe("/rest/getAlbumList2");
+    expect(httpProxy.mock.calls[1][0].searchParams.get("type")).toBe("alphabeticalByName");
+    expect(httpProxy.mock.calls[1][0].searchParams.get("size")).toBe("500");
+    expect(httpProxy.mock.calls[1][0].searchParams.get("offset")).toBe("0");
+    expect(httpProxy.mock.calls[2][0].pathname).toBe("/rest/getScanStatus");
+    expect(httpProxy.mock.calls[3][0].pathname).toBe("/rest/getPlaylists");
+  });
+
+  it("aggregates library stats from already-parsed JSON responses", async () => {
+    httpProxy
+      .mockResolvedValueOnce([200, "application/json", { indexes: { index: [{ artist: [{ id: "1" }] }] } }])
+      .mockResolvedValueOnce([200, "application/json", { albumList2: { album: [{ id: "a" }] } }])
+      .mockResolvedValueOnce([200, "application/json", { scanStatus: { count: 2 } }])
+      .mockResolvedValueOnce([200, "application/json", { playlists: { playlist: [{ id: "p1" }] } }]);
+
+    const req = { query: { group: "g", service: "s", index: "0", endpoint: "libraryStats" } };
+    const res = createMockRes();
+
+    await navidromeProxyHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ artists: 1, albums: 1, songs: 2, playlists: 1 });
+  });
+
+  it("treats empty library payloads as zero counts", async () => {
+    httpProxy
+      .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { indexes: {} } }))
+      .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { albumList2: {} } }))
+      .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { scanStatus: { count: 0 } } }))
+      .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { playlists: {} } }));
+
+    const req = { query: { group: "g", service: "s", index: "0", endpoint: "libraryStats" } };
+    const res = createMockRes();
+
+    await navidromeProxyHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ artists: 0, albums: 0, songs: 0, playlists: 0 });
+  });
+
+  it("aggregates album stats across multiple album pages", async () => {
+    httpProxy
+      .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { indexes: { index: [] } } }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          "subsonic-response": {
+            albumList2: {
+              album: Array.from({ length: 500 }, (_, index) => ({ id: `album-${index}` })),
+            },
+          },
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { scanStatus: { count: 502 } } }))
+      .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { playlists: { playlist: [] } } }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          "subsonic-response": {
+            albumList2: {
+              album: [{ id: "album-500" }],
+            },
+          },
+        }),
+      );
+
+    const req = { query: { group: "g", service: "s", index: "0", endpoint: "libraryStats" } };
+    const res = createMockRes();
+
+    await navidromeProxyHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ artists: 0, albums: 501, songs: 502, playlists: 0 });
+    expect(httpProxy.mock.calls[1][0].searchParams.get("offset")).toBe("0");
+    expect(httpProxy.mock.calls[4][0].searchParams.get("offset")).toBe("500");
+  });
+
+  it("normalizes singleton Subsonic response objects", async () => {
+    httpProxy
+      .mockResolvedValueOnce(
+        jsonResponse({
+          "subsonic-response": {
+            indexes: {
+              index: { artist: { id: "1" } },
+            },
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          "subsonic-response": {
+            albumList2: {
+              album: { id: "a" },
+            },
+          },
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { scanStatus: { count: 5 } } }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          "subsonic-response": {
+            playlists: {
+              playlist: { id: "p1" },
+            },
+          },
+        }),
+      );
+
+    const req = { query: { group: "g", service: "s", index: "0", endpoint: "libraryStats" } };
+    const res = createMockRes();
+
+    await navidromeProxyHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ artists: 1, albums: 1, songs: 5, playlists: 1 });
+  });
+
+  it("returns a placeholder song count when scan status count is missing", async () => {
+    httpProxy
+      .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { indexes: { index: [] } } }))
+      .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { albumList2: { album: [{ id: "a" }] } } }))
+      .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { scanStatus: {} } }))
+      .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { playlists: { playlist: [] } } }));
+
+    const req = { query: { group: "g", service: "s", index: "0", endpoint: "libraryStats" } };
+    const res = createMockRes();
+
+    await navidromeProxyHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ artists: 0, albums: 1, songs: null, playlists: 0 });
+  });
+
+  it("returns a sanitized Subsonic error when every upstream call reports one", async () => {
+    httpProxy
+      .mockResolvedValueOnce(
+        jsonResponse({
+          "subsonic-response": {
+            error: { code: 40, message: "Wrong username or password" },
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          "subsonic-response": {
+            error: { code: 40, message: "Wrong username or password" },
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          "subsonic-response": {
+            error: { code: 40, message: "Wrong username or password" },
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          "subsonic-response": {
+            error: { code: 40, message: "Wrong username or password" },
+          },
+        }),
+      );
+
+    const req = { query: { group: "g", service: "s", index: "0", endpoint: "libraryStats" } };
+    const res = createMockRes();
+
+    await navidromeProxyHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.error.data).toEqual({ code: 40, message: "Wrong username or password" });
+    expect(res.body.error.url).toContain("t=***");
+    expect(res.body.error.url).toContain("u=***");
+    expect(res.body.error.url).toContain("s=***");
+  });
+
+  it("returns partial stats when album pagination does not advance", async () => {
+    httpProxy
+      .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { indexes: { index: [] } } }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          "subsonic-response": {
+            albumList2: {
+              album: Array.from({ length: 500 }, (_, index) => ({ id: `album-${index}` })),
+            },
+          },
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { scanStatus: { count: 0 } } }))
+      .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { playlists: { playlist: [] } } }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          "subsonic-response": {
+            albumList2: {
+              album: Array.from({ length: 500 }, (_, index) => ({ id: `album-${index}` })),
+            },
+          },
+        }),
+      );
+
+    const req = { query: { group: "g", service: "s", index: "0", endpoint: "libraryStats" } };
+    const res = createMockRes();
+
+    await navidromeProxyHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ artists: 0, albums: null, songs: 0, playlists: 0 });
+  });
+
+  it("returns partial stats when one upstream call fails", async () => {
+    httpProxy
+      .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { indexes: { index: [{ artist: [{ id: "1" }] }] } } }))
+      .mockResolvedValueOnce([500, "application/json", Buffer.from(JSON.stringify({ error: "boom" }))])
+      .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { scanStatus: { count: 2 } } }))
+      .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { playlists: { playlist: [{ id: "p1" }] } } }));
+
+    const req = { query: { group: "g", service: "s", index: "0", endpoint: "libraryStats" } };
+    const res = createMockRes();
+
+    await navidromeProxyHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ artists: 1, albums: null, songs: 2, playlists: 1 });
+  });
+
+  it("returns partial stats when one upstream call throws", async () => {
+    httpProxy
+      .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { indexes: { index: [{ artist: [{ id: "1" }] }] } } }))
+      .mockRejectedValueOnce(new Error("connection reset"))
+      .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { scanStatus: { count: 2 } } }))
+      .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { playlists: { playlist: [{ id: "p1" }] } } }));
+
+    const req = { query: { group: "g", service: "s", index: "0", endpoint: "libraryStats" } };
+    const res = createMockRes();
+
+    await navidromeProxyHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ artists: 1, albums: null, songs: 2, playlists: 1 });
+  });
+
+  it("returns an error when every upstream stats call fails", async () => {
+    httpProxy
+      .mockResolvedValueOnce([500, "application/json", Buffer.from(JSON.stringify({ error: "a" }))])
+      .mockResolvedValueOnce([500, "application/json", Buffer.from(JSON.stringify({ error: "b" }))])
+      .mockResolvedValueOnce([500, "application/json", Buffer.from(JSON.stringify({ error: "c" }))])
+      .mockResolvedValueOnce([500, "application/json", Buffer.from(JSON.stringify({ error: "d" }))]);
+
+    const req = { query: { group: "g", service: "s", index: "0", endpoint: "libraryStats" } };
+    const res = createMockRes();
+
+    await navidromeProxyHandler(req, res);
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body.error.url).toContain("t=***");
+    expect(res.body.error.url).toContain("u=***");
+    expect(res.body.error.url).toContain("s=***");
+    expect(res.body.error.url).not.toContain("user");
+    expect(res.body.error.url).not.toContain("token");
+    expect(res.body.error.url).not.toContain("salt");
+  });
+
+  it("returns an unexpected error when writing the stats response throws", async () => {
+    httpProxy
+      .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { indexes: {} } }))
+      .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { albumList2: {} } }))
+      .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { scanStatus: { count: 0 } } }))
+      .mockResolvedValueOnce(jsonResponse({ "subsonic-response": { playlists: {} } }));
+
+    const req = { query: { group: "g", service: "s", index: "0", endpoint: "libraryStats" } };
+    const res = createMockRes();
+    res.status.mockImplementationOnce(() => {
+      throw new Error("response unavailable");
+    });
+
+    await navidromeProxyHandler(req, res);
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({ error: { message: "Unexpected error" } });
+    expect(httpProxy).toHaveBeenCalledTimes(4);
+  });
+});

--- a/src/widgets/navidrome/widget.js
+++ b/src/widgets/navidrome/widget.js
@@ -1,12 +1,15 @@
-import genericProxyHandler from "utils/proxy/handlers/generic";
+import navidromeProxyHandler from "./proxy";
 
 const widget = {
   api: "{url}/rest/{endpoint}?u={user}&t={token}&s={salt}&v=1.16.1&c=homepage&f=json",
-  proxyHandler: genericProxyHandler,
+  proxyHandler: navidromeProxyHandler,
 
   mappings: {
     getNowPlaying: {
       endpoint: "getNowPlaying",
+    },
+    libraryStats: {
+      endpoint: "libraryStats",
     },
   },
 };


### PR DESCRIPTION
## Proposed change

Adds Navidrome library statistics support to the existing Navidrome widget.

AI disclosure: I used AI assistance while developing and revising this PR.
<img width="512" height="167" alt="image" src="https://github.com/user-attachments/assets/b2fff28f-8d64-41d5-85b4-f6fb9f29814e" />


### Summary
- Adds a new `libraryStats` proxy endpoint for Navidrome service widgets.
- Aggregates and returns counts for:
  - artists
  - albums
  - songs
  - playlists
- Updates the Navidrome widget UI to display library counts alongside now-playing entries.
- Handles partial upstream failures gracefully by returning available stats where possible.
- Adds robust tests for proxy behavior (including pagination and failure modes) and component rendering states.
- Updates Navidrome widget docs to reflect the newly displayed fields.
- Updates the English locale labels for new Navidrome stat keys.

Related discussion: https://github.com/gethomepage/homepage/discussions/6027

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget
guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
  - Related request discussion: https://github.com/gethomepage/homepage/discussions/6027
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting
checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [X] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.



