### PR TITLE
Feat: add allowUrlSuggestions setting to Quick Launch for direct URL handling

### DIFF
--- a/docs/configs/settings.md
+++ b/docs/configs/settings.md
@@ -507,6 +507,7 @@ There are a few optional settings for the Quick Launch feature:
 - `searchDescriptions`: which lets you control whether item descriptions are included in searches. This is false by default. When enabled, results that match the item name will be placed above those that only match the description.
 - `hideInternetSearch`: disable automatically including the currently-selected web search (e.g. from the widget) as a Quick Launch option. This is false by default, enabling the feature.
 - `showSearchSuggestions`: show search suggestions for the internet search. If this is not specified then the setting will be inherited from the search widget. If it is not specified there either, it will default to false. For custom providers the `suggestionUrl` needs to be set in order for this to work.
+- `allowUrlSuggestions`: allow search suggestions that are URLs to be opened directly without being treated as search queries. This is true by default, enabling the feature.
 - `provider`: search engine provider. If none is specified it will try to use the provider set for the Search Widget, if neither are present then internet search will be disabled.
 - `hideVisitURL`: disable detecting and offering an option to open URLs. This is false by default, enabling the feature.
 - `mobileButtonPosition`: enables and sets the position of the mobile quicklaunch button. Options are `top-left`, `top-right`, `bottom-left`, `bottom-right`. This is empty by default, disabling the feature.
@@ -516,6 +517,7 @@ quicklaunch:
   searchDescriptions: true
   hideInternetSearch: true
   showSearchSuggestions: true
+  allowUrlSuggestions: true
   hideVisitURL: true
   provider: google # google, duckduckgo, bing, baidu, brave or custom
 ```

--- a/src/components/quicklaunch.jsx
+++ b/src/components/quicklaunch.jsx
@@ -190,8 +190,9 @@ export default function QuickLaunch({ servicesAndBookmarks, searchString, setSea
             newResults = newResults.concat(
               searchSuggestions[1].map((suggestion) => {
                 // Check if the suggestion is actually a URL (if feature is enabled)
-                const isUrl = allowUrlSuggestions && (suggestion.startsWith('http://') || suggestion.startsWith('https://'));
-                
+                const isUrl =
+                  allowUrlSuggestions && (suggestion.startsWith("http://") || suggestion.startsWith("https://"));
+
                 return {
                   href: isUrl ? suggestion : searchProvider.url + encodeURIComponent(suggestion),
                   name: suggestion,
@@ -222,7 +223,16 @@ export default function QuickLaunch({ servicesAndBookmarks, searchString, setSea
       abortController.abort();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchString, servicesAndBookmarks, searchDescriptions, hideVisitURL, allowUrlSuggestions, searchSuggestions, searchProvider, url]);
+  }, [
+    searchString,
+    servicesAndBookmarks,
+    searchDescriptions,
+    hideVisitURL,
+    allowUrlSuggestions,
+    searchSuggestions,
+    searchProvider,
+    url,
+  ]);
 
   const [hidden, setHidden] = useState(true);
   useEffect(() => {

--- a/src/components/quicklaunch.jsx
+++ b/src/components/quicklaunch.jsx
@@ -19,7 +19,7 @@ export default function QuickLaunch({ servicesAndBookmarks, searchString, setSea
   const { t } = useTranslation();
 
   const { settings } = useContext(SettingsContext);
-  const { searchDescriptions = false, hideVisitURL = false } = settings?.quicklaunch ?? {};
+  const { searchDescriptions = false, hideVisitURL = false, allowUrlSuggestions = true } = settings?.quicklaunch ?? {};
 
   const searchField = useRef();
 
@@ -188,11 +188,16 @@ export default function QuickLaunch({ servicesAndBookmarks, searchString, setSea
 
           if (searchSuggestions[1]) {
             newResults = newResults.concat(
-              searchSuggestions[1].map((suggestion) => ({
-                href: searchProvider.url + encodeURIComponent(suggestion),
-                name: suggestion,
-                type: "searchSuggestion",
-              })),
+              searchSuggestions[1].map((suggestion) => {
+                // Check if the suggestion is actually a URL (if feature is enabled)
+                const isUrl = allowUrlSuggestions && (suggestion.startsWith('http://') || suggestion.startsWith('https://'));
+                
+                return {
+                  href: isUrl ? suggestion : searchProvider.url + encodeURIComponent(suggestion),
+                  name: suggestion,
+                  type: isUrl ? "url" : "searchSuggestion",
+                };
+              }),
             );
           }
         }
@@ -217,7 +222,7 @@ export default function QuickLaunch({ servicesAndBookmarks, searchString, setSea
       abortController.abort();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchString, servicesAndBookmarks, searchDescriptions, hideVisitURL, searchSuggestions, searchProvider, url]);
+  }, [searchString, servicesAndBookmarks, searchDescriptions, hideVisitURL, allowUrlSuggestions, searchSuggestions, searchProvider, url]);
 
   const [hidden, setHidden] = useState(true);
   useEffect(() => {

--- a/src/components/quicklaunch.test.jsx
+++ b/src/components/quicklaunch.test.jsx
@@ -318,6 +318,86 @@ describe("components/quicklaunch", () => {
     fetch = originalFetch;
   });
 
+  it("treats URLs in search suggestions as direct URLs when allowUrlSuggestions is true (default)", async () => {
+    const originalFetch = globalThis.fetch;
+    const fetchSpy = vi.fn(async () => ({
+      json: async () => ["test", ["https://example.com", "http://another.com", "regular suggestion"]],
+    }));
+
+    fetch = fetchSpy;
+
+    renderWithProviders(<Wrapper />, {
+      settings: {
+        quicklaunch: {
+          provider: "duckduckgo",
+          showSearchSuggestions: true,
+          allowUrlSuggestions: true,
+        },
+      },
+    });
+
+    const input = screen.getByPlaceholderText("Search");
+    await waitFor(() => expect(input).toHaveFocus());
+
+    fireEvent.change(input, { target: { value: "test" } });
+
+    await waitFor(() => {
+      expect(screen.getAllByText("quicklaunch.searchsuggestion").length).toBeGreaterThan(0);
+    });
+
+    // Check that the URL suggestions have type "url"
+    const urlButtons = Array.from(document.querySelectorAll("button")).filter((btn) =>
+      btn.textContent?.includes("https://example.com") || btn.textContent?.includes("http://another.com"),
+    );
+
+    expect(urlButtons.length).toBe(2);
+    urlButtons.forEach((btn) => {
+      expect(btn.textContent).toContain("quicklaunch.url");
+    });
+
+    // The regular suggestion should still be a search suggestion
+    const regularButton = Array.from(document.querySelectorAll("button")).find((btn) =>
+      btn.textContent?.includes("regular suggestion"),
+    );
+    expect(regularButton?.textContent).toContain("quicklaunch.searchsuggestion");
+
+    fetch = originalFetch;
+  });
+
+  it("treats URLs in search suggestions as search queries when allowUrlSuggestions is false", async () => {
+    const originalFetch = globalThis.fetch;
+    const fetchSpy = vi.fn(async () => ({
+      json: async () => ["test", ["https://example.com", "http://another.com", "regular suggestion"]],
+    }));
+
+    fetch = fetchSpy;
+
+    renderWithProviders(<Wrapper />, {
+      settings: {
+        quicklaunch: {
+          provider: "duckduckgo",
+          showSearchSuggestions: true,
+          allowUrlSuggestions: false,
+        },
+      },
+    });
+
+    const input = screen.getByPlaceholderText("Search");
+    await waitFor(() => expect(input).toHaveFocus());
+
+    fireEvent.change(input, { target: { value: "test" } });
+
+    await waitFor(() => {
+      expect(screen.getAllByText("quicklaunch.searchsuggestion").length).toBeGreaterThan(0);
+    });
+
+    // All suggestions, including URLs, should be search suggestions when allowUrlSuggestions is false
+    const allSearchSuggestions = screen.getAllByText("quicklaunch.searchsuggestion");
+    expect(allSearchSuggestions.length).toBe(3);
+
+    fetch = originalFetch;
+  });
+
   it("uses the stored provider when the search widget provides a provider list", async () => {
     state.widgets = {
       w: {

--- a/src/components/quicklaunch.test.jsx
+++ b/src/components/quicklaunch.test.jsx
@@ -346,8 +346,8 @@ describe("components/quicklaunch", () => {
     });
 
     // Check that the URL suggestions have type "url"
-    const urlButtons = Array.from(document.querySelectorAll("button")).filter((btn) =>
-      btn.textContent?.includes("https://example.com") || btn.textContent?.includes("http://another.com"),
+    const urlButtons = Array.from(document.querySelectorAll("button")).filter(
+      (btn) => btn.textContent?.includes("https://example.com") || btn.textContent?.includes("http://another.com"),
     );
 
     expect(urlButtons.length).toBe(2);


### PR DESCRIPTION
## Proposed change

Treat search suggestions that look like URLs as direct URLs when selected, and add a setting to control this behavior.

This change introduces the `allowUrlSuggestions` setting (default: `true`) to `quicklaunch`.
When enabled, suggestion items that start with `http://` or `https://` are treated as URLs: selecting them will open the URL directly and they are rendered with type `url`. When disabled, those suggestions are treated as regular search queries and opened via the configured search provider.

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] I have added corresponding documentation changes. (see `docs/configs/settings.md`)
- [x] I have added or updated tests for new behavior. (see `src/components/quicklaunch.test.jsx`)
- [ ] I have reviewed the feature / enhancement and / or service widget guidelines.
- [ ] I have checked that all code style checks pass using pre-commit hooks and linting checks.
- [ ] If applicable, I have tested my change on mobile & desktop browsers.
- [x] In the description above I have disclosed the use of AI tools in the coding of this PR.

### Details for reviewers
- **Goal:** Allow Quick Launch to distinguish URL-like suggestions from ordinary search suggestions and handle them appropriately.
- **Behavior:** Suggestions starting with `http://` or `https://` are considered URLs when `allowUrlSuggestions: true`. They will have `type: "url"` and `href` set to the suggestion text; otherwise they are encoded and sent to the search provider URL as search queries.
- **Files changed:** `src/components/quicklaunch.jsx`, `src/components/quicklaunch.test.jsx`, `docs/configs/settings.md`
- **Tests:** Added unit tests covering both `allowUrlSuggestions: true` and `false` cases.
- **Docs:** `docs/configs/settings.md` documents the new `allowUrlSuggestions` and shows the default setting in the example.

### AI assistance disclosure

- This change was implemented with assistance from GitHub Copilot.
