### PR TITLE
fix: exempt /api/healthcheck from host validation and auth

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -5,6 +5,11 @@ const authEnabled = Boolean(process.env.HOMEPAGE_AUTH_ENABLED);
 const authSecret = process.env.NEXTAUTH_SECRET || process.env.HOMEPAGE_AUTH_SECRET;
 
 export async function middleware(req) {
+  // Allow healthcheck through before host and auth checks; orchestrator probes use the pod IP as Host
+  if (new URL(req.url).pathname === "/api/healthcheck") {
+    return NextResponse.next();
+  }
+
   // Check the Host header, if HOMEPAGE_ALLOWED_HOSTS is set
   const host = req.headers.get("host");
   const port = process.env.PORT || 3000;

--- a/src/middleware.test.js
+++ b/src/middleware.test.js
@@ -85,6 +85,20 @@ describe("middleware", () => {
     expect(res).toEqual({ type: "next" });
   });
 
+  it("allows healthcheck requests regardless of host and auth", async () => {
+    process.env.HOMEPAGE_AUTH_ENABLED = "true";
+    process.env.HOMEPAGE_AUTH_SECRET = "secret";
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const middleware = await loadMiddleware();
+    const res = await middleware(createReq("10.1.2.3:3000", "http://10.1.2.3:3000/api/healthcheck"));
+
+    expect(NextResponse.next).toHaveBeenCalled();
+    expect(errSpy).not.toHaveBeenCalled();
+    expect(getToken).not.toHaveBeenCalled();
+    expect(res).toEqual({ type: "next" });
+  });
+
   it("redirects to signin when auth is enabled and no token is present", async () => {
     process.env.HOMEPAGE_AUTH_ENABLED = "true";
     process.env.HOMEPAGE_AUTH_SECRET = "secret";


### PR DESCRIPTION
## Proposed change

`/api/healthcheck` is polled by container orchestrators (Kubernetes liveness/readiness probes, Docker healthchecks). These probes send the pod/container **IP** as the `Host` header and cannot authenticate.

Because the host-validation middleware now matches all routes (`matcher: ["/", "/((?!_next/...|api/auth|auth/).*)"]`), a probe to `/api/healthcheck` whose Host is the pod IP fails validation and returns **HTTP 400**:

```
error: Host validation failed for: 10.1.2.3:3000. Hint: Set the HOMEPAGE_ALLOWED_HOSTS environment variable to allow requests from this host / port.
```

In Kubernetes this fails the liveness probe and the kubelet restarts the container in a crash loop. There is no way to make it pass from the deployment side, because the probe's `Host` header is the (dynamic) pod IP and the orchestrator probe spec often can't override it. Setting `HOMEPAGE_ALLOWED_HOSTS=*` works but disables host validation entirely, which defeats its purpose.

This change lets `/api/healthcheck` through ahead of host validation and auth. The endpoint returns only liveness status and exposes no sensitive data or host-reflected content, so exempting it does not weaken the protections host validation provides (cache poisoning, password-reset-link poisoning, etc.).

A unit test is added covering a healthcheck request with a non-allowed host and auth enabled; it asserts the request passes without host validation or a token lookup.

Verified locally: `vitest run src/middleware.test.js` (7 passed), `eslint`, and `prettier --check` all clean.

Closes # (no issue — per CONTRIBUTING, bugs go to Discussions; happy to open one if preferred)

## Type of change

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have added or updated tests for new features and bug fixes.
- [ ] If applicable, I have reviewed the feature / enhancement and / or service widget guidelines.
- [x] I have checked that all code style checks pass using pre-commit hooks and linting checks.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices.
- [x] In the description above I have disclosed the use of AI tools in the coding of this PR.

---

**Disclosure:** This PR was prepared with the assistance of AI tools (Claude). The change was reviewed and is owned by me; the underlying problem is real — it currently breaks Kubernetes liveness/readiness probes against `/api/healthcheck` when host validation is active. Flagging the AI assistance explicitly per the contributing guidelines; happy to adjust the approach or move this to a Discussion first if the maintainers prefer.