### PR TITLE
Feature: Pulse service widget

### DIFF
--- a/docs/widgets/services/pulse.md
+++ b/docs/widgets/services/pulse.md
@@ -1,0 +1,20 @@
+---
+title: Pulse
+description: Pulse Widget Configuration
+---
+
+Learn more about [Pulse](https://github.com/rcourtman/Pulse).
+
+Pulse is a real-time monitoring dashboard for Proxmox VE, Proxmox Backup Server, and Docker/host infrastructure.
+
+An API token with the **Kiosk / Dashboard** scope is required. Generate one in Pulse under **Settings → Security → API Tokens**.
+
+Allowed fields: `["nodes", "vms", "lxcs"]`
+
+```yaml
+widget:
+  type: pulse
+  url: http://pulse.host.or.ip:7655
+  key: your-api-token
+  fields: ["nodes", "vms", "lxcs"] # optional, defaults to all
+```

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -790,6 +790,11 @@
         "servers": "Servers",
         "nodes": "Nodes"
     },
+    "pulse": {
+        "nodes": "Nodes online",
+        "vms": "VMs running",
+        "lxcs": "LXCs running"
+    },
     "prometheus": {
         "targets_up": "Targets Up",
         "targets_down": "Targets Down",

--- a/src/utils/proxy/handlers/credentialed.js
+++ b/src/utils/proxy/handlers/credentialed.js
@@ -88,7 +88,7 @@ export default async function credentialedProxyHandler(req, res, map) {
       } else if (widget.type === "proxmoxbackupserver") {
         delete headers["Content-Type"];
         headers.Authorization = `PBSAPIToken=${widget.username}:${widget.password}`;
-      } else if (["autobrr", "jellystat"].includes(widget.type)) {
+      } else if (["autobrr", "jellystat", "pulse"].includes(widget.type)) {
         headers["X-API-Token"] = `${widget.key}`;
       } else if (widget.type === "tubearchivist") {
         headers.Authorization = `Token ${widget.key}`;

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -116,6 +116,7 @@ const components = {
   prowlarr: dynamic(() => import("./prowlarr/component")),
   proxmox: dynamic(() => import("./proxmox/component")),
   pterodactyl: dynamic(() => import("./pterodactyl/component")),
+  pulse: dynamic(() => import("./pulse/component")),
   pyload: dynamic(() => import("./pyload/component")),
   qbittorrent: dynamic(() => import("./qbittorrent/component")),
   qnap: dynamic(() => import("./qnap/component")),

--- a/src/widgets/pulse/component.jsx
+++ b/src/widgets/pulse/component.jsx
@@ -1,0 +1,41 @@
+import Block from "components/services/widget/block";
+import Container from "components/services/widget/container";
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { widget } = service;
+
+  const { data: resourcesData, error: resourcesError } = useWidgetAPI(widget, "resources");
+
+  if (resourcesError) {
+    return <Container service={service} error={resourcesError} />;
+  }
+
+  if (!resourcesData) {
+    return (
+      <Container service={service}>
+        <Block label="pulse.nodes" />
+        <Block label="pulse.vms" />
+        <Block label="pulse.lxcs" />
+      </Container>
+    );
+  }
+
+  const resources = resourcesData.resources ?? [];
+
+  const nodes = resources.filter((r) => r.type === "node");
+  const vms = resources.filter((r) => r.type === "vm");
+  const lxcs = resources.filter((r) => r.type === "container" && r.platformType === "proxmox-pve");
+
+  const nodesOnline = nodes.filter((n) => n.status === "online").length;
+  const vmsRunning = vms.filter((v) => v.status === "running").length;
+  const lxcsRunning = lxcs.filter((c) => c.status === "running").length;
+
+  return (
+    <Container service={service}>
+      <Block label="pulse.nodes" value={`${nodesOnline}/${nodes.length}`} />
+      <Block label="pulse.vms" value={`${vmsRunning}/${vms.length}`} />
+      <Block label="pulse.lxcs" value={`${lxcsRunning}/${lxcs.length}`} />
+    </Container>
+  );
+}

--- a/src/widgets/pulse/component.test.jsx
+++ b/src/widgets/pulse/component.test.jsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "test-utils/render-with-providers";
+import { expectBlockValue } from "test-utils/widget-assertions";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { useWidgetAPI } = vi.hoisted(() => ({ useWidgetAPI: vi.fn() }));
+vi.mock("utils/proxy/use-widget-api", () => ({ default: useWidgetAPI }));
+
+import Component from "./component";
+
+describe("widgets/pulse/component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders placeholders while loading", () => {
+    useWidgetAPI.mockReturnValue({ data: undefined, error: undefined });
+    const { container } = renderWithProviders(<Component service={{ widget: { type: "pulse" } }} />, {
+      settings: { hideErrors: false },
+    });
+    expect(container.querySelectorAll(".service-block")).toHaveLength(3);
+    expect(screen.getByText("pulse.nodes")).toBeInTheDocument();
+    expect(screen.getByText("pulse.vms")).toBeInTheDocument();
+    expect(screen.getByText("pulse.lxcs")).toBeInTheDocument();
+  });
+
+  it("renders node, vm and lxc counts when loaded", () => {
+    useWidgetAPI.mockReturnValue({
+      data: {
+        resources: [
+          { type: "node", status: "online" },
+          { type: "node", status: "online" },
+          { type: "node", status: "online" },
+          { type: "vm", status: "running" },
+          { type: "vm", status: "running" },
+          { type: "vm", status: "stopped" },
+          { type: "container", platformType: "proxmox-pve", status: "running" },
+          { type: "container", platformType: "proxmox-pve", status: "stopped" },
+        ],
+      },
+      error: undefined,
+    });
+    const { container } = renderWithProviders(<Component service={{ widget: { type: "pulse" } }} />, {
+      settings: { hideErrors: false },
+    });
+    expectBlockValue(container, "pulse.nodes", "3/3");
+    expectBlockValue(container, "pulse.vms", "2/3");
+    expectBlockValue(container, "pulse.lxcs", "1/2");
+  });
+});

--- a/src/widgets/pulse/component.test.jsx
+++ b/src/widgets/pulse/component.test.jsx
@@ -48,4 +48,12 @@ describe("widgets/pulse/component", () => {
     expectBlockValue(container, "pulse.vms", "2/3");
     expectBlockValue(container, "pulse.lxcs", "1/2");
   });
+
+  it("renders error state", () => {
+    useWidgetAPI.mockReturnValue({ data: undefined, error: { message: "HTTP Error 401" } });
+    const { container } = renderWithProviders(<Component service={{ widget: { type: "pulse" } }} />, {
+      settings: { hideErrors: false },
+    });
+    expect(container.querySelector(".service-block")).toBeNull();
+  });
 });

--- a/src/widgets/pulse/widget.js
+++ b/src/widgets/pulse/widget.js
@@ -1,15 +1,12 @@
-import genericProxyHandler from "utils/proxy/handlers/generic";
+import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
 
 const widget = {
   api: "{url}/{endpoint}",
-  proxyHandler: genericProxyHandler,
+  proxyHandler: credentialedProxyHandler,
 
   mappings: {
     resources: {
       endpoint: "api/resources",
-      headers: {
-        "X-API-Token": "{key}",
-      },
     },
   },
 };

--- a/src/widgets/pulse/widget.js
+++ b/src/widgets/pulse/widget.js
@@ -1,0 +1,17 @@
+import genericProxyHandler from "utils/proxy/handlers/generic";
+
+const widget = {
+  api: "{url}/{endpoint}",
+  proxyHandler: genericProxyHandler,
+
+  mappings: {
+    resources: {
+      endpoint: "api/resources",
+      headers: {
+        "X-API-Token": "{key}",
+      },
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -106,6 +106,7 @@ import prowlarr from "./prowlarr/widget";
 import proxmox from "./proxmox/widget";
 import proxmoxbackupserver from "./proxmoxbackupserver/widget";
 import pterodactyl from "./pterodactyl/widget";
+import pulse from "./pulse/widget";
 import pyload from "./pyload/widget";
 import qbittorrent from "./qbittorrent/widget";
 import qnap from "./qnap/widget";
@@ -266,6 +267,7 @@ const widgets = {
   prowlarr,
   proxmox,
   pterodactyl,
+  pulse,
   pyload,
   qbittorrent,
   qnap,


### PR DESCRIPTION
## Proposed change
Adds a service widget for [Pulse](https://github.com/rcourtman/Pulse), 
a real-time monitoring dashboard for Proxmox VE, PBS, and Docker/host infrastructure.

The widget shows:
- Nodes online (X/Y)
- VMs running (X/Y)  
- LXCs running (X/Y)

Example API response (`GET /api/resources`):
{"resources": [{"type": "node", "status": "online", "name": "pve1"}, ...]}

## Type of change
✅ New service widget

## Checklist:
✅ Documentation added (docs/widgets/services/pulse.md)
❌ Tests (not yet added)
✅ Reviewed service widget guidelines
❌ Pre-commit hooks (not yet run)
✅ AI tools disclosure: This PR was developed with AI assistance (Claude by Anthropic)