### PR TITLE
fix(config): fall back to skeleton when config dir is read-only

### DIFF
--- a/src/__tests__/pages/api/hash.test.js
+++ b/src/__tests__/pages/api/hash.test.js
@@ -7,10 +7,11 @@ function sha256(input) {
   return createHash("sha256").update(input).digest("hex");
 }
 
-const { readFileSync, checkAndCopyConfig, CONF_DIR } = vi.hoisted(() => ({
+const { readFileSync, checkAndCopyConfig, CONF_DIR, getConfigPath } = vi.hoisted(() => ({
   readFileSync: vi.fn(),
   checkAndCopyConfig: vi.fn(),
   CONF_DIR: "/conf",
+  getConfigPath: vi.fn((c) => `/conf/${c}`),
 }));
 
 vi.mock("fs", () => ({
@@ -20,6 +21,7 @@ vi.mock("fs", () => ({
 vi.mock("utils/config/config", () => ({
   default: checkAndCopyConfig,
   CONF_DIR,
+  getConfigPath,
 }));
 
 import handler from "pages/api/hash";

--- a/src/pages/api/hash.js
+++ b/src/pages/api/hash.js
@@ -2,7 +2,7 @@ import { createHash } from "crypto";
 import { readFileSync } from "fs";
 import { join } from "path";
 
-import checkAndCopyConfig, { CONF_DIR } from "utils/config/config";
+import checkAndCopyConfig, { getConfigPath } from "utils/config/config";
 
 const configs = [
   "docker.yaml",
@@ -23,7 +23,7 @@ function hash(buffer) {
 export default async function handler(req, res) {
   const hashes = configs.map((config) => {
     checkAndCopyConfig(config);
-    const configYaml = join(CONF_DIR, config);
+    const configYaml = getConfigPath(config);
     return hash(readFileSync(configYaml, "utf8"));
   });
 

--- a/src/utils/config/api-response.js
+++ b/src/utils/config/api-response.js
@@ -1,9 +1,8 @@
 import { promises as fs } from "fs";
-import path from "path";
 
 import yaml from "js-yaml";
 
-import checkAndCopyConfig, { CONF_DIR, getSettings, substituteEnvironmentVars } from "utils/config/config";
+import checkAndCopyConfig, { getConfigPath, getSettings, substituteEnvironmentVars } from "utils/config/config";
 import {
   cleanServiceGroups,
   findGroupByName,
@@ -27,7 +26,7 @@ function compareServices(service1, service2) {
 export async function bookmarksResponse() {
   checkAndCopyConfig("bookmarks.yaml");
 
-  const bookmarksYaml = path.join(CONF_DIR, "bookmarks.yaml");
+  const bookmarksYaml = getConfigPath("bookmarks.yaml");
   const rawFileContents = await fs.readFile(bookmarksYaml, "utf8");
   const fileContents = substituteEnvironmentVars(rawFileContents);
   const bookmarks = yaml.load(fileContents);

--- a/src/utils/config/api-response.test.js
+++ b/src/utils/config/api-response.test.js
@@ -9,6 +9,7 @@ const { fs, yaml, config, widgetHelpers, serviceHelpers } = vi.hoisted(() => ({
   },
   config: {
     CONF_DIR: "/conf",
+    getConfigPath: vi.fn((c) => `/conf/${c}`),
     getSettings: vi.fn(),
     substituteEnvironmentVars: vi.fn((s) => s),
     default: vi.fn(),

--- a/src/utils/config/config.check-copy.test.js
+++ b/src/utils/config/config.check-copy.test.js
@@ -53,25 +53,26 @@ describe("utils/config/config checkAndCopyConfig", () => {
     infoSpy.mockRestore();
   });
 
-  it("exits the process when copying the skeleton fails", async () => {
+  it("warns and continues when copying the skeleton fails (read-only config dir)", async () => {
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
       throw new Error("exit");
     });
-    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     fs.existsSync.mockReturnValueOnce(true);
     fs.existsSync.mockReturnValueOnce(false);
     fs.copyFileSync.mockImplementationOnce(() => {
-      throw new Error("copy failed");
+      throw Object.assign(new Error("read-only file system"), { code: "EROFS" });
     });
 
     const mod = await import("./config");
-    expect(() => mod.default("services.yaml")).toThrow("exit");
-    expect(exitSpy).toHaveBeenCalledWith(1);
-    expect(errSpy).toHaveBeenCalled();
+    // It must not crash: returns true and falls back to the bundled skeleton.
+    expect(mod.default("services.yaml")).toBe(true);
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled();
 
     exitSpy.mockRestore();
-    errSpy.mockRestore();
+    warnSpy.mockRestore();
   });
 
   it("returns a parse error with config name when YAML is invalid", async () => {
@@ -86,5 +87,25 @@ describe("utils/config/config checkAndCopyConfig", () => {
     const result = mod.default("services.yaml");
 
     expect(result).toEqual(expect.objectContaining({ name: "YAMLException", config: "services.yaml" }));
+  });
+});
+
+describe("utils/config/config getConfigPath", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    process.env = { ...process.env, HOMEPAGE_CONFIG_DIR: "/conf" };
+  });
+
+  it("returns the config-dir path when the file exists there", async () => {
+    fs.existsSync.mockReturnValueOnce(true);
+    const mod = await import("./config");
+    expect(mod.getConfigPath("services.yaml")).toBe("/conf/services.yaml");
+  });
+
+  it("falls back to the bundled skeleton when the file is missing", async () => {
+    fs.existsSync.mockReturnValueOnce(false);
+    const mod = await import("./config");
+    expect(mod.getConfigPath("services.yaml")).toBe(mod.SKELETON_DIR + "/services.yaml");
   });
 });

--- a/src/utils/config/config.js
+++ b/src/utils/config/config.js
@@ -12,6 +12,21 @@ export const CONF_DIR = process.env.HOMEPAGE_CONFIG_DIR
   ? process.env.HOMEPAGE_CONFIG_DIR
   : join(process.cwd(), "config");
 
+export const SKELETON_DIR = join(process.cwd(), "src", "skeleton");
+
+// Resolve the path a config file should be read from. The user's config
+// directory is preferred, falling back to the bundled skeleton when the file
+// is not present there. This keeps Homepage working when the config directory
+// is read-only and only some files are provided — e.g. individual files
+// mounted via subPath from a Kubernetes ConfigMap. See #2040 and #2172.
+export function getConfigPath(config) {
+  const configYaml = join(CONF_DIR, config);
+  if (existsSync(configYaml)) {
+    return configYaml;
+  }
+  return join(SKELETON_DIR, config);
+}
+
 export default function checkAndCopyConfig(config) {
   // Ensure config directory exists
   if (!existsSync(CONF_DIR)) {
@@ -27,15 +42,22 @@ export default function checkAndCopyConfig(config) {
 
   // If the config file doesn't exist, try to copy the skeleton
   if (!existsSync(configYaml)) {
-    const configSkeleton = join(process.cwd(), "src", "skeleton", config);
+    const configSkeleton = join(SKELETON_DIR, config);
     try {
       copyFileSync(configSkeleton, configYaml);
       console.info("%s was copied to the config folder", config);
     } catch (err) {
-      console.error("❌ Failed to initialize required config: %s", configYaml);
-      console.error("Reason: %s", err.message);
-      console.error("Hint: Make /app/config writable or manually place the config file.");
-      process.exit(1);
+      // The config directory may be read-only — for example when individual
+      // files are mounted via subPath from a Kubernetes ConfigMap. In that
+      // case we cannot seed the default file, but we can still run using the
+      // bundled skeleton (see getConfigPath), so warn and continue instead of
+      // crashing the whole app. See #2040 and #2172.
+      console.warn(
+        "Could not copy default %s into %s (%s); falling back to the bundled skeleton.",
+        config,
+        CONF_DIR,
+        err.code || err.message,
+      );
     }
 
     return true;
@@ -82,7 +104,7 @@ export function substituteEnvironmentVars(str) {
 export function getSettings() {
   checkAndCopyConfig("settings.yaml");
 
-  const settingsYaml = join(CONF_DIR, "settings.yaml");
+  const settingsYaml = getConfigPath("settings.yaml");
   const rawFileContents = readFileSync(settingsYaml, "utf8");
   const fileContents = substituteEnvironmentVars(rawFileContents);
   const initialSettings = yaml.load(fileContents) ?? {};

--- a/src/utils/config/docker.js
+++ b/src/utils/config/docker.js
@@ -3,7 +3,7 @@ import path from "path";
 
 import yaml from "js-yaml";
 
-import checkAndCopyConfig, { CONF_DIR, substituteEnvironmentVars } from "utils/config/config";
+import checkAndCopyConfig, { CONF_DIR, getConfigPath, substituteEnvironmentVars } from "utils/config/config";
 
 export function getDefaultDockerArgs(platform = process.platform) {
   if (platform !== "win32" && platform !== "darwin") {
@@ -16,7 +16,7 @@ export function getDefaultDockerArgs(platform = process.platform) {
 export default function getDockerArguments(server) {
   checkAndCopyConfig("docker.yaml");
 
-  const configFile = path.join(CONF_DIR, "docker.yaml");
+  const configFile = getConfigPath("docker.yaml");
   const rawConfigData = readFileSync(configFile, "utf8");
   const configData = substituteEnvironmentVars(rawConfigData);
   const servers = yaml.load(configData);

--- a/src/utils/config/docker.test.js
+++ b/src/utils/config/docker.test.js
@@ -12,6 +12,7 @@ const { fs, yaml, config, checkAndCopyConfig } = vi.hoisted(() => ({
   },
   config: {
     CONF_DIR: "/conf",
+    getConfigPath: vi.fn((c) => `/conf/${c}`),
     substituteEnvironmentVars: vi.fn((s) => s),
   },
   checkAndCopyConfig: vi.fn(),

--- a/src/utils/config/kubernetes.js
+++ b/src/utils/config/kubernetes.js
@@ -1,14 +1,13 @@
 import { readFileSync } from "fs";
-import path from "path";
 
 import { ApiextensionsV1Api, KubeConfig } from "@kubernetes/client-node";
 import yaml from "js-yaml";
 
-import checkAndCopyConfig, { CONF_DIR, substituteEnvironmentVars } from "utils/config/config";
+import checkAndCopyConfig, { getConfigPath, substituteEnvironmentVars } from "utils/config/config";
 
 export function getKubernetes() {
   checkAndCopyConfig("kubernetes.yaml");
-  const configFile = path.join(CONF_DIR, "kubernetes.yaml");
+  const configFile = getConfigPath("kubernetes.yaml");
   const rawConfigData = readFileSync(configFile, "utf8");
   const configData = substituteEnvironmentVars(rawConfigData);
   return yaml.load(configData);

--- a/src/utils/config/kubernetes.test.js
+++ b/src/utils/config/kubernetes.test.js
@@ -20,6 +20,7 @@ const { fs, yaml, config, checkAndCopyConfig, kube, apiExt } = vi.hoisted(() => 
     },
     config: {
       CONF_DIR: "/conf",
+      getConfigPath: vi.fn((c) => `/conf/${c}`),
       substituteEnvironmentVars: vi.fn((s) => s),
     },
     checkAndCopyConfig: vi.fn(),

--- a/src/utils/config/proxmox.js
+++ b/src/utils/config/proxmox.js
@@ -1,13 +1,12 @@
 import { readFileSync } from "fs";
-import path from "path";
 
 import yaml from "js-yaml";
 
-import checkAndCopyConfig, { CONF_DIR, substituteEnvironmentVars } from "utils/config/config";
+import checkAndCopyConfig, { getConfigPath, substituteEnvironmentVars } from "utils/config/config";
 
 export function getProxmoxConfig() {
   checkAndCopyConfig("proxmox.yaml");
-  const configFile = path.join(CONF_DIR, "proxmox.yaml");
+  const configFile = getConfigPath("proxmox.yaml");
   const rawConfigData = readFileSync(configFile, "utf8");
   const configData = substituteEnvironmentVars(rawConfigData);
   return yaml.load(configData);

--- a/src/utils/config/proxmox.test.js
+++ b/src/utils/config/proxmox.test.js
@@ -9,6 +9,7 @@ const { fs, yaml, config, checkAndCopyConfig } = vi.hoisted(() => ({
   },
   config: {
     CONF_DIR: "/conf",
+    getConfigPath: vi.fn((c) => `/conf/${c}`),
     substituteEnvironmentVars: vi.fn((s) => s),
   },
   checkAndCopyConfig: vi.fn(),

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -1,10 +1,9 @@
 import { promises as fs } from "fs";
-import path from "path";
 
 import Docker from "dockerode";
 import yaml from "js-yaml";
 
-import checkAndCopyConfig, { CONF_DIR, getSettings, substituteEnvironmentVars } from "utils/config/config";
+import checkAndCopyConfig, { getConfigPath, getSettings, substituteEnvironmentVars } from "utils/config/config";
 import getDockerArguments from "utils/config/docker";
 import { getKubeConfig } from "utils/config/kubernetes";
 import * as shvl from "utils/config/shvl";
@@ -53,7 +52,7 @@ function parseServicesToGroups(services) {
 export async function servicesFromConfig() {
   checkAndCopyConfig("services.yaml");
 
-  const servicesYaml = path.join(CONF_DIR, "services.yaml");
+  const servicesYaml = getConfigPath("services.yaml");
   const rawFileContents = await fs.readFile(servicesYaml, "utf8");
   const fileContents = substituteEnvironmentVars(rawFileContents);
   const services = yaml.load(fileContents);
@@ -63,7 +62,7 @@ export async function servicesFromConfig() {
 export async function servicesFromDocker() {
   checkAndCopyConfig("docker.yaml");
 
-  const dockerYaml = path.join(CONF_DIR, "docker.yaml");
+  const dockerYaml = getConfigPath("docker.yaml");
   const rawDockerFileContents = await fs.readFile(dockerYaml, "utf8");
   const dockerFileContents = substituteEnvironmentVars(rawDockerFileContents);
   const servers = yaml.load(dockerFileContents);

--- a/src/utils/config/service-helpers.test.js
+++ b/src/utils/config/service-helpers.test.js
@@ -35,6 +35,7 @@ const { state, fs, yaml, config, Docker, dockerCfg, kubeCfg, kubeApi } = vi.hois
 
   const config = {
     CONF_DIR: "/conf",
+    getConfigPath: vi.fn((c) => `/conf/${c}`),
     getSettings: vi.fn(() => ({ instanceName: undefined })),
     substituteEnvironmentVars: vi.fn((s) => s),
     default: vi.fn(),

--- a/src/utils/config/widget-helpers.js
+++ b/src/utils/config/widget-helpers.js
@@ -1,14 +1,13 @@
 import { promises as fs } from "fs";
-import path from "path";
 
 import yaml from "js-yaml";
 
-import checkAndCopyConfig, { CONF_DIR, substituteEnvironmentVars } from "utils/config/config";
+import checkAndCopyConfig, { getConfigPath, substituteEnvironmentVars } from "utils/config/config";
 
 export async function widgetsFromConfig() {
   checkAndCopyConfig("widgets.yaml");
 
-  const widgetsYaml = path.join(CONF_DIR, "widgets.yaml");
+  const widgetsYaml = getConfigPath("widgets.yaml");
   const rawFileContents = await fs.readFile(widgetsYaml, "utf8");
   const fileContents = substituteEnvironmentVars(rawFileContents);
   const widgets = yaml.load(fileContents);

--- a/src/utils/config/widget-helpers.test.js
+++ b/src/utils/config/widget-helpers.test.js
@@ -9,6 +9,7 @@ const { fs, yaml, config } = vi.hoisted(() => ({
   },
   config: {
     CONF_DIR: "/conf",
+    getConfigPath: vi.fn((c) => `/conf/${c}`),
     substituteEnvironmentVars: vi.fn((s) => s),
     default: vi.fn(),
   },


### PR DESCRIPTION
ASLOP-PR-VERIFY

## Proposed change

Homepage hard-crashes with `process.exit(1)` when it cannot copy a default config file into the config directory. This happens whenever the config directory is **read-only and only some files are present** — most commonly when individual files are mounted via `subPath` from a Kubernetes ConfigMap, which makes the directory non-writable. Any missing skeleton file then triggers an `EACCES`/`EROFS` copyfile error and takes the whole app down with `CrashLoopBackOff`.

This PR makes config loading resilient to a read-only config directory:

- `checkAndCopyConfig()` now **warns and continues** instead of calling `process.exit(1)` when it cannot seed a default file.
- A new `getConfigPath()` helper resolves each config read to the user's file when present, and **falls back to the bundled `src/skeleton/` copy** when it is absent. The skeletons are valid (mostly-commented) YAML/CSS/JS, so Homepage starts cleanly with whatever subset of config files the user provided.
- All config readers (`settings`, `services`, `docker`, `widgets`, `bookmarks`, `kubernetes`, `proxmox`, and the `/api/hash` route) now read through `getConfigPath()`.

This matches the direction discussed by the community in the referenced issues — avoid requiring writes to the config directory in the first place, and fall back to the skeleton.

Closes #2172
Refs #2040

## Type of change

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [ ] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] In the description above I have disclosed the use of AI tools in the coding of this PR.

## Tests

- Updated `config.check-copy.test.js`: replaced the "exits the process when copying fails" test with one asserting that an `EROFS` copy failure now **warns and continues** (no `process.exit`), plus new `getConfigPath` tests (config-dir hit and skeleton fallback).
- Added `getConfigPath` to the existing mocks in `widget-helpers`, `docker`, `service-helpers`, `api-response`, `kubernetes`, `proxmox`, and `hash` test suites.
- All config/api test suites pass; the only failing tests in the full run (theme/color/search/index component tests) fail identically on a clean `dev` checkout and are unrelated to this change. `eslint` is clean on all touched files.

## AI tool disclosure

This change was developed with AI-assisted tooling (GitHub Copilot CLI). The diagnosis, design (skeleton fallback rather than forcing a writable config dir), code, and tests were human-reviewed and verified locally before submission.
