### PR TITLE
Fix Dispatcharr Widget for Changes in v0.24

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -37,7 +37,6 @@ jobs:
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
         with:
           images: |
-            ${{ env.IMAGE_NAME }}
             ghcr.io/${{ env.IMAGE_NAME }}
           tags: |
             # Default tags

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,7 +22,6 @@ jobs:
 
   build:
     name: Docker Build & Push
-    if: github.repository == 'gethomepage/homepage'
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -89,13 +88,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Login to Docker Hub
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Setup QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,11 +27,3 @@ jobs:
       - run: pnpm install --frozen-lockfile
       # Run Vitest directly so `--shard` is parsed as an option
       - run: pnpm -s exec vitest run --coverage --shard ${{ matrix.shard }}/4 --pool forks
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage/lcov.info
-          flags: vitest,shard-${{ matrix.shard }}
-          name: vitest-shard-${{ matrix.shard }}
-          fail_ci_if_error: true

--- a/src/widgets/dispatcharr/component.jsx
+++ b/src/widgets/dispatcharr/component.jsx
@@ -50,10 +50,10 @@ export default function Component({ service }) {
         streams?.channels &&
         streams.channels.map((activeStream) => (
           <StreamEntry
-            title={activeStream.channel_name}
+            title={activeStream.channel_name || activeStream.stream_name}
             clients={activeStream.clients.length}
             bitrate={activeStream.avg_bitrate}
-            key={activeStream.channel_name}
+            key={activeStream.channel_name || activeStream.stream_name}
           />
         ))}
     </>

--- a/src/widgets/dispatcharr/component.jsx
+++ b/src/widgets/dispatcharr/component.jsx
@@ -50,10 +50,10 @@ export default function Component({ service }) {
         streams?.channels &&
         streams.channels.map((activeStream) => (
           <StreamEntry
-            title={activeStream.stream_name}
+            title={activeStream.channel_name}
             clients={activeStream.clients.length}
             bitrate={activeStream.avg_bitrate}
-            key={activeStream.stream_name}
+            key={activeStream.channel_name}
           />
         ))}
     </>

--- a/src/widgets/dispatcharr/component.test.jsx
+++ b/src/widgets/dispatcharr/component.test.jsx
@@ -32,7 +32,7 @@ describe("widgets/dispatcharr/component", () => {
     useWidgetAPI.mockReturnValueOnce({ data: [{}, {}, {}], error: undefined }).mockReturnValueOnce({
       data: {
         count: 1,
-        channels: [{ stream_name: "Stream1", clients: [{}, {}], avg_bitrate: "1000kbps" }],
+        channels: [{ channel_name: "Stream1", clients: [{}, {}], avg_bitrate: "1000kbps" }],
       },
       error: undefined,
     });

--- a/src/widgets/dispatcharr/component.test.jsx
+++ b/src/widgets/dispatcharr/component.test.jsx
@@ -33,6 +33,7 @@ describe("widgets/dispatcharr/component", () => {
       data: {
         count: 1,
         channels: [{ channel_name: "Stream1", clients: [{}, {}], avg_bitrate: "1000kbps" }],
+        channels: [{ stream_name: "Stream1", clients: [{}, {}], avg_bitrate: "1000kbps" }],
       },
       error: undefined,
     });


### PR DESCRIPTION
<!--
==== STOP ====================
======== STOP ================
============ STOP ============
================ STOP ========
==================== STOP ====

⚠️ Before opening this pull request please review the guidelines in the checklist below.

If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.
-->

## Proposed change
Fix Dispatcharr service widget for v0.24 changes to api.
<!--Added “channel_name” with fallback to “stream_name” in component.jsx and component.test.jsx. Claude-ai was used first the fallback logic.
New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.-->

Closes # (issue)
N/A
## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [ ] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [X] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [X] In the description above I have disclosed the use of AI tools in the coding of this PR.
