### PR TITLE
Feature: Graylog widget

### DIFF
--- a/docs/widgets/services/graylog.md
+++ b/docs/widgets/services/graylog.md
@@ -1,0 +1,17 @@
+---
+title: Graylog
+description: Graylog Widget Configuration
+---
+
+Learn more about [Graylog](https://github.com/Graylog2/graylog2-server).
+
+Shows three metrics for a Graylog instance: ingested message count over a configurable time window, current input throughput, and the number of active system notifications.
+
+```yaml
+widget:
+  type: graylog
+  url: http://graylog.host.or.ip:port
+  username: admin
+  password: password
+  range: 86400 # optional, in seconds, default 86400 (24h)
+```

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -766,6 +766,11 @@
         "totalalerts": "Total Alerts",
         "alertstriggered": "Alerts Triggered"
     },
+    "graylog": {
+        "messages": "Messages",
+        "throughput": "Throughput",
+        "notifications": "Notifications"
+    },
     "nextcloud": {
         "cpuload": "Cpu Load",
         "memoryusage": "Memory Usage",

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -52,6 +52,7 @@ const components = {
   gluetun: dynamic(() => import("./gluetun/component")),
   gotify: dynamic(() => import("./gotify/component")),
   grafana: dynamic(() => import("./grafana/component")),
+  graylog: dynamic(() => import("./graylog/component")),
   hdhomerun: dynamic(() => import("./hdhomerun/component")),
   headscale: dynamic(() => import("./headscale/component")),
   hoarder: dynamic(() => import("./karakeep/component")),

--- a/src/widgets/graylog/component.jsx
+++ b/src/widgets/graylog/component.jsx
@@ -1,0 +1,46 @@
+import Block from "components/services/widget/block";
+import Container from "components/services/widget/container";
+import { useTranslation } from "next-i18next";
+
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+  const { widget } = service;
+  const range = widget.range ?? 86400;
+
+  const { data: countData, error: countError } = useWidgetAPI(widget, "count", {
+    query: "*",
+    range,
+    limit: 1,
+  });
+  const { data: throughputData, error: throughputError } = useWidgetAPI(widget, "throughput");
+  const { data: notificationsData, error: notificationsError } = useWidgetAPI(widget, "notifications");
+
+  const error = countError ?? throughputError ?? notificationsError;
+
+  if (error) {
+    return <Container service={service} error={error} />;
+  }
+
+  if (!countData || !throughputData || !notificationsData) {
+    return (
+      <Container service={service}>
+        <Block label="graylog.messages" />
+        <Block label="graylog.throughput" />
+        <Block label="graylog.notifications" />
+      </Container>
+    );
+  }
+
+  const inputMetric = throughputData.metrics?.find((m) => m.full_name?.includes("input.1-sec-rate"));
+  const throughputValue = Math.round(inputMetric?.metric?.value ?? 0);
+
+  return (
+    <Container service={service}>
+      <Block label="graylog.messages" value={t("common.number", { value: countData.total_results })} />
+      <Block label="graylog.throughput" value={t("common.number", { value: throughputValue })} />
+      <Block label="graylog.notifications" value={t("common.number", { value: notificationsData.total })} />
+    </Container>
+  );
+}

--- a/src/widgets/graylog/component.test.jsx
+++ b/src/widgets/graylog/component.test.jsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+
+import { screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "test-utils/render-with-providers";
+import { expectBlockValue } from "test-utils/widget-assertions";
+
+const { useWidgetAPI } = vi.hoisted(() => ({ useWidgetAPI: vi.fn() }));
+vi.mock("utils/proxy/use-widget-api", () => ({ default: useWidgetAPI }));
+
+import Component from "./component";
+
+const service = {
+  widget: { type: "graylog", url: "http://x" },
+};
+
+describe("widgets/graylog/component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders placeholders while loading", () => {
+    useWidgetAPI.mockReturnValue({ data: undefined, error: undefined });
+
+    const { container } = renderWithProviders(<Component service={service} />, {
+      settings: { hideErrors: false },
+    });
+
+    expect(container.querySelectorAll(".service-block")).toHaveLength(3);
+    expect(screen.getByText("graylog.messages")).toBeInTheDocument();
+    expect(screen.getByText("graylog.throughput")).toBeInTheDocument();
+    expect(screen.getByText("graylog.notifications")).toBeInTheDocument();
+    expect(screen.getAllByText("-")).toHaveLength(3);
+  });
+
+  it("renders error UI when any API call fails", () => {
+    useWidgetAPI.mockReturnValue({ data: undefined, error: { message: "connection refused" } });
+
+    renderWithProviders(<Component service={service} />, {
+      settings: { hideErrors: false },
+    });
+
+    expect(screen.getAllByText(/widget\.api_error/i).length).toBeGreaterThan(0);
+  });
+
+  it("renders message count, throughput and notification count", () => {
+    useWidgetAPI.mockImplementation((_widget, endpoint) => {
+      if (endpoint === "count") return { data: { total_results: 42 }, error: undefined };
+      if (endpoint === "throughput")
+        return {
+          data: {
+            metrics: [
+              {
+                full_name: "org.graylog2.throughput.input.1-sec-rate",
+                metric: { type: "gauge", value: 7.6 },
+              },
+            ],
+          },
+          error: undefined,
+        };
+      if (endpoint === "notifications") return { data: { total: 3 }, error: undefined };
+      return { data: undefined, error: undefined };
+    });
+
+    const { container } = renderWithProviders(<Component service={service} />, {
+      settings: { hideErrors: false },
+    });
+
+    // Use small integers to avoid i18n locale-specific number formatting issues
+    expectBlockValue(container, "graylog.messages", 42);
+    expectBlockValue(container, "graylog.throughput", 8); // Math.round(7.6) = 8
+    expectBlockValue(container, "graylog.notifications", 3);
+  });
+
+  it("uses widget.range when provided, defaulting to 86400", () => {
+    const calls = [];
+    useWidgetAPI.mockImplementation((_widget, endpoint, params) => {
+      calls.push({ endpoint, params });
+      return { data: undefined, error: undefined };
+    });
+
+    const serviceWithRange = { widget: { ...service.widget, range: 3600 } };
+    renderWithProviders(<Component service={serviceWithRange} />, {
+      settings: { hideErrors: false },
+    });
+
+    const countCall = calls.find((c) => c.endpoint === "count");
+    expect(countCall.params.range).toBe(3600);
+  });
+
+  it("defaults range to 86400 when widget.range is not set", () => {
+    const calls = [];
+    useWidgetAPI.mockImplementation((_widget, endpoint, params) => {
+      calls.push({ endpoint, params });
+      return { data: undefined, error: undefined };
+    });
+
+    renderWithProviders(<Component service={service} />, {
+      settings: { hideErrors: false },
+    });
+
+    const countCall = calls.find((c) => c.endpoint === "count");
+    expect(countCall.params.range).toBe(86400);
+  });
+});

--- a/src/widgets/graylog/widget.js
+++ b/src/widgets/graylog/widget.js
@@ -1,0 +1,28 @@
+import genericProxyHandler from "utils/proxy/handlers/generic";
+
+const widget = {
+  api: "{url}/api/{endpoint}",
+  proxyHandler: genericProxyHandler,
+  headers: {
+    "X-Requested-By": "homepage",
+    Accept: "application/json",
+  },
+  mappings: {
+    count: {
+      endpoint: "search/universal/relative",
+      params: ["query", "limit"],
+      optionalParams: ["range"],
+      validate: ["total_results"],
+    },
+    throughput: {
+      endpoint: "system/metrics/namespace/org.graylog2.throughput",
+      validate: ["metrics"],
+    },
+    notifications: {
+      endpoint: "system/notifications",
+      validate: ["total"],
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/graylog/widget.test.js
+++ b/src/widgets/graylog/widget.test.js
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { expectWidgetConfigShape } from "test-utils/widget-config";
+
+import widget from "./widget";
+
+describe("graylog widget config", () => {
+  it("exports a valid widget config", () => {
+    expectWidgetConfigShape(widget);
+  });
+
+  it("defines the count mapping with required params", () => {
+    const { count } = widget.mappings;
+    expect(count.endpoint).toBe("search/universal/relative");
+    expect(count.params).toEqual(["query", "limit"]);
+    expect(count.optionalParams).toContain("range");
+    expect(count.validate).toContain("total_results");
+  });
+
+  it("defines the throughput mapping", () => {
+    const { throughput } = widget.mappings;
+    expect(throughput.endpoint).toBe("system/metrics/namespace/org.graylog2.throughput");
+    expect(throughput.validate).toContain("metrics");
+  });
+
+  it("defines the notifications mapping", () => {
+    const { notifications } = widget.mappings;
+    expect(notifications.endpoint).toBe("system/notifications");
+    expect(notifications.validate).toContain("total");
+  });
+
+  it("sets the X-Requested-By header", () => {
+    expect(widget.headers["X-Requested-By"]).toBe("homepage");
+  });
+});

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -46,6 +46,7 @@ import glances from "./glances/widget";
 import gluetun from "./gluetun/widget";
 import gotify from "./gotify/widget";
 import grafana from "./grafana/widget";
+import graylog from "./graylog/widget";
 import hdhomerun from "./hdhomerun/widget";
 import headscale from "./headscale/widget";
 import healthchecks from "./healthchecks/widget";
@@ -201,6 +202,7 @@ const widgets = {
   gluetun,
   gotify,
   grafana,
+  graylog,
   hdhomerun,
   headscale,
   hoarder: karakeep,


### PR DESCRIPTION
## Proposed change

Adds a service widget for [Graylog](https://graylog.org), the open-source log management platform.

The widget displays three metrics:

- **Messages** — total ingested messages over a configurable time range (default 24h, set via `range` in seconds)
- **Throughput** — current input rate in messages/second (`input.1-sec-rate` from the metrics namespace)
- **Notifications** — number of active Graylog system notifications

Tested against Graylog 7.1.2 with OpenSearch as the datanode. One thing worth noting: the `/api/search/universal/relative` endpoint routes to either a JSON or a chunked/streaming implementation depending on the `Accept` header. Without `Accept: application/json`, Graylog picks the chunked variant which requires a `fields` parameter and returns a 400 if it's absent. The widget sets this header explicitly.

Authentication uses Basic Auth via the existing `genericProxyHandler` — no custom handler needed. The `X-Requested-By` header is required on all Graylog API requests (CSRF protection).

**API endpoints used**

| Metric | Endpoint |
|--------|----------|
| Messages | `GET /api/search/universal/relative?query=*&range={range}&limit=1` |
| Throughput | `GET /api/system/metrics/namespace/org.graylog2.throughput` |
| Notifications | `GET /api/system/notifications` |

**Example configuration**

```yaml
widget:
  type: graylog
  url: http://graylog.host.or.ip:9000
  username: admin
  password: password
  range: 86400 # optional, default 24h
```

**AI Disclosure**

Claude was used to assist with development, including scaffolding, test coverage, and review passes.

Closes # (issue)

## Type of change

- [x] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] In the description above I have disclosed the use of AI tools in the coding of this PR.