### PR TITLE
feat: add HOMEPAGE_PORT support for flexible container orchestration

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 export function middleware(req) {
   // Check the Host header, if HOMEPAGE_ALLOWED_HOSTS is set
   const host = req.headers.get("host");
-  const port = process.env.PORT || 3000;
+  const port = process.env.HOMEPAGE_PORT || process.env.PORT || 3000;
   let allowedHosts = [`localhost:${port}`, `127.0.0.1:${port}`, `[::1]:${port}`];
   const allowAll = process.env.HOMEPAGE_ALLOWED_HOSTS === "*";
   if (process.env.HOMEPAGE_ALLOWED_HOSTS) {


### PR DESCRIPTION
## Type of change
This PR adds support for a `HOMEPAGE_PORT` environment variable, allowing users to explicitly define the application port. While the application previously respected the generic `PORT` variable (which it keeps available for backwards compatability), adding `HOMEPAGE_PORT` provides a more specific and predictable configuration option.

This change is particularly beneficial for users deploying Homepage in isolated container environments, such as rootless Podman or Quadlet, where managing internal vs. host port mapping is critical for preventing collisions and simplifying orchestration.

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [x ] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [x ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [x ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] In the description above I have disclosed the use of AI tools in the coding of this PR.