### PR TITLE
[codex] Add Bangumi timeline widget integration

### DIFF
--- a/docs/superpowers/plans/2026-06-29-bangumi-homepage.md
+++ b/docs/superpowers/plans/2026-06-29-bangumi-homepage.md
@@ -32,6 +32,7 @@
 ## Task 1: Bangumi Core Data Model
 
 **Files:**
+
 - Create: `src/utils/bangumi/paths.js`
 - Create: `src/utils/bangumi/core.js`
 - Test: `src/utils/bangumi/core.test.js`
@@ -94,11 +95,21 @@ describe("bangumi core", () => {
         firstEpisode: 1,
       },
     };
-    expect(deriveStatus(show, { lastArrivedEpisode: 3 }, new Date("2026-06-17T12:00:00+08:00"), 12).status).toBe("arrived");
-    expect(deriveStatus(show, { lastArrivedEpisode: 2 }, new Date("2026-06-17T09:00:00+08:00"), 12).status).toBe("today");
-    expect(deriveStatus(show, { lastArrivedEpisode: 2 }, new Date("2026-06-17T13:00:00+08:00"), 12).status).toBe("waiting");
-    expect(deriveStatus(show, { lastArrivedEpisode: 2 }, new Date("2026-06-18T00:30:00+08:00"), 12).status).toBe("overdue");
-    expect(deriveStatus({ key: "x", title: "X" }, {}, new Date("2026-06-17T12:00:00+08:00"), 12).status).toBe("missing_schedule");
+    expect(deriveStatus(show, { lastArrivedEpisode: 3 }, new Date("2026-06-17T12:00:00+08:00"), 12).status).toBe(
+      "arrived",
+    );
+    expect(deriveStatus(show, { lastArrivedEpisode: 2 }, new Date("2026-06-17T09:00:00+08:00"), 12).status).toBe(
+      "today",
+    );
+    expect(deriveStatus(show, { lastArrivedEpisode: 2 }, new Date("2026-06-17T13:00:00+08:00"), 12).status).toBe(
+      "waiting",
+    );
+    expect(deriveStatus(show, { lastArrivedEpisode: 2 }, new Date("2026-06-18T00:30:00+08:00"), 12).status).toBe(
+      "overdue",
+    );
+    expect(deriveStatus({ key: "x", title: "X" }, {}, new Date("2026-06-17T12:00:00+08:00"), 12).status).toBe(
+      "missing_schedule",
+    );
   });
 
   it("builds timeline payload and records matched and unmatched arrivals", () => {
@@ -152,6 +163,7 @@ Expected: all tests in `core.test.js` pass.
 ## Task 2: AutoBangumi Sync
 
 **Files:**
+
 - Create: `src/utils/bangumi/autobangumi.js`
 - Test: `src/utils/bangumi/autobangumi.test.js`
 
@@ -178,6 +190,7 @@ Expected: all AutoBangumi tests pass.
 ## Task 3: Bangumi API Routes and Authorization
 
 **Files:**
+
 - Create: `src/utils/bangumi/auth.js`
 - Create: `src/pages/api/bangumi/status.js`
 - Create: `src/pages/api/bangumi/webhook/arrival.js`
@@ -212,6 +225,7 @@ Expected: all route tests pass.
 ## Task 4: Bangumi Widget Registration and UI
 
 **Files:**
+
 - Create: `src/widgets/bangumi/widget.js`
 - Create: `src/widgets/bangumi/proxy.js`
 - Create: `src/widgets/bangumi/component.jsx`
@@ -245,6 +259,7 @@ Expected: all widget/config tests pass.
 ## Task 5: Documentation and Example Schedule
 
 **Files:**
+
 - Create: `docs/widgets/services/bangumi.md`
 - Create: `src/skeleton/bangumi-schedule.json`
 - Modify: `docs/widgets/services/index.md`
@@ -262,6 +277,7 @@ Expected: Bangumi docs, index link, and skeleton file appear.
 ## Task 6: Integration Verification and Local Page Test
 
 **Files:**
+
 - Modify only if fixes are needed after verification.
 
 - [ ] **Step 1: Run focused Bangumi tests**

--- a/docs/superpowers/plans/2026-06-29-bangumi-homepage.md
+++ b/docs/superpowers/plans/2026-06-29-bangumi-homepage.md
@@ -1,0 +1,299 @@
+# Bangumi Homepage Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a first-class Bangumi timeline widget inside Homepage with internal APIs for schedule status, arrival webhooks, AutoBangumi sync, and management writes.
+
+**Architecture:** Port the Python source behavior into focused JavaScript modules under `src/utils/bangumi`, expose thin Next.js API routes, and render through a new `src/widgets/bangumi` service widget. Persist JSON state under Homepage config paths with atomic writes and protect write APIs with explicit token/session checks.
+
+**Tech Stack:** Next.js API routes, React 19, SWR, Vitest, Testing Library, `node:fs`, `node:path`, built-in `fetch`.
+
+---
+
+## File Structure
+
+- Create `src/utils/bangumi/paths.js`: config/data path resolution and JSON atomic read/write helpers.
+- Create `src/utils/bangumi/core.js`: pure schedule, title, episode, status, timeline, and management helpers.
+- Create `src/utils/bangumi/autobangumi.js`: AutoBangumi fetch, login, response normalization, and state merge helpers.
+- Create `src/utils/bangumi/auth.js`: admin and webhook authorization helpers.
+- Create `src/pages/api/bangumi/status.js`: status read endpoint with optional interval sync.
+- Create `src/pages/api/bangumi/webhook/arrival.js`: arrival webhook endpoint.
+- Create `src/pages/api/admin/bangumi/manage.js`: management read endpoint.
+- Create `src/pages/api/admin/bangumi/sync.js`: manual sync endpoint.
+- Create `src/pages/api/admin/bangumi/shows/index.js`: create schedule entry endpoint.
+- Create `src/pages/api/admin/bangumi/shows/[key].js`: patch/hide/restore endpoint.
+- Create `src/widgets/bangumi/widget.js`: widget proxy mapping.
+- Create `src/widgets/bangumi/proxy.js`: local API proxy for widget calls.
+- Create `src/widgets/bangumi/component.jsx`: timeline and management UI.
+- Modify `src/widgets/widgets.js`, `src/widgets/components.js`, and `src/utils/config/service-helpers.js`: register and whitelist Bangumi.
+- Create `docs/widgets/services/bangumi.md`: user-facing configuration documentation.
+- Add focused tests beside each new module and route.
+
+## Task 1: Bangumi Core Data Model
+
+**Files:**
+- Create: `src/utils/bangumi/paths.js`
+- Create: `src/utils/bangumi/core.js`
+- Test: `src/utils/bangumi/core.test.js`
+
+- [ ] **Step 1: Write failing tests for pure core behavior**
+
+Add tests covering:
+
+```js
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_SCHEDULE,
+  deriveStatus,
+  episodeNumber,
+  expectedEpisode,
+  makeTimelinePayload,
+  normalizeTitle,
+  recordArrivalInData,
+  scheduledAtForEpisode,
+} from "./core";
+
+describe("bangumi core", () => {
+  it("normalizes titles and extracts episode numbers from common payloads", () => {
+    expect(normalizeTitle("  Example Show S2  ")).toBe("exampleshows2");
+    expect(normalizeTitle("葬送 的 芙莉莲")).toBe("葬送的芙莉莲");
+    expect(episodeNumber({ episode_numbers: [7] })).toBe(7);
+    expect(episodeNumber({ episode_display: "第12集" })).toBe(12);
+    expect(episodeNumber({ path: "/Animation/Show/Show S01E03.mkv" })).toBe(3);
+    expect(episodeNumber({ episode_display: "特别篇" })).toBeNull();
+  });
+
+  it("calculates expected episode and scheduled time from first air date", () => {
+    const show = {
+      key: "demo",
+      title: "Demo",
+      airing: {
+        weekday: 3,
+        time: "10:00",
+        timezone: "Asia/Shanghai",
+        firstAirDate: "2026-06-03",
+        firstEpisode: 1,
+        totalEpisodes: 12,
+      },
+    };
+    const now = new Date("2026-06-17T12:00:00+08:00");
+    expect(expectedEpisode(show, now)).toBe(3);
+    expect(scheduledAtForEpisode(show, 3).toISOString()).toBe("2026-06-17T02:00:00.000Z");
+  });
+
+  it("derives today, waiting, overdue, arrived, and missing schedule statuses", () => {
+    const show = {
+      key: "demo",
+      title: "Demo",
+      airing: {
+        weekday: 3,
+        time: "10:00",
+        timezone: "Asia/Shanghai",
+        firstAirDate: "2026-06-03",
+        firstEpisode: 1,
+      },
+    };
+    expect(deriveStatus(show, { lastArrivedEpisode: 3 }, new Date("2026-06-17T12:00:00+08:00"), 12).status).toBe("arrived");
+    expect(deriveStatus(show, { lastArrivedEpisode: 2 }, new Date("2026-06-17T09:00:00+08:00"), 12).status).toBe("today");
+    expect(deriveStatus(show, { lastArrivedEpisode: 2 }, new Date("2026-06-17T13:00:00+08:00"), 12).status).toBe("waiting");
+    expect(deriveStatus(show, { lastArrivedEpisode: 2 }, new Date("2026-06-18T00:30:00+08:00"), 12).status).toBe("overdue");
+    expect(deriveStatus({ key: "x", title: "X" }, {}, new Date("2026-06-17T12:00:00+08:00"), 12).status).toBe("missing_schedule");
+  });
+
+  it("builds timeline payload and records matched and unmatched arrivals", () => {
+    const schedule = {
+      ...DEFAULT_SCHEDULE,
+      shows: [
+        {
+          key: "demo",
+          title: "Demo Show",
+          aliases: ["Demo"],
+          airing: { weekday: 3, time: "10:00", timezone: "Asia/Shanghai", firstAirDate: "2026-06-03", firstEpisode: 1 },
+        },
+      ],
+    };
+    const state = { shows: {} };
+    const events = { events: [] };
+    const matched = recordArrivalInData(schedule, state, events, {
+      series_title: "Demo",
+      episode_numbers: [3],
+      path: "/Animation/Demo/Demo S01E03.mkv",
+      event_time: "2026-06-17T12:30:00+08:00",
+    });
+    expect(matched.matched).toBe(true);
+    expect(state.shows.demo.lastArrivedEpisode).toBe(3);
+    const payload = makeTimelinePayload(schedule, state, events, new Date("2026-06-17T13:00:00+08:00"));
+    expect(payload.summary.arrived).toBe(1);
+    expect(payload.rows[0].title).toBe("Demo Show");
+    const unmatched = recordArrivalInData(schedule, state, events, { series_title: "Other", episode_display: "第1集" });
+    expect(unmatched.matched).toBe(false);
+    expect(state.unmatchedEvents).toHaveLength(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run: `pnpm vitest run src/utils/bangumi/core.test.js`
+
+Expected: fails because `src/utils/bangumi/core.js` does not exist.
+
+- [ ] **Step 3: Implement core helpers and path helpers**
+
+Implement CommonJS-free ES modules with named exports. Keep `core.js` pure except for date/time parsing. `paths.js` should export `schedulePath`, `dataDir`, `statePath`, `eventsPath`, `loadJson`, `atomicWriteJson`, and `ensureBangumiDataFiles`.
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+Run: `pnpm vitest run src/utils/bangumi/core.test.js`
+
+Expected: all tests in `core.test.js` pass.
+
+## Task 2: AutoBangumi Sync
+
+**Files:**
+- Create: `src/utils/bangumi/autobangumi.js`
+- Test: `src/utils/bangumi/autobangumi.test.js`
+
+- [ ] **Step 1: Write failing AutoBangumi tests**
+
+Add tests for subscription normalization, matching several response shapes, merge behavior, missing schedule names, and login/candidate endpoint fetch order using mocked `fetch`.
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run: `pnpm vitest run src/utils/bangumi/autobangumi.test.js`
+
+Expected: fails because `autobangumi.js` does not exist.
+
+- [ ] **Step 3: Implement AutoBangumi helpers**
+
+Exports: `normalizeAutoBangumiSubscriptions`, `fetchAutoBangumiSubscriptions`, `mergeAutoBangumiSubscriptions`, `syncAutoBangumi`, `maybeSyncAutoBangumi`.
+
+- [ ] **Step 4: Run tests and verify GREEN**
+
+Run: `pnpm vitest run src/utils/bangumi/autobangumi.test.js`
+
+Expected: all AutoBangumi tests pass.
+
+## Task 3: Bangumi API Routes and Authorization
+
+**Files:**
+- Create: `src/utils/bangumi/auth.js`
+- Create: `src/pages/api/bangumi/status.js`
+- Create: `src/pages/api/bangumi/webhook/arrival.js`
+- Create: `src/pages/api/admin/bangumi/manage.js`
+- Create: `src/pages/api/admin/bangumi/sync.js`
+- Create: `src/pages/api/admin/bangumi/shows/index.js`
+- Create: `src/pages/api/admin/bangumi/shows/[key].js`
+- Test: `src/__tests__/pages/api/bangumi/status.test.js`
+- Test: `src/__tests__/pages/api/bangumi/webhook-arrival.test.js`
+- Test: `src/__tests__/pages/api/admin/bangumi.test.js`
+
+- [ ] **Step 1: Write failing API tests**
+
+Test method handling, JSON responses, webhook token acceptance through `X-Homepage-Bangumi-Token` and `X-Homelab-Webhook-Token`, admin token/session authorization, schedule create, patch, hide, restore, and manual sync errors.
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run: `pnpm vitest run src/__tests__/pages/api/bangumi/status.test.js src/__tests__/pages/api/bangumi/webhook-arrival.test.js src/__tests__/pages/api/admin/bangumi.test.js`
+
+Expected: route imports fail.
+
+- [ ] **Step 3: Implement routes as thin wrappers**
+
+Routes should import utilities from `src/utils/bangumi`, avoid duplicating core logic, and return stable HTTP statuses: `200`, `201`, `400`, `401`, `405`, `500`, `502`.
+
+- [ ] **Step 4: Run tests and verify GREEN**
+
+Run: `pnpm vitest run src/__tests__/pages/api/bangumi/status.test.js src/__tests__/pages/api/bangumi/webhook-arrival.test.js src/__tests__/pages/api/admin/bangumi.test.js`
+
+Expected: all route tests pass.
+
+## Task 4: Bangumi Widget Registration and UI
+
+**Files:**
+- Create: `src/widgets/bangumi/widget.js`
+- Create: `src/widgets/bangumi/proxy.js`
+- Create: `src/widgets/bangumi/component.jsx`
+- Create: `src/widgets/bangumi/component.test.jsx`
+- Create: `src/widgets/bangumi/widget.test.js`
+- Modify: `src/widgets/widgets.js`
+- Modify: `src/widgets/components.js`
+- Modify: `src/utils/config/service-helpers.js`
+- Test: `src/utils/config/service-helpers.test.js`
+
+- [ ] **Step 1: Write failing widget and config tests**
+
+Test widget registration, `service-helpers` whitelist for `maxTodayItems`, `maxEvents`, `refreshInterval`, and `showManage`, loading state, summary rendering, filters, expansion, and management button visibility.
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run: `pnpm vitest run src/widgets/bangumi/component.test.jsx src/widgets/bangumi/widget.test.js src/utils/config/service-helpers.test.js`
+
+Expected: Bangumi imports and whitelist assertions fail.
+
+- [ ] **Step 3: Implement widget files and registration**
+
+Use `useWidgetAPI(widget, "status", { refreshInterval })` for reads. Keep styling with Tailwind utility classes inside the component. Use a dialog for management and call API endpoints through `fetch`.
+
+- [ ] **Step 4: Run tests and verify GREEN**
+
+Run: `pnpm vitest run src/widgets/bangumi/component.test.jsx src/widgets/bangumi/widget.test.js src/utils/config/service-helpers.test.js`
+
+Expected: all widget/config tests pass.
+
+## Task 5: Documentation and Example Schedule
+
+**Files:**
+- Create: `docs/widgets/services/bangumi.md`
+- Create: `src/skeleton/bangumi-schedule.json`
+- Modify: `docs/widgets/services/index.md`
+
+- [ ] **Step 1: Write docs and example schedule**
+
+Document environment variables, schedule schema, widget YAML, webhook URL, AutoBangumi sync, management auth, and migration notes from `homelab-homepage`.
+
+- [ ] **Step 2: Verify docs are linked**
+
+Run: `rg -n "Bangumi|bangumi" docs/widgets/services src/skeleton`
+
+Expected: Bangumi docs, index link, and skeleton file appear.
+
+## Task 6: Integration Verification and Local Page Test
+
+**Files:**
+- Modify only if fixes are needed after verification.
+
+- [ ] **Step 1: Run focused Bangumi tests**
+
+Run: `pnpm vitest run src/utils/bangumi src/widgets/bangumi src/__tests__/pages/api/bangumi src/__tests__/pages/api/admin/bangumi.test.js`
+
+Expected: all focused Bangumi tests pass.
+
+- [ ] **Step 2: Run lint**
+
+Run: `pnpm lint`
+
+Expected: no lint errors.
+
+- [ ] **Step 3: Run Homepage dev server locally**
+
+Run: `pnpm dev`
+
+Expected: local server starts on `http://localhost:3000`.
+
+- [ ] **Step 4: Configure a local test service**
+
+Use `HOMEPAGE_CONFIG_DIR` pointing at a temporary config directory with `services.yaml`, `settings.yaml`, and `bangumi-schedule.json`.
+
+- [ ] **Step 5: Browser verify the page**
+
+Open `http://localhost:3000`, confirm the Bangumi widget renders summary, today queue, week strip, filters, expandable rows, and management dialog without visual overlap at desktop and mobile widths.
+
+---
+
+## Self-Review
+
+- Spec coverage: tasks cover data logic, AutoBangumi sync, API routes, widget UI, docs, tests, and local page verification.
+- Placeholder scan: no task relies on TBD implementation; each task names files and expected commands.
+- Type consistency: route and utility names are consistent across tasks.

--- a/docs/superpowers/specs/2026-06-29-bangumi-homepage-design.md
+++ b/docs/superpowers/specs/2026-06-29-bangumi-homepage-design.md
@@ -1,0 +1,146 @@
+# Bangumi Homepage Integration Design
+
+## Goal
+
+Embed the `homelab-homepage` Bangumi timeline into `gethomepage/homepage` as a first-class, self-contained Homepage service widget with internal Next.js APIs for schedule state, AutoBangumi sync, arrival webhooks, and schedule management.
+
+## Source Behavior
+
+The source implementation in `Garess/unraid-wenti/homelab-homepage` provides:
+
+- `bangumi.py` core schedule, state, event, AutoBangumi, matching, and status logic.
+- `/api/bangumi/status` for the timeline payload.
+- `/api/bangumi/webhook/arrival` for local media arrival notifications.
+- `/api/admin/bangumi/manage`, `/sync`, `/shows`, and `/shows/:key` for management.
+- A static UI with summary counts, today queue, week filters, status filters, expandable rows, and a management dialog.
+
+## Homepage Architecture
+
+The Homepage integration will use the existing Next.js/React structure:
+
+- `src/utils/bangumi/` contains pure data and state logic.
+- `src/pages/api/bangumi/` exposes status and webhook APIs.
+- `src/pages/api/admin/bangumi/` exposes authenticated management APIs.
+- `src/widgets/bangumi/` renders the timeline widget inside Homepage services.
+- `src/widgets/components.js`, `src/widgets/widgets.js`, and `src/utils/config/service-helpers.js` register and whitelist the widget.
+- `docs/widgets/services/bangumi.md` documents configuration.
+
+## Data Files
+
+Bangumi uses JSON files under Homepage's config area:
+
+- Schedule: `${HOMEPAGE_CONFIG_DIR}/bangumi-schedule.json`
+- State: `${HOMEPAGE_BANGUMI_DATA_DIR || HOMEPAGE_CONFIG_DIR + "/bangumi-data"}/bangumi-state.json`
+- Events: `${HOMEPAGE_BANGUMI_DATA_DIR || HOMEPAGE_CONFIG_DIR + "/bangumi-data"}/bangumi-events.json`
+
+Missing files return safe defaults. Writes are atomic: write a temporary file in the same directory, then rename it into place.
+
+## Runtime Configuration
+
+Environment variables:
+
+- `HOMEPAGE_BANGUMI_ENABLED`: overrides schedule `settings.enabled` when set.
+- `HOMEPAGE_BANGUMI_DATA_DIR`: optional state/events directory.
+- `HOMEPAGE_BANGUMI_WEBHOOK_TOKEN`: required for arrival webhook writes when set.
+- `HOMEPAGE_BANGUMI_ADMIN_TOKEN`: optional token for management writes when Homepage auth is not enabled.
+- `HOMEPAGE_BANGUMI_SYNC_INTERVAL_MINUTES`: default sync cadence.
+- `HOMEPAGE_BANGUMI_OVERDUE_GRACE_HOURS`: default overdue grace window.
+- `HOMEPAGE_AUTOBANGUMI_API_URL`: optional AutoBangumi base URL.
+- `HOMEPAGE_AUTOBANGUMI_USERNAME` / `HOMEPAGE_AUTOBANGUMI_PASSWORD`: optional AutoBangumi login credentials.
+
+Widget YAML:
+
+```yaml
+widget:
+  type: bangumi
+  maxTodayItems: 6
+  maxEvents: 10
+  refreshInterval: 300000
+  showManage: true
+```
+
+## API Contract
+
+`GET /api/bangumi/status`
+
+Returns:
+
+- `generatedAt`
+- `summary`
+- `todayQueue`
+- `week`
+- `rows`
+- `recentEvents`
+- `unmatchedEvents`
+
+`POST /api/bangumi/webhook/arrival`
+
+Accepts payloads compatible with the source implementation:
+
+- `series_title`
+- `season_name`
+- `episode_numbers`
+- `episode_display`
+- `path`
+- `notification_message`
+- `event_time`
+
+It requires `X-Homepage-Bangumi-Token` or `X-Homelab-Webhook-Token` when `HOMEPAGE_BANGUMI_WEBHOOK_TOKEN` is set.
+
+Management APIs:
+
+- `GET /api/admin/bangumi/manage`
+- `POST /api/admin/bangumi/sync`
+- `POST /api/admin/bangumi/shows`
+- `PATCH /api/admin/bangumi/shows/:key`
+
+Management APIs require either a Homepage authenticated session when `HOMEPAGE_AUTH_ENABLED` is set, or `HOMEPAGE_BANGUMI_ADMIN_TOKEN` via `Authorization: Bearer <token>` or `X-Homepage-Bangumi-Admin-Token`.
+
+## AutoBangumi Sync
+
+AutoBangumi sync supports:
+
+- Optional login through `/api/v1/auth/login`.
+- Subscription discovery through `/api/v1/rss`, `/api/v1/bangumi/get/all`, `/api/v1/bangumi`, `/api/bangumi`, and `/api/subscriptions`.
+- Normalization of common response shapes into subscription names, status, and download status.
+- Merge into state without modifying schedule entries directly.
+
+No background loop will be introduced. Status and management reads call `maybeSyncAutoBangumi`, which triggers sync only when the configured interval has elapsed. Manual sync stays available through the management API.
+
+## UI
+
+The widget renders:
+
+- Header with generated time and optional manage button.
+- Summary counts.
+- Today queue chips.
+- Week strip filter.
+- Status filter tabs.
+- Expandable rows with episode, local path, subscription, match, and reason details.
+- Management dialog with missing, configured, and hidden sections.
+
+The UI should follow Homepage service widget styling: compact, dense, and usable inside a service card without marketing-style decoration.
+
+## Testing
+
+Tests must cover:
+
+- Title normalization and episode extraction.
+- Expected episode and scheduled time calculation.
+- Status derivation, including waiting, today, overdue, arrived, upcoming, finished, hidden, and missing schedule.
+- Timeline payload generation.
+- Arrival webhook matching and unmatched event behavior.
+- AutoBangumi response normalization and merge behavior.
+- API authorization for admin and webhook writes.
+- Component rendering for loading, summary, filtering, expansion, and management actions.
+- Service config whitelist and widget registration.
+
+## Fork and Delivery
+
+Development happens locally on `codex/bangumi-homepage-integration`. `Garess/homepage` does not currently exist, so pushing requires one of:
+
+- User creates the GitHub fork in the web UI.
+- A GitHub API token is provided for `POST /repos/gethomepage/homepage/forks`.
+- A working GitHub connector or `gh` installation becomes available.
+
+After the remote exists, push the branch to `Garess/homepage`.

--- a/docs/widgets/services/bangumi.md
+++ b/docs/widgets/services/bangumi.md
@@ -1,0 +1,57 @@
+---
+title: Bangumi
+description: Bangumi Timeline Widget Configuration
+---
+
+The Bangumi widget shows a local anime airing timeline powered by Homepage's built-in Bangumi API.
+
+Allowed fields: `["total", "today", "overdue", "unmatched"]`.
+
+```yaml
+widget:
+  type: bangumi
+```
+
+Create `bangumi-schedule.json` in your Homepage config directory. Runtime state is stored in `bangumi-data/bangumi-state.json` and `bangumi-data/bangumi-events.json`.
+
+```json
+{
+  "settings": {
+    "enabled": true,
+    "overdueGraceHours": 12,
+    "eventLimit": 100,
+    "syncIntervalMinutes": 60
+  },
+  "shows": [
+    {
+      "key": "example-weekly-show",
+      "title": "Example Weekly Show",
+      "aliases": ["Example Weekly Anime", "Example Show"],
+      "autobangumiNames": ["Example Weekly Show"],
+      "airing": {
+        "weekday": 6,
+        "time": "23:30",
+        "timezone": "Asia/Tokyo",
+        "firstAirDate": "2026-01-10",
+        "firstEpisode": 1,
+        "totalEpisodes": 12
+      },
+      "hidden": false,
+      "finished": false
+    }
+  ]
+}
+```
+
+Optional environment variables:
+
+```text
+HOMEPAGE_BANGUMI_DATA_DIR=/app/config/bangumi-data
+HOMEPAGE_BANGUMI_WEBHOOK_TOKEN=change-me
+HOMEPAGE_BANGUMI_ADMIN_TOKEN=change-me
+HOMEPAGE_AUTOBANGUMI_API_URL=http://autobangumi:7892
+HOMEPAGE_AUTOBANGUMI_USERNAME=username
+HOMEPAGE_AUTOBANGUMI_PASSWORD=password
+```
+
+Arrival webhooks can be posted to `/api/bangumi/webhook/arrival` with `X-Homepage-Bangumi-Token` or `X-Homelab-Webhook-Token`. Management endpoints require Homepage auth or `HOMEPAGE_BANGUMI_ADMIN_TOKEN`.

--- a/src/__tests__/pages/api/admin/bangumi/manage.test.js
+++ b/src/__tests__/pages/api/admin/bangumi/manage.test.js
@@ -1,0 +1,217 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "fs/promises";
+import os from "os";
+import path from "path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import createMockRes from "test-utils/create-mock-res";
+
+const { config, autoBangumi, getServerSession } = vi.hoisted(() => ({
+  config: {
+    CONF_DIR: "",
+  },
+  autoBangumi: {
+    syncAutoBangumi: vi.fn(),
+  },
+  getServerSession: vi.fn(),
+}));
+
+vi.mock("utils/config/config", () => config);
+vi.mock("next-auth/next", () => ({ getServerSession }));
+vi.mock("utils/bangumi/autobangumi", async (importOriginal) => ({
+  ...(await importOriginal()),
+  syncAutoBangumi: autoBangumi.syncAutoBangumi,
+}));
+
+import manageHandler from "pages/api/admin/bangumi/manage";
+import showsHandler from "pages/api/admin/bangumi/shows";
+import showPatchHandler from "pages/api/admin/bangumi/shows/[key]";
+import syncHandler from "pages/api/admin/bangumi/sync";
+
+function adminReq(method, body = undefined, headers = {}) {
+  return {
+    method,
+    headers: { authorization: "Bearer admin-secret", ...headers },
+    body,
+    query: {},
+  };
+}
+
+describe("pages/api/admin/bangumi", () => {
+  let tmpDir;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), "homepage-bangumi-admin-"));
+    config.CONF_DIR = tmpDir;
+    process.env.HOMEPAGE_BANGUMI_ADMIN_TOKEN = "admin-secret";
+    delete process.env.HOMEPAGE_AUTH_ENABLED;
+    delete process.env.HOMEPAGE_BANGUMI_DATA_DIR;
+
+    await mkdir(path.join(tmpDir, "bangumi-data"), { recursive: true });
+    await writeFile(
+      path.join(tmpDir, "bangumi-schedule.json"),
+      JSON.stringify({
+        settings: { enabled: true },
+        shows: [
+          {
+            key: "old-show",
+            title: "Old Show",
+            autobangumiNames: ["Old Show"],
+            airing: { weekday: 2, time: "18:30", timezone: "Asia/Shanghai", firstAirDate: "2026-06-09" },
+          },
+        ],
+      }),
+    );
+    await writeFile(
+      path.join(tmpDir, "bangumi-data", "bangumi-state.json"),
+      JSON.stringify({
+        updatedAt: "",
+        shows: {},
+        unmatchedEvents: [],
+        autobangumi: { lastSyncAt: "2026-06-20T10:00:00.000Z", error: "", missingScheduleNames: ["New Show"] },
+      }),
+    );
+    await writeFile(path.join(tmpDir, "bangumi-data", "bangumi-events.json"), JSON.stringify({ events: [] }));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+    delete process.env.HOMEPAGE_BANGUMI_ADMIN_TOKEN;
+    delete process.env.HOMEPAGE_AUTH_ENABLED;
+    delete process.env.HOMEPAGE_BANGUMI_DATA_DIR;
+  });
+
+  it("requires admin authorization for manage", async () => {
+    const res = createMockRes();
+
+    await manageHandler({ method: "GET", headers: {} }, res);
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("allows the admin token header and Homepage sessions", async () => {
+    const headerRes = createMockRes();
+    await manageHandler(
+      { method: "GET", headers: { "x-homepage-bangumi-admin-token": "admin-secret" }, query: {} },
+      headerRes,
+    );
+    expect(headerRes.statusCode).toBe(200);
+
+    delete process.env.HOMEPAGE_BANGUMI_ADMIN_TOKEN;
+    process.env.HOMEPAGE_AUTH_ENABLED = "true";
+    getServerSession.mockResolvedValueOnce({ user: { name: "Homepage" } });
+    const sessionRes = createMockRes();
+    await manageHandler({ method: "GET", headers: {}, query: {} }, sessionRes);
+
+    expect(sessionRes.statusCode).toBe(200);
+    expect(getServerSession).toHaveBeenCalled();
+  });
+
+  it("returns 405 for unsupported authorized admin methods", async () => {
+    const manageRes = createMockRes();
+    await manageHandler(adminReq("POST"), manageRes);
+    expect(manageRes.statusCode).toBe(405);
+    expect(manageRes.headers.Allow).toBe("GET");
+
+    const showRes = createMockRes();
+    await showsHandler(adminReq("GET"), showRes);
+    expect(showRes.statusCode).toBe(405);
+    expect(showRes.headers.Allow).toBe("POST");
+
+    const syncRes = createMockRes();
+    await syncHandler(adminReq("GET"), syncRes);
+    expect(syncRes.statusCode).toBe(405);
+    expect(syncRes.headers.Allow).toBe("POST");
+  });
+
+  it("returns configured, missing, hidden, and sync metadata", async () => {
+    const res = createMockRes();
+
+    await manageHandler(adminReq("GET"), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.configured.map((item) => item.title)).toEqual(["Old Show"]);
+    expect(res.body.missing.map((item) => item.title)).toEqual(["New Show"]);
+    expect(res.body.hidden).toEqual([]);
+    expect(res.body.sync.missingSchedule).toBe(1);
+  });
+
+  it("creates a show from a missing AutoBangumi subscription", async () => {
+    const res = createMockRes();
+
+    await showsHandler(adminReq("POST", { title: "New Show", weekday: 6, time: "22:15", firstAirDate: "2026-06-20" }), res);
+
+    const schedule = JSON.parse(await readFile(path.join(tmpDir, "bangumi-schedule.json"), "utf8"));
+    expect(res.statusCode).toBe(201);
+    expect(res.body.show.title).toBe("New Show");
+    expect(res.body.show.hasSchedule).toBe(true);
+    expect(schedule.shows.map((show) => show.title)).toEqual(["Old Show", "New Show"]);
+  });
+
+  it("rejects invalid create and patch payloads without writing bad schedule values", async () => {
+    const createRes = createMockRes();
+    await showsHandler(adminReq("POST", { title: "Bad Show", weekday: 6, time: "99:99", firstAirDate: "2026-06-20" }), createRes);
+    expect(createRes.statusCode).toBe(400);
+
+    const patchRes = createMockRes();
+    await showPatchHandler({ ...adminReq("PATCH", { firstEpisode: "not-a-number" }), query: { key: "old-show" } }, patchRes);
+    expect(patchRes.statusCode).toBe(400);
+  });
+
+  it("rejects malformed patch keys without throwing", async () => {
+    const res = createMockRes();
+
+    await showPatchHandler({ ...adminReq("PATCH", { hidden: true }), query: { key: "%E0%A4%A" } }, res);
+
+    expect(res.statusCode).toBe(404);
+    expect(res.body.error).toBe("not_found");
+  });
+
+  it("patches a show hidden and restores schedule fields", async () => {
+    const hiddenRes = createMockRes();
+
+    await showPatchHandler({ ...adminReq("PATCH", { hidden: true }), query: { key: "old-show" } }, hiddenRes);
+
+    expect(hiddenRes.statusCode).toBe(200);
+    expect(hiddenRes.body.show.hidden).toBe(true);
+
+    const restoredRes = createMockRes();
+    await showPatchHandler(
+      { ...adminReq("PATCH", { hidden: false, weekday: 3, time: "19:45", firstAirDate: "2026-06-10" }), query: { key: "old-show" } },
+      restoredRes,
+    );
+
+    expect(restoredRes.statusCode).toBe(200);
+    expect(restoredRes.body.show.hidden).toBe(false);
+    expect(restoredRes.body.show.weekday).toBe(3);
+  });
+
+  it("runs manual AutoBangumi sync and persists updated state", async () => {
+    autoBangumi.syncAutoBangumi.mockImplementationOnce((schedule, state) => {
+      state.autobangumi.lastSyncAt = "2026-06-29T09:00:00.000Z";
+      state.autobangumi.missingScheduleNames = [];
+      return { matched: schedule.shows.length, missingSchedule: 0, missingScheduleNames: [] };
+    });
+    const res = createMockRes();
+
+    await syncHandler(adminReq("POST"), res);
+
+    const state = JSON.parse(await readFile(path.join(tmpDir, "bangumi-data", "bangumi-state.json"), "utf8"));
+    expect(res.statusCode).toBe(200);
+    expect(res.body.result.matched).toBe(1);
+    expect(state.autobangumi.lastSyncAt).toBe("2026-06-29T09:00:00.000Z");
+  });
+
+  it("records manual AutoBangumi sync errors without leaking details", async () => {
+    autoBangumi.syncAutoBangumi.mockRejectedValueOnce(new Error("raw upstream failure"));
+    const res = createMockRes();
+
+    await syncHandler(adminReq("POST"), res);
+
+    const state = JSON.parse(await readFile(path.join(tmpDir, "bangumi-data", "bangumi-state.json"), "utf8"));
+    expect(res.statusCode).toBe(502);
+    expect(res.body).toEqual({ error: "bangumi_sync_failed" });
+    expect(state.autobangumi.error).toBe("raw upstream failure");
+  });
+});

--- a/src/__tests__/pages/api/admin/bangumi/manage.test.js
+++ b/src/__tests__/pages/api/admin/bangumi/manage.test.js
@@ -140,7 +140,10 @@ describe("pages/api/admin/bangumi", () => {
   it("creates a show from a missing AutoBangumi subscription", async () => {
     const res = createMockRes();
 
-    await showsHandler(adminReq("POST", { title: "New Show", weekday: 6, time: "22:15", firstAirDate: "2026-06-20" }), res);
+    await showsHandler(
+      adminReq("POST", { title: "New Show", weekday: 6, time: "22:15", firstAirDate: "2026-06-20" }),
+      res,
+    );
 
     const schedule = JSON.parse(await readFile(path.join(tmpDir, "bangumi-schedule.json"), "utf8"));
     expect(res.statusCode).toBe(201);
@@ -151,11 +154,17 @@ describe("pages/api/admin/bangumi", () => {
 
   it("rejects invalid create and patch payloads without writing bad schedule values", async () => {
     const createRes = createMockRes();
-    await showsHandler(adminReq("POST", { title: "Bad Show", weekday: 6, time: "99:99", firstAirDate: "2026-06-20" }), createRes);
+    await showsHandler(
+      adminReq("POST", { title: "Bad Show", weekday: 6, time: "99:99", firstAirDate: "2026-06-20" }),
+      createRes,
+    );
     expect(createRes.statusCode).toBe(400);
 
     const patchRes = createMockRes();
-    await showPatchHandler({ ...adminReq("PATCH", { firstEpisode: "not-a-number" }), query: { key: "old-show" } }, patchRes);
+    await showPatchHandler(
+      { ...adminReq("PATCH", { firstEpisode: "not-a-number" }), query: { key: "old-show" } },
+      patchRes,
+    );
     expect(patchRes.statusCode).toBe(400);
   });
 
@@ -178,7 +187,10 @@ describe("pages/api/admin/bangumi", () => {
 
     const restoredRes = createMockRes();
     await showPatchHandler(
-      { ...adminReq("PATCH", { hidden: false, weekday: 3, time: "19:45", firstAirDate: "2026-06-10" }), query: { key: "old-show" } },
+      {
+        ...adminReq("PATCH", { hidden: false, weekday: 3, time: "19:45", firstAirDate: "2026-06-10" }),
+        query: { key: "old-show" },
+      },
       restoredRes,
     );
 

--- a/src/__tests__/pages/api/bangumi/status.test.js
+++ b/src/__tests__/pages/api/bangumi/status.test.js
@@ -1,0 +1,138 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "fs/promises";
+import os from "os";
+import path from "path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import createMockRes from "test-utils/create-mock-res";
+
+const { config } = vi.hoisted(() => ({
+  config: {
+    CONF_DIR: "",
+  },
+}));
+
+vi.mock("utils/config/config", () => config);
+
+import handler from "pages/api/bangumi/status";
+
+describe("pages/api/bangumi/status", () => {
+  let tmpDir;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), "homepage-bangumi-status-"));
+    config.CONF_DIR = tmpDir;
+    delete process.env.HOMEPAGE_BANGUMI_DATA_DIR;
+    delete process.env.HOMEPAGE_AUTOBANGUMI_API_URL;
+    delete process.env.HOMEPAGE_BANGUMI_WEBHOOK_TOKEN;
+
+    await mkdir(path.join(tmpDir, "bangumi-data"), { recursive: true });
+    await writeFile(
+      path.join(tmpDir, "bangumi-schedule.json"),
+      JSON.stringify({
+        settings: { enabled: true, overdueGraceHours: 12 },
+        shows: [
+          {
+            key: "demo",
+            title: "Demo Show",
+            airing: {
+              weekday: 3,
+              time: "20:00",
+              timezone: "UTC",
+              firstAirDate: "2026-06-17",
+              firstEpisode: 1,
+            },
+          },
+        ],
+      }),
+    );
+    await writeFile(
+      path.join(tmpDir, "bangumi-data", "bangumi-state.json"),
+      JSON.stringify({ updatedAt: "", shows: { demo: { lastArrivedEpisode: 1 } }, unmatchedEvents: [], autobangumi: {} }),
+    );
+    await writeFile(path.join(tmpDir, "bangumi-data", "bangumi-events.json"), JSON.stringify({ events: [] }));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+    delete process.env.HOMEPAGE_BANGUMI_WEBHOOK_TOKEN;
+  });
+
+  it("returns the timeline payload from bangumi files", async () => {
+    const req = { method: "GET" };
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.summary.total).toBe(1);
+    expect(res.body.rows[0].title).toBe("Demo Show");
+    expect(res.body.rows[0].lastArrivedEpisode).toBe(1);
+  });
+
+  it("rejects unsupported methods", async () => {
+    const req = { method: "POST" };
+    const res = createMockRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(405);
+    expect(res.headers.Allow).toBe("GET");
+  });
+
+  it("records webhook arrivals when the shared token matches", async () => {
+    process.env.HOMEPAGE_BANGUMI_WEBHOOK_TOKEN = "secret";
+    const arrival = (await import("pages/api/bangumi/webhook/arrival")).default;
+    const req = {
+      method: "POST",
+      headers: { "x-homepage-bangumi-token": "secret" },
+      body: { series_title: "Demo Show", episode_numbers: [2], event_time: "2026-06-24T20:30:00Z" },
+    };
+    const res = createMockRes();
+
+    await arrival(req, res);
+
+    const state = JSON.parse(await readFile(path.join(tmpDir, "bangumi-data", "bangumi-state.json"), "utf8"));
+    expect(res.statusCode).toBe(200);
+    expect(res.body.matched).toBe(true);
+    expect(state.shows.demo.lastArrivedEpisode).toBe(2);
+  });
+
+  it("records webhook arrivals with the legacy homelab token header", async () => {
+    process.env.HOMEPAGE_BANGUMI_WEBHOOK_TOKEN = "secret";
+    const arrival = (await import("pages/api/bangumi/webhook/arrival")).default;
+    const req = {
+      method: "POST",
+      headers: { "x-homelab-webhook-token": "secret" },
+      body: { series_title: "Demo Show", episode_numbers: [3], event_time: "2026-07-01T20:30:00Z" },
+    };
+    const res = createMockRes();
+
+    await arrival(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.matched).toBe(true);
+  });
+
+  it("rejects webhook arrivals when the shared token is not configured", async () => {
+    const arrival = (await import("pages/api/bangumi/webhook/arrival")).default;
+    const req = { method: "POST", headers: {}, body: { series_title: "Demo Show" } };
+    const res = createMockRes();
+
+    await arrival(req, res);
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("rejects webhook arrivals when the shared token is wrong", async () => {
+    process.env.HOMEPAGE_BANGUMI_WEBHOOK_TOKEN = "secret";
+    const arrival = (await import("pages/api/bangumi/webhook/arrival")).default;
+    const req = { method: "POST", headers: { "x-homepage-bangumi-token": "nope" }, body: {} };
+    const res = createMockRes();
+
+    await arrival(req, res);
+
+    expect(res.statusCode).toBe(401);
+  });
+});

--- a/src/__tests__/pages/api/bangumi/status.test.js
+++ b/src/__tests__/pages/api/bangumi/status.test.js
@@ -49,7 +49,12 @@ describe("pages/api/bangumi/status", () => {
     );
     await writeFile(
       path.join(tmpDir, "bangumi-data", "bangumi-state.json"),
-      JSON.stringify({ updatedAt: "", shows: { demo: { lastArrivedEpisode: 1 } }, unmatchedEvents: [], autobangumi: {} }),
+      JSON.stringify({
+        updatedAt: "",
+        shows: { demo: { lastArrivedEpisode: 1 } },
+        unmatchedEvents: [],
+        autobangumi: {},
+      }),
     );
     await writeFile(path.join(tmpDir, "bangumi-data", "bangumi-events.json"), JSON.stringify({ events: [] }));
   });

--- a/src/pages/api/admin/bangumi/manage.js
+++ b/src/pages/api/admin/bangumi/manage.js
@@ -1,7 +1,7 @@
-import { CONF_DIR } from "utils/config/config";
 import { adminAuthorized, unauthorized } from "utils/bangumi/auth";
 import { buildManagePayload } from "utils/bangumi/manage";
 import { ensureBangumiDataFiles, loadJson } from "utils/bangumi/paths";
+import { CONF_DIR } from "utils/config/config";
 
 export default async function handler(req, res) {
   if (!(await adminAuthorized(req, res))) return unauthorized(res);

--- a/src/pages/api/admin/bangumi/manage.js
+++ b/src/pages/api/admin/bangumi/manage.js
@@ -1,0 +1,21 @@
+import { CONF_DIR } from "utils/config/config";
+import { adminAuthorized, unauthorized } from "utils/bangumi/auth";
+import { buildManagePayload } from "utils/bangumi/manage";
+import { ensureBangumiDataFiles, loadJson } from "utils/bangumi/paths";
+
+export default async function handler(req, res) {
+  if (!(await adminAuthorized(req, res))) return unauthorized(res);
+
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    return res.status(405).end("Method Not Allowed");
+  }
+
+  try {
+    const paths = await ensureBangumiDataFiles(CONF_DIR);
+    const [schedule, state] = await Promise.all([loadJson(paths.schedule, {}), loadJson(paths.state, {})]);
+    return res.status(200).json(buildManagePayload(schedule, state));
+  } catch (error) {
+    return res.status(500).json({ error: "bangumi_manage_failed" });
+  }
+}

--- a/src/pages/api/admin/bangumi/shows.js
+++ b/src/pages/api/admin/bangumi/shows.js
@@ -1,0 +1,23 @@
+import { CONF_DIR } from "utils/config/config";
+import { adminAuthorized, unauthorized } from "utils/bangumi/auth";
+import { createManagedShow } from "utils/bangumi/manage";
+import { atomicWriteJson, ensureBangumiDataFiles, loadJson } from "utils/bangumi/paths";
+
+export default async function handler(req, res) {
+  if (!(await adminAuthorized(req, res))) return unauthorized(res);
+
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    return res.status(405).end("Method Not Allowed");
+  }
+
+  try {
+    const paths = await ensureBangumiDataFiles(CONF_DIR);
+    const schedule = await loadJson(paths.schedule, {});
+    const result = createManagedShow(schedule, req.body || {});
+    await atomicWriteJson(paths.schedule, result.schedule);
+    return res.status(201).json({ ok: true, show: result.show });
+  } catch (error) {
+    return res.status(400).json({ error: error.message || "bangumi_show_create_failed" });
+  }
+}

--- a/src/pages/api/admin/bangumi/shows.js
+++ b/src/pages/api/admin/bangumi/shows.js
@@ -1,7 +1,7 @@
-import { CONF_DIR } from "utils/config/config";
 import { adminAuthorized, unauthorized } from "utils/bangumi/auth";
 import { createManagedShow } from "utils/bangumi/manage";
 import { atomicWriteJson, ensureBangumiDataFiles, loadJson } from "utils/bangumi/paths";
+import { CONF_DIR } from "utils/config/config";
 
 export default async function handler(req, res) {
   if (!(await adminAuthorized(req, res))) return unauthorized(res);

--- a/src/pages/api/admin/bangumi/shows/[key].js
+++ b/src/pages/api/admin/bangumi/shows/[key].js
@@ -1,0 +1,39 @@
+import { CONF_DIR } from "utils/config/config";
+import { adminAuthorized, unauthorized } from "utils/bangumi/auth";
+import { patchManagedShow } from "utils/bangumi/manage";
+import { atomicWriteJson, ensureBangumiDataFiles, loadJson } from "utils/bangumi/paths";
+
+function queryKey(req) {
+  const key = req?.query?.key;
+  if (Array.isArray(key)) return null;
+  let decoded = "";
+  try {
+    decoded = decodeURIComponent(String(key || ""));
+  } catch (error) {
+    return null;
+  }
+  return decoded.includes("/") ? null : decoded;
+}
+
+export default async function handler(req, res) {
+  if (!(await adminAuthorized(req, res))) return unauthorized(res);
+
+  if (req.method !== "PATCH") {
+    res.setHeader("Allow", "PATCH");
+    return res.status(405).end("Method Not Allowed");
+  }
+
+  const key = queryKey(req);
+  if (!key) return res.status(404).json({ error: "not_found" });
+
+  try {
+    const paths = await ensureBangumiDataFiles(CONF_DIR);
+    const schedule = await loadJson(paths.schedule, {});
+    const result = patchManagedShow(schedule, key, req.body || {});
+    if (!result) return res.status(404).json({ error: "not_found" });
+    await atomicWriteJson(paths.schedule, result.schedule);
+    return res.status(200).json({ ok: true, show: result.show });
+  } catch (error) {
+    return res.status(400).json({ error: error.message || "bangumi_show_patch_failed" });
+  }
+}

--- a/src/pages/api/admin/bangumi/shows/[key].js
+++ b/src/pages/api/admin/bangumi/shows/[key].js
@@ -1,7 +1,7 @@
-import { CONF_DIR } from "utils/config/config";
 import { adminAuthorized, unauthorized } from "utils/bangumi/auth";
 import { patchManagedShow } from "utils/bangumi/manage";
 import { atomicWriteJson, ensureBangumiDataFiles, loadJson } from "utils/bangumi/paths";
+import { CONF_DIR } from "utils/config/config";
 
 function queryKey(req) {
   const key = req?.query?.key;

--- a/src/pages/api/admin/bangumi/sync.js
+++ b/src/pages/api/admin/bangumi/sync.js
@@ -1,7 +1,7 @@
-import { CONF_DIR } from "utils/config/config";
 import { adminAuthorized, unauthorized } from "utils/bangumi/auth";
 import { syncAutoBangumi } from "utils/bangumi/autobangumi";
 import { atomicWriteJson, ensureBangumiDataFiles, loadJson } from "utils/bangumi/paths";
+import { CONF_DIR } from "utils/config/config";
 
 export default async function handler(req, res) {
   if (!(await adminAuthorized(req, res))) return unauthorized(res);

--- a/src/pages/api/admin/bangumi/sync.js
+++ b/src/pages/api/admin/bangumi/sync.js
@@ -1,0 +1,27 @@
+import { CONF_DIR } from "utils/config/config";
+import { adminAuthorized, unauthorized } from "utils/bangumi/auth";
+import { syncAutoBangumi } from "utils/bangumi/autobangumi";
+import { atomicWriteJson, ensureBangumiDataFiles, loadJson } from "utils/bangumi/paths";
+
+export default async function handler(req, res) {
+  if (!(await adminAuthorized(req, res))) return unauthorized(res);
+
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    return res.status(405).end("Method Not Allowed");
+  }
+
+  const paths = await ensureBangumiDataFiles(CONF_DIR);
+  const [schedule, state] = await Promise.all([loadJson(paths.schedule, {}), loadJson(paths.state, {})]);
+
+  try {
+    const result = await syncAutoBangumi(schedule, state, { force: true });
+    await atomicWriteJson(paths.state, state);
+    return res.status(200).json({ ok: true, result });
+  } catch (error) {
+    if (!state.autobangumi || typeof state.autobangumi !== "object") state.autobangumi = {};
+    state.autobangumi.error = error.message;
+    await atomicWriteJson(paths.state, state);
+    return res.status(502).json({ error: "bangumi_sync_failed" });
+  }
+}

--- a/src/pages/api/bangumi/status.js
+++ b/src/pages/api/bangumi/status.js
@@ -1,0 +1,32 @@
+import { CONF_DIR } from "utils/config/config";
+import { maybeSyncAutoBangumi } from "utils/bangumi/autobangumi";
+import { makeTimelinePayload } from "utils/bangumi/core";
+import { atomicWriteJson, ensureBangumiDataFiles, loadJson } from "utils/bangumi/paths";
+
+async function loadBangumiFiles() {
+  const paths = await ensureBangumiDataFiles(CONF_DIR);
+  const [schedule, state, events] = await Promise.all([
+    loadJson(paths.schedule, {}),
+    loadJson(paths.state, {}),
+    loadJson(paths.events, {}),
+  ]);
+  return { paths, schedule, state, events };
+}
+
+export default async function handler(req, res) {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    return res.status(405).end("Method Not Allowed");
+  }
+
+  const { paths, schedule, state, events } = await loadBangumiFiles();
+  try {
+    await maybeSyncAutoBangumi(schedule, state);
+    await atomicWriteJson(paths.state, state);
+  } catch (error) {
+    if (!state.autobangumi || typeof state.autobangumi !== "object") state.autobangumi = {};
+    state.autobangumi.error = error.message;
+  }
+
+  return res.status(200).json(makeTimelinePayload(schedule, state, events));
+}

--- a/src/pages/api/bangumi/status.js
+++ b/src/pages/api/bangumi/status.js
@@ -1,7 +1,7 @@
-import { CONF_DIR } from "utils/config/config";
 import { maybeSyncAutoBangumi } from "utils/bangumi/autobangumi";
 import { makeTimelinePayload } from "utils/bangumi/core";
 import { atomicWriteJson, ensureBangumiDataFiles, loadJson } from "utils/bangumi/paths";
+import { CONF_DIR } from "utils/config/config";
 
 async function loadBangumiFiles() {
   const paths = await ensureBangumiDataFiles(CONF_DIR);

--- a/src/pages/api/bangumi/webhook/arrival.js
+++ b/src/pages/api/bangumi/webhook/arrival.js
@@ -1,0 +1,25 @@
+import { CONF_DIR } from "utils/config/config";
+import { webhookAuthorized } from "utils/bangumi/auth";
+import { recordArrivalInData } from "utils/bangumi/core";
+import { atomicWriteJson, ensureBangumiDataFiles, loadJson } from "utils/bangumi/paths";
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    return res.status(405).end("Method Not Allowed");
+  }
+
+  if (!webhookAuthorized(req)) return res.status(401).json({ error: "Unauthorized" });
+
+  const paths = await ensureBangumiDataFiles(CONF_DIR);
+  const [schedule, state, events] = await Promise.all([
+    loadJson(paths.schedule, {}),
+    loadJson(paths.state, {}),
+    loadJson(paths.events, {}),
+  ]);
+  const result = recordArrivalInData(schedule, state, events, req.body || {});
+
+  await Promise.all([atomicWriteJson(paths.state, result.state), atomicWriteJson(paths.events, result.events)]);
+
+  return res.status(200).json({ matched: result.matched, showKey: result.showKey, event: result.event });
+}

--- a/src/pages/api/bangumi/webhook/arrival.js
+++ b/src/pages/api/bangumi/webhook/arrival.js
@@ -1,7 +1,7 @@
-import { CONF_DIR } from "utils/config/config";
 import { webhookAuthorized } from "utils/bangumi/auth";
 import { recordArrivalInData } from "utils/bangumi/core";
 import { atomicWriteJson, ensureBangumiDataFiles, loadJson } from "utils/bangumi/paths";
+import { CONF_DIR } from "utils/config/config";
 
 export default async function handler(req, res) {
   if (req.method !== "POST") {

--- a/src/skeleton/bangumi-schedule.json
+++ b/src/skeleton/bangumi-schedule.json
@@ -1,0 +1,36 @@
+{
+  "settings": {
+    "enabled": true,
+    "overdueGraceHours": 12,
+    "eventLimit": 100,
+    "syncIntervalMinutes": 60
+  },
+  "shows": [
+    {
+      "key": "example-weekly-show",
+      "title": "Example Weekly Show",
+      "aliases": [
+        "Example Weekly Anime",
+        "Example Show"
+      ],
+      "autobangumiNames": [
+        "Example Weekly Show"
+      ],
+      "airing": {
+        "weekday": 6,
+        "time": "23:30",
+        "timezone": "Asia/Tokyo",
+        "firstAirDate": "2026-01-10",
+        "firstEpisode": 1,
+        "totalEpisodes": 12
+      },
+      "overrides": {
+        "expectedEpisode": null,
+        "status": null,
+        "reason": ""
+      },
+      "hidden": false,
+      "finished": false
+    }
+  ]
+}

--- a/src/utils/bangumi/auth.js
+++ b/src/utils/bangumi/auth.js
@@ -16,10 +16,7 @@ function bearerToken(req) {
 export function adminTokenAuthorized(req) {
   const expected = process.env.HOMEPAGE_BANGUMI_ADMIN_TOKEN;
   if (!expected) return false;
-  return (
-    bearerToken(req) === expected ||
-    String(headerValue(req, "x-homepage-bangumi-admin-token") || "") === expected
-  );
+  return bearerToken(req) === expected || String(headerValue(req, "x-homepage-bangumi-admin-token") || "") === expected;
 }
 
 export function webhookAuthorized(req) {

--- a/src/utils/bangumi/auth.js
+++ b/src/utils/bangumi/auth.js
@@ -1,0 +1,42 @@
+import { getServerSession } from "next-auth/next";
+
+import { authOptions } from "pages/api/auth/[...nextauth]";
+
+function headerValue(req, name) {
+  const headers = req?.headers || {};
+  return headers[name] || headers[name.toLowerCase()] || headers[name.toUpperCase()] || "";
+}
+
+function bearerToken(req) {
+  const authorization = String(headerValue(req, "authorization") || "");
+  const match = authorization.match(/^Bearer\s+(.+)$/i);
+  return match ? match[1] : "";
+}
+
+export function adminTokenAuthorized(req) {
+  const expected = process.env.HOMEPAGE_BANGUMI_ADMIN_TOKEN;
+  if (!expected) return false;
+  return (
+    bearerToken(req) === expected ||
+    String(headerValue(req, "x-homepage-bangumi-admin-token") || "") === expected
+  );
+}
+
+export function webhookAuthorized(req) {
+  const expected = process.env.HOMEPAGE_BANGUMI_WEBHOOK_TOKEN;
+  if (!expected) return false;
+  return (
+    String(headerValue(req, "x-homepage-bangumi-token") || "") === expected ||
+    String(headerValue(req, "x-homelab-webhook-token") || "") === expected
+  );
+}
+
+export async function adminAuthorized(req, res) {
+  if (adminTokenAuthorized(req)) return true;
+  if (!process.env.HOMEPAGE_AUTH_ENABLED) return false;
+  return Boolean(await getServerSession(req, res, authOptions));
+}
+
+export function unauthorized(res) {
+  return res.status(401).json({ error: "Unauthorized" });
+}

--- a/src/utils/bangumi/autobangumi.js
+++ b/src/utils/bangumi/autobangumi.js
@@ -1,0 +1,192 @@
+import { normalizeTitle } from "./core";
+
+function collectionList(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function collectionObject(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+}
+
+function scalarText(value, defaultValue = "") {
+  if (value === null || value === undefined || typeof value === "object") return defaultValue;
+  return String(value);
+}
+
+function subscriptionItems(raw) {
+  if (Array.isArray(raw)) return raw;
+  const data = collectionObject(raw);
+  for (const key of ["data", "items", "subscriptions", "results"]) {
+    if (Array.isArray(data[key])) return data[key];
+  }
+  return [];
+}
+
+function collectionArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function showMatchValues(show) {
+  const showData = collectionObject(show);
+  return new Set(
+    [showData.key, showData.title, ...collectionArray(showData.aliases), ...collectionArray(showData.autobangumiNames)]
+      .map(normalizeTitle)
+      .filter(Boolean),
+  );
+}
+
+function findMatchingShow(schedule, name) {
+  const normalizedName = normalizeTitle(name);
+  if (!normalizedName) return null;
+  return collectionArray(collectionObject(schedule).shows).find((show) => showMatchValues(show).has(normalizedName)) || null;
+}
+
+export function normalizeAutoBangumiSubscriptions(raw) {
+  return subscriptionItems(raw)
+    .filter((item) => item && typeof item === "object" && !Array.isArray(item))
+    .map((item) => {
+      let name = "";
+      for (const key of ["name", "title", "official_title", "rss"]) {
+        name = scalarText(item[key]).trim();
+        if (name) break;
+      }
+      if (!name) return null;
+
+      let subscriptionStatus = scalarText(item.status).trim();
+      if (!subscriptionStatus) subscriptionStatus = item.enabled === false ? "disabled" : "active";
+
+      let downloadStatus = "";
+      for (const key of ["progress", "download_status", "state", "connection_status"]) {
+        downloadStatus = scalarText(item[key]).trim();
+        if (downloadStatus) break;
+      }
+
+      return { name, subscriptionStatus, downloadStatus, raw: item };
+    })
+    .filter(Boolean);
+}
+
+async function readJsonResponse(response, url) {
+  if (!response.ok) throw new Error(`HTTP ${response.status} from ${url}`);
+  return response.json();
+}
+
+function joinUrl(baseUrl, path) {
+  return `${String(baseUrl).replace(/\/+$/, "")}/${path.replace(/^\/+/, "")}`;
+}
+
+export async function fetchAutoBangumiSubscriptions(
+  apiUrl = process.env.HOMEPAGE_AUTOBANGUMI_API_URL,
+  {
+    username = process.env.HOMEPAGE_AUTOBANGUMI_USERNAME || "",
+    password = process.env.HOMEPAGE_AUTOBANGUMI_PASSWORD || "",
+    fetchImpl = fetch,
+  } = {},
+) {
+  if (!apiUrl) return [];
+
+  const legacyCandidates = ["/api/v1/bangumi", "/api/bangumi", "/api/subscriptions"];
+  let candidates = legacyCandidates;
+  const headers = {};
+  let lastError = null;
+
+  if (username && password) {
+    const loginUrl = joinUrl(apiUrl, "/api/v1/auth/login");
+    try {
+      const loginResponse = await fetchImpl(loginUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({ username, password }).toString(),
+      });
+      const tokenPayload = await readJsonResponse(loginResponse, loginUrl);
+      const token = scalarText(tokenPayload.access_token || tokenPayload.token || tokenPayload.accessToken);
+      const tokenType = scalarText(tokenPayload.token_type, "bearer");
+      if (token) {
+        headers.Authorization = `${tokenType.charAt(0).toUpperCase()}${tokenType.slice(1)} ${token}`;
+        candidates = ["/api/v1/rss", "/api/v1/bangumi/get/all", ...legacyCandidates];
+      }
+    } catch (error) {
+      lastError = `${loginUrl}: ${error.message}`;
+    }
+  }
+
+  for (const path of candidates) {
+    const url = joinUrl(apiUrl, path);
+    try {
+      const response = await fetchImpl(url, { headers });
+      const raw = await readJsonResponse(response, url);
+      return normalizeAutoBangumiSubscriptions(raw);
+    } catch (error) {
+      lastError = `${url}: ${error.message}`;
+    }
+  }
+
+  throw new Error(`AutoBangumi API request failed: ${lastError}`);
+}
+
+export function mergeAutoBangumiSubscriptions(schedule, state, subscriptions, now = new Date()) {
+  const stateData = state;
+  if (!stateData.shows || typeof stateData.shows !== "object" || Array.isArray(stateData.shows)) stateData.shows = {};
+  if (!stateData.autobangumi || typeof stateData.autobangumi !== "object" || Array.isArray(stateData.autobangumi)) {
+    stateData.autobangumi = {};
+  }
+
+  const syncedAt = now.toISOString();
+  const matchedKeys = new Set();
+  const missingNames = [];
+  const missingSeen = new Set();
+
+  normalizeAutoBangumiSubscriptions(subscriptions).forEach((subscription) => {
+    const show = findMatchingShow(schedule, subscription.name);
+    const showKey = scalarText(show?.key).trim();
+    if (showKey) {
+      if (!stateData.shows[showKey] || typeof stateData.shows[showKey] !== "object") stateData.shows[showKey] = {};
+      stateData.shows[showKey].autobangumi = {
+        subscriptionName: subscription.name,
+        subscriptionStatus: subscription.subscriptionStatus,
+        downloadStatus: subscription.downloadStatus,
+        lastSyncAt: syncedAt,
+      };
+      matchedKeys.add(showKey);
+      return;
+    }
+
+    const normalizedName = normalizeTitle(subscription.name);
+    if (normalizedName && !missingSeen.has(normalizedName)) {
+      missingSeen.add(normalizedName);
+      missingNames.push(subscription.name.trim());
+    }
+  });
+
+  stateData.updatedAt = syncedAt;
+  stateData.autobangumi.lastSyncAt = syncedAt;
+  stateData.autobangumi.error = "";
+  stateData.autobangumi.missingScheduleNames = missingNames;
+
+  return { matched: matchedKeys.size, missingSchedule: missingNames.length, missingScheduleNames: missingNames };
+}
+
+export async function syncAutoBangumi(schedule, state, options = {}) {
+  const now = options.now || new Date();
+  const subscriptions = await fetchAutoBangumiSubscriptions(options.apiUrl, options);
+  return mergeAutoBangumiSubscriptions(schedule, state, subscriptions, now);
+}
+
+export async function maybeSyncAutoBangumi(schedule, state, now = new Date(), options = {}) {
+  const settings = collectionObject(schedule?.settings);
+  const intervalMinutes = Number(settings.syncIntervalMinutes ?? process.env.HOMEPAGE_BANGUMI_SYNC_INTERVAL_MINUTES ?? 60);
+  const lastSyncAt = scalarText(collectionObject(state?.autobangumi).lastSyncAt);
+
+  if (!options.force && lastSyncAt) {
+    const lastSyncTime = new Date(lastSyncAt).getTime();
+    if (!Number.isNaN(lastSyncTime) && now.getTime() - lastSyncTime < intervalMinutes * 60_000) {
+      return { skipped: true, reason: "fresh" };
+    }
+  }
+
+  if (!options.apiUrl && !process.env.HOMEPAGE_AUTOBANGUMI_API_URL) {
+    return { skipped: true, reason: "missing_api_url" };
+  }
+
+  return syncAutoBangumi(schedule, state, { ...options, now });
+}

--- a/src/utils/bangumi/autobangumi.js
+++ b/src/utils/bangumi/autobangumi.js
@@ -38,7 +38,9 @@ function showMatchValues(show) {
 function findMatchingShow(schedule, name) {
   const normalizedName = normalizeTitle(name);
   if (!normalizedName) return null;
-  return collectionArray(collectionObject(schedule).shows).find((show) => showMatchValues(show).has(normalizedName)) || null;
+  return (
+    collectionArray(collectionObject(schedule).shows).find((show) => showMatchValues(show).has(normalizedName)) || null
+  );
 }
 
 export function normalizeAutoBangumiSubscriptions(raw) {
@@ -174,7 +176,9 @@ export async function syncAutoBangumi(schedule, state, options = {}) {
 
 export async function maybeSyncAutoBangumi(schedule, state, now = new Date(), options = {}) {
   const settings = collectionObject(schedule?.settings);
-  const intervalMinutes = Number(settings.syncIntervalMinutes ?? process.env.HOMEPAGE_BANGUMI_SYNC_INTERVAL_MINUTES ?? 60);
+  const intervalMinutes = Number(
+    settings.syncIntervalMinutes ?? process.env.HOMEPAGE_BANGUMI_SYNC_INTERVAL_MINUTES ?? 60,
+  );
   const lastSyncAt = scalarText(collectionObject(state?.autobangumi).lastSyncAt);
 
   if (!options.force && lastSyncAt) {

--- a/src/utils/bangumi/autobangumi.test.js
+++ b/src/utils/bangumi/autobangumi.test.js
@@ -25,13 +25,27 @@ describe("bangumi autobangumi", () => {
         ],
       }),
     ).toEqual([
-      { name: "Demo", subscriptionStatus: "active", downloadStatus: "downloading", raw: { name: "Demo", enabled: true, progress: "downloading" } },
-      { name: "Other", subscriptionStatus: "disabled", downloadStatus: "paused", raw: { title: "Other", enabled: false, state: "paused" } },
+      {
+        name: "Demo",
+        subscriptionStatus: "active",
+        downloadStatus: "downloading",
+        raw: { name: "Demo", enabled: true, progress: "downloading" },
+      },
+      {
+        name: "Other",
+        subscriptionStatus: "disabled",
+        downloadStatus: "paused",
+        raw: { title: "Other", enabled: false, state: "paused" },
+      },
     ]);
 
-    expect(normalizeAutoBangumiSubscriptions([{ official_title: "Official", status: "active" }])[0].name).toBe("Official");
+    expect(normalizeAutoBangumiSubscriptions([{ official_title: "Official", status: "active" }])[0].name).toBe(
+      "Official",
+    );
     expect(normalizeAutoBangumiSubscriptions({ items: [{ name: "Items" }] })[0].name).toBe("Items");
-    expect(normalizeAutoBangumiSubscriptions({ subscriptions: [{ name: "Subscriptions" }] })[0].name).toBe("Subscriptions");
+    expect(normalizeAutoBangumiSubscriptions({ subscriptions: [{ name: "Subscriptions" }] })[0].name).toBe(
+      "Subscriptions",
+    );
     expect(normalizeAutoBangumiSubscriptions({ results: [{ name: "Results" }] })[0].name).toBe("Results");
   });
 
@@ -67,10 +81,15 @@ describe("bangumi autobangumi", () => {
       shows: [{ key: "demo", title: "Demo Show", autobangumiNames: ["Demo"] }],
     };
     const state = { shows: {}, autobangumi: {} };
-    const result = mergeAutoBangumiSubscriptions(schedule, state, [
-      { name: "Demo", subscriptionStatus: "active", downloadStatus: "ready" },
-      { name: "Missing", subscriptionStatus: "active", downloadStatus: "" },
-    ], new Date("2026-06-17T12:00:00Z"));
+    const result = mergeAutoBangumiSubscriptions(
+      schedule,
+      state,
+      [
+        { name: "Demo", subscriptionStatus: "active", downloadStatus: "ready" },
+        { name: "Missing", subscriptionStatus: "active", downloadStatus: "" },
+      ],
+      new Date("2026-06-17T12:00:00Z"),
+    );
 
     expect(result).toEqual({ matched: 1, missingSchedule: 1, missingScheduleNames: ["Missing"] });
     expect(state.shows.demo.autobangumi.subscriptionName).toBe("Demo");

--- a/src/utils/bangumi/autobangumi.test.js
+++ b/src/utils/bangumi/autobangumi.test.js
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  fetchAutoBangumiSubscriptions,
+  maybeSyncAutoBangumi,
+  mergeAutoBangumiSubscriptions,
+  normalizeAutoBangumiSubscriptions,
+} from "./autobangumi";
+
+describe("bangumi autobangumi", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.HOMEPAGE_AUTOBANGUMI_API_URL;
+    delete process.env.HOMEPAGE_AUTOBANGUMI_USERNAME;
+    delete process.env.HOMEPAGE_AUTOBANGUMI_PASSWORD;
+  });
+
+  it("normalizes common subscription response shapes", () => {
+    expect(
+      normalizeAutoBangumiSubscriptions({
+        data: [
+          { name: "Demo", enabled: true, progress: "downloading" },
+          { title: "Other", enabled: false, state: "paused" },
+          { empty: true },
+        ],
+      }),
+    ).toEqual([
+      { name: "Demo", subscriptionStatus: "active", downloadStatus: "downloading", raw: { name: "Demo", enabled: true, progress: "downloading" } },
+      { name: "Other", subscriptionStatus: "disabled", downloadStatus: "paused", raw: { title: "Other", enabled: false, state: "paused" } },
+    ]);
+
+    expect(normalizeAutoBangumiSubscriptions([{ official_title: "Official", status: "active" }])[0].name).toBe("Official");
+    expect(normalizeAutoBangumiSubscriptions({ items: [{ name: "Items" }] })[0].name).toBe("Items");
+    expect(normalizeAutoBangumiSubscriptions({ subscriptions: [{ name: "Subscriptions" }] })[0].name).toBe("Subscriptions");
+    expect(normalizeAutoBangumiSubscriptions({ results: [{ name: "Results" }] })[0].name).toBe("Results");
+  });
+
+  it("fetches authenticated subscriptions from preferred endpoints", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      if (String(url).endsWith("/api/v1/auth/login")) {
+        return Response.json({ access_token: "token", token_type: "bearer" });
+      }
+      if (String(url).endsWith("/api/v1/bangumi/get/all")) {
+        return Response.json([{ name: "Demo" }]);
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const result = await fetchAutoBangumiSubscriptions("http://autobangumi", {
+      username: "u",
+      password: "p",
+      fetchImpl: fetchMock,
+    });
+
+    expect(result).toEqual([{ name: "Demo", subscriptionStatus: "active", downloadStatus: "", raw: { name: "Demo" } }]);
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
+      "http://autobangumi/api/v1/auth/login",
+      "http://autobangumi/api/v1/rss",
+      "http://autobangumi/api/v1/bangumi/get/all",
+    ]);
+    expect(fetchMock.mock.calls[1][1].headers.Authorization).toBe("Bearer token");
+    expect(fetchMock.mock.calls[2][1].headers.Authorization).toBe("Bearer token");
+  });
+
+  it("merges matched and missing subscriptions into state", () => {
+    const schedule = {
+      shows: [{ key: "demo", title: "Demo Show", autobangumiNames: ["Demo"] }],
+    };
+    const state = { shows: {}, autobangumi: {} };
+    const result = mergeAutoBangumiSubscriptions(schedule, state, [
+      { name: "Demo", subscriptionStatus: "active", downloadStatus: "ready" },
+      { name: "Missing", subscriptionStatus: "active", downloadStatus: "" },
+    ], new Date("2026-06-17T12:00:00Z"));
+
+    expect(result).toEqual({ matched: 1, missingSchedule: 1, missingScheduleNames: ["Missing"] });
+    expect(state.shows.demo.autobangumi.subscriptionName).toBe("Demo");
+    expect(state.autobangumi.missingScheduleNames).toEqual(["Missing"]);
+  });
+
+  it("skips interval sync when last sync is still fresh", async () => {
+    const result = await maybeSyncAutoBangumi(
+      { settings: { syncIntervalMinutes: 60 }, shows: [] },
+      { autobangumi: { lastSyncAt: "2026-06-17T11:30:00.000Z" } },
+      new Date("2026-06-17T12:00:00Z"),
+    );
+
+    expect(result).toEqual({ skipped: true, reason: "fresh" });
+  });
+});

--- a/src/utils/bangumi/core.js
+++ b/src/utils/bangumi/core.js
@@ -1,0 +1,412 @@
+export const DEFAULT_SCHEDULE = {
+  settings: {
+    enabled: true,
+    overdueGraceHours: 12,
+    eventLimit: 100,
+    syncIntervalMinutes: 60,
+  },
+  shows: [],
+};
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function collectionList(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function collectionDict(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+}
+
+function scalarText(value, fallback = "") {
+  if (value === null || value === undefined || typeof value === "object") return fallback;
+  return String(value);
+}
+
+function isoNow(now) {
+  return now.toISOString();
+}
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value ?? {}));
+}
+
+export function normalizeTitle(value) {
+  return scalarText(value).trim().toLowerCase().replace(/\s+/g, "");
+}
+
+function parseDateParts(value) {
+  const match = scalarText(value).match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) throw new Error("invalid date");
+  return { year: Number(match[1]), month: Number(match[2]), day: Number(match[3]) };
+}
+
+function parseTimeParts(value) {
+  const match = scalarText(value || "00:00").match(/^(\d{1,2}):(\d{2})$/);
+  if (!match) throw new Error("invalid time");
+  const hour = Number(match[1]);
+  const minute = Number(match[2]);
+  if (hour < 0 || hour > 23 || minute < 0 || minute > 59) throw new Error("invalid time");
+  return { hour, minute };
+}
+
+function parseWeekday(value) {
+  const weekday = Number(value);
+  if (!Number.isInteger(weekday) || weekday < 1 || weekday > 7) throw new Error("invalid weekday");
+  return weekday;
+}
+
+function timeZoneForShow(show) {
+  return scalarText(collectionDict(collectionDict(show).airing).timezone, "UTC") || "UTC";
+}
+
+function zonedParts(date, timeZone) {
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hourCycle: "h23",
+  });
+  const parts = Object.fromEntries(formatter.formatToParts(date).map((part) => [part.type, part.value]));
+
+  return {
+    year: Number(parts.year),
+    month: Number(parts.month),
+    day: Number(parts.day),
+    hour: Number(parts.hour),
+    minute: Number(parts.minute),
+    second: Number(parts.second),
+  };
+}
+
+function zonedTimeToDate(parts, timeZone) {
+  const targetMs = Date.UTC(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute, parts.second || 0);
+  let utcMs = targetMs;
+
+  for (let index = 0; index < 4; index += 1) {
+    const actual = zonedParts(new Date(utcMs), timeZone);
+    const actualMs = Date.UTC(actual.year, actual.month - 1, actual.day, actual.hour, actual.minute, actual.second);
+    const delta = actualMs - targetMs;
+    if (delta === 0) break;
+    utcMs -= delta;
+  }
+
+  return new Date(utcMs);
+}
+
+function dateOrdinal(parts) {
+  return Math.floor(Date.UTC(parts.year, parts.month - 1, parts.day) / MS_PER_DAY);
+}
+
+function localDateOrdinal(date, timeZone) {
+  const parts = zonedParts(date, timeZone);
+  return dateOrdinal(parts);
+}
+
+export function episodeNumber(payload) {
+  const numbers = collectionList(collectionDict(payload).episode_numbers);
+  if (numbers.length > 0) {
+    const episode = Number.parseInt(numbers[0], 10);
+    if (!Number.isNaN(episode)) return episode;
+  }
+
+  const text = ["episode_display", "path", "notification_message"]
+    .map((key) => scalarText(collectionDict(payload)[key]))
+    .join(" ");
+  const patterns = [/S\d{1,2}E(\d{1,4})/i, /[第\s](\d{1,4})[集话話]/i, /\bE(\d{1,4})\b/i];
+
+  for (const pattern of patterns) {
+    const match = text.match(pattern);
+    if (match) return Number.parseInt(match[1], 10);
+  }
+
+  return null;
+}
+
+export function expectedEpisode(show, now = new Date()) {
+  const showConfig = collectionDict(show);
+  const overrides = collectionDict(showConfig.overrides);
+  if (overrides.expectedEpisode !== undefined && overrides.expectedEpisode !== null)
+    return Number(overrides.expectedEpisode);
+
+  const airing = collectionDict(showConfig.airing);
+  if (!airing.firstAirDate) return null;
+
+  const timeZone = timeZoneForShow(showConfig);
+  const firstAirDate = parseDateParts(airing.firstAirDate);
+  const elapsedDays = localDateOrdinal(now, timeZone) - dateOrdinal(firstAirDate);
+  const firstEpisode = Number(airing.firstEpisode ?? 1);
+  let episode = elapsedDays < 0 ? firstEpisode : firstEpisode + Math.floor(elapsedDays / 7);
+
+  if (airing.totalEpisodes) episode = Math.min(episode, Number(airing.totalEpisodes));
+  return episode;
+}
+
+export function scheduledAtForEpisode(show, episode, now = new Date()) {
+  const airing = collectionDict(collectionDict(show).airing);
+  const firstAirDate = parseDateParts(airing.firstAirDate);
+  const firstEpisode = Number(airing.firstEpisode ?? 1);
+  const targetOrdinal = dateOrdinal(firstAirDate) + 7 * (Number(episode) - firstEpisode);
+  const targetDate = new Date(targetOrdinal * MS_PER_DAY);
+  const { year, month, day } = {
+    year: targetDate.getUTCFullYear(),
+    month: targetDate.getUTCMonth() + 1,
+    day: targetDate.getUTCDate(),
+  };
+  const { hour, minute } = parseTimeParts(airing.time || "00:00");
+  const timeZone = timeZoneForShow(show);
+
+  zonedParts(now, timeZone);
+  return zonedTimeToDate({ year, month, day, hour, minute, second: 0 }, timeZone);
+}
+
+function missingSchedule(reason) {
+  return { status: "missing_schedule", reason };
+}
+
+export function deriveStatus(show, showState, now = new Date(), graceHours = 12) {
+  const showConfig = collectionDict(show);
+  const state = collectionDict(showState);
+
+  if (showConfig.hidden) return { status: "hidden", reason: "" };
+  if (showConfig.finished || collectionDict(showConfig.overrides).status === "finished")
+    return { status: "finished", reason: "" };
+
+  const airing = collectionDict(showConfig.airing);
+  if (!airing.firstAirDate || !airing.weekday || !airing.time) {
+    return missingSchedule("AutoBangumi subscription has no schedule config");
+  }
+
+  try {
+    const timeZone = timeZoneForShow(showConfig);
+    const firstAirDate = parseDateParts(airing.firstAirDate);
+    const grace = Number.parseInt(graceHours, 10);
+    if (Number.isNaN(grace)) return missingSchedule("Invalid grace hours in schedule config");
+
+    parseWeekday(airing.weekday);
+
+    const arrived =
+      state.lastArrivedEpisode === undefined || state.lastArrivedEpisode === null
+        ? null
+        : Number.parseInt(state.lastArrivedEpisode, 10);
+    if (arrived !== null && Number.isNaN(arrived)) return missingSchedule("Invalid lastArrivedEpisode in show state");
+    if (localDateOrdinal(now, timeZone) < dateOrdinal(firstAirDate)) return { status: "upcoming", reason: "" };
+
+    const overrideStatus = collectionDict(showConfig.overrides).status;
+    if (overrideStatus === "paused" || overrideStatus === "delayed") {
+      return { status: "waiting", reason: scalarText(collectionDict(showConfig.overrides).reason, overrideStatus) };
+    }
+
+    const expected = expectedEpisode(showConfig, now);
+    const scheduledAt = scheduledAtForEpisode(showConfig, expected, now);
+    const localNow = zonedParts(now, timeZone);
+    const localScheduled = zonedParts(scheduledAt, timeZone);
+
+    if (arrived !== null && expected !== null && arrived >= Number(expected)) return { status: "arrived", reason: "" };
+    if (dateOrdinal(localNow) === dateOrdinal(localScheduled) && now < scheduledAt)
+      return { status: "today", reason: "" };
+    if (now < scheduledAt) return { status: "upcoming", reason: "" };
+    if (now.getTime() <= scheduledAt.getTime() + grace * 60 * 60 * 1000) return { status: "waiting", reason: "" };
+
+    return { status: "overdue", reason: `Expected episode ${expected} has not arrived` };
+  } catch (error) {
+    return missingSchedule("Invalid schedule config");
+  }
+}
+
+function weekdayLabel(weekday) {
+  return { 1: "周一", 2: "周二", 3: "周三", 4: "周四", 5: "周五", 6: "周六", 7: "周日" }[weekday] || "";
+}
+
+function showMatchValues(show) {
+  const showConfig = collectionDict(show);
+  const values = [
+    showConfig.key,
+    showConfig.title,
+    ...collectionList(showConfig.aliases),
+    ...collectionList(showConfig.autobangumiNames),
+  ];
+  return new Set(values.map((value) => normalizeTitle(value)).filter(Boolean));
+}
+
+function pathTitleCandidates(value) {
+  const parts = scalarText(value).replaceAll("\\", "/").split("/").filter(Boolean);
+  const candidates = [];
+  const animationIndex = parts.indexOf("Animation");
+  if (animationIndex >= 0 && parts[animationIndex + 1]) candidates.push(parts[animationIndex + 1]);
+  candidates.push(...parts.slice(-3, -1));
+
+  return new Set(candidates.map((item) => normalizeTitle(item)).filter(Boolean));
+}
+
+function matchShow(schedule, payload) {
+  const payloadConfig = collectionDict(payload);
+  const values = new Set([
+    normalizeTitle(payloadConfig.series_title),
+    normalizeTitle(payloadConfig.notification_title),
+    ...pathTitleCandidates(payloadConfig.path),
+  ]);
+  values.delete("");
+
+  return (
+    collectionList(collectionDict(schedule).shows).find((show) => {
+      const showValues = showMatchValues(show);
+      return [...values].some((value) => showValues.has(value));
+    }) || null
+  );
+}
+
+function eventId(showKey, episode, receivedAt) {
+  const stamp = scalarText(receivedAt).replace(/\D/g, "").slice(0, 14) || "event";
+  return `${stamp}-${showKey}-${episode ?? "unknown"}`;
+}
+
+export function recordArrivalInData(schedule, state, events, payload, now = new Date()) {
+  const stateData = clone(collectionDict(state));
+  const eventsData = clone(collectionDict(events));
+  const payloadData = collectionDict(payload);
+  const receivedAt = scalarText(payloadData.event_time) || isoNow(now);
+  const episode = episodeNumber(payloadData);
+  const show = matchShow(schedule, payloadData);
+
+  if (!show) {
+    const unmatched = {
+      type: "unmatched_event",
+      seriesTitle: scalarText(payloadData.series_title),
+      episodeNumbers: collectionList(payloadData.episode_numbers),
+      episodeDisplay: scalarText(payloadData.episode_display),
+      path: scalarText(payloadData.path),
+      receivedAt,
+    };
+    if (!Array.isArray(stateData.unmatchedEvents)) stateData.unmatchedEvents = [];
+    stateData.unmatchedEvents.push(unmatched);
+    stateData.updatedAt = isoNow(now);
+    return { matched: false, event: unmatched, state: stateData, events: eventsData };
+  }
+
+  const showKey = scalarText(show.key);
+  const event = {
+    id: eventId(showKey, episode, receivedAt),
+    type: "arrival",
+    showKey,
+    seriesTitle: scalarText(payloadData.series_title),
+    seasonName: scalarText(payloadData.season_name),
+    episodeNumbers: collectionList(payloadData.episode_numbers),
+    episodeDisplay: scalarText(payloadData.episode_display),
+    path: scalarText(payloadData.path),
+    receivedAt,
+  };
+
+  if (!stateData.shows || typeof stateData.shows !== "object" || Array.isArray(stateData.shows)) stateData.shows = {};
+  const showState = collectionDict(stateData.shows[showKey]);
+  stateData.shows[showKey] = showState;
+
+  if (episode !== null)
+    showState.lastArrivedEpisode = Math.max(Number(showState.lastArrivedEpisode || 0), Number(episode));
+  showState.lastArrivedAt = receivedAt;
+  showState.lastLocalPath = scalarText(payloadData.path);
+  showState.match = { source: "arrival_payload", confidence: "high" };
+  stateData.updatedAt = isoNow(now);
+
+  if (!Array.isArray(eventsData.events)) eventsData.events = [];
+  eventsData.events.push(event);
+  const limitValue =
+    collectionDict(collectionDict(schedule).settings).eventLimit ?? DEFAULT_SCHEDULE.settings.eventLimit;
+  const limit = Number.parseInt(limitValue, 10);
+  eventsData.events = limit > 0 ? eventsData.events.slice(-limit) : [];
+
+  return { matched: true, showKey, event, state: stateData, events: eventsData };
+}
+
+export function makeTimelinePayload(schedule, state, events, now = new Date()) {
+  const scheduleData = collectionDict(schedule);
+  const stateData = collectionDict(state);
+  const settings = collectionDict(scheduleData.settings);
+  const stateShows = collectionDict(stateData.shows);
+  const graceHours = settings.overdueGraceHours ?? DEFAULT_SCHEDULE.settings.overdueGraceHours;
+  const rows = [];
+  const week = Array.from({ length: 7 }, (_, index) => ({
+    weekday: index + 1,
+    label: weekdayLabel(index + 1),
+    count: 0,
+    arrived: 0,
+    waiting: 0,
+    overdue: 0,
+  }));
+
+  collectionList(scheduleData.shows).forEach((show, index) => {
+    const showConfig = collectionDict(show);
+    const key = scalarText(showConfig.key) || `configured:${index}`;
+    const airing = collectionDict(showConfig.airing);
+    const statusInfo = deriveStatus(showConfig, stateShows[key], now, graceHours);
+    let expected = null;
+    try {
+      expected = expectedEpisode(showConfig, now);
+    } catch (error) {
+      expected = null;
+    }
+
+    const weekday = Number.parseInt(airing.weekday || 0, 10) || 0;
+    const row = {
+      key,
+      title: scalarText(showConfig.title, key),
+      weekday,
+      weekdayLabel: weekdayLabel(weekday),
+      airTime: scalarText(airing.time),
+      expectedEpisode: expected,
+      lastArrivedEpisode: collectionDict(stateShows[key]).lastArrivedEpisode,
+      lastArrivedAt: scalarText(collectionDict(stateShows[key]).lastArrivedAt),
+      lastLocalPath: scalarText(collectionDict(stateShows[key]).lastLocalPath),
+      autobangumi: collectionDict(collectionDict(stateShows[key]).autobangumi),
+      match: collectionDict(collectionDict(stateShows[key]).match),
+      status: statusInfo.status,
+      reason: statusInfo.reason || "",
+      hidden: Boolean(showConfig.hidden),
+      finished: Boolean(showConfig.finished),
+    };
+    rows.push(row);
+
+    if (row.status !== "hidden" && weekday >= 1 && weekday <= 7) {
+      const bucket = week[weekday - 1];
+      bucket.count += 1;
+      if (row.status === "arrived") bucket.arrived += 1;
+      else if (row.status === "overdue") bucket.overdue += 1;
+      else if (row.status === "today" || row.status === "waiting") bucket.waiting += 1;
+    }
+  });
+
+  const visibleRows = rows.filter((row) => row.status !== "hidden");
+  const counts = visibleRows.reduce((acc, row) => ({ ...acc, [row.status]: (acc[row.status] || 0) + 1 }), {});
+  const eventItems = collectionList(collectionDict(events).events);
+  const unmatchedEvents = collectionList(stateData.unmatchedEvents);
+
+  return {
+    generatedAt: now.toISOString(),
+    summary: {
+      enabled: settings.enabled ?? true,
+      total: visibleRows.length,
+      today: counts.today || 0,
+      arrived: counts.arrived || 0,
+      waiting: counts.waiting || 0,
+      overdue: counts.overdue || 0,
+      missingSchedule: counts.missing_schedule || 0,
+      unmatchedEvents: unmatchedEvents.length,
+    },
+    todayQueue: visibleRows
+      .filter((row) => row.status === "today" || row.status === "waiting" || row.status === "overdue")
+      .sort((a, b) => (a.airTime || "99:99").localeCompare(b.airTime || "99:99") || a.title.localeCompare(b.title)),
+    week,
+    rows: visibleRows.sort(
+      (a, b) =>
+        (a.weekday || 9) - (b.weekday || 9) ||
+        (a.airTime || "99:99").localeCompare(b.airTime || "99:99") ||
+        a.title.localeCompare(b.title),
+    ),
+    recentEvents: eventItems.slice(-10).reverse(),
+    unmatchedEvents: unmatchedEvents.slice(-10).reverse(),
+  };
+}

--- a/src/utils/bangumi/core.test.js
+++ b/src/utils/bangumi/core.test.js
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_SCHEDULE,
+  deriveStatus,
+  episodeNumber,
+  expectedEpisode,
+  makeTimelinePayload,
+  normalizeTitle,
+  recordArrivalInData,
+  scheduledAtForEpisode,
+} from "./core";
+
+describe("bangumi core", () => {
+  it("normalizes titles and extracts episode numbers from common payloads", () => {
+    expect(normalizeTitle("  Example Show S2  ")).toBe("exampleshows2");
+    expect(normalizeTitle("葬送 的 芙莉莲")).toBe("葬送的芙莉莲");
+    expect(episodeNumber({ episode_numbers: [7] })).toBe(7);
+    expect(episodeNumber({ episode_display: "第12集" })).toBe(12);
+    expect(episodeNumber({ path: "/Animation/Show/Show S01E03.mkv" })).toBe(3);
+    expect(episodeNumber({ episode_display: "特别篇" })).toBeNull();
+  });
+
+  it("calculates expected episode and scheduled time from first air date", () => {
+    const show = {
+      key: "demo",
+      title: "Demo",
+      airing: {
+        weekday: 3,
+        time: "10:00",
+        timezone: "Asia/Shanghai",
+        firstAirDate: "2026-06-03",
+        firstEpisode: 1,
+        totalEpisodes: 12,
+      },
+    };
+    const now = new Date("2026-06-17T12:00:00+08:00");
+    expect(expectedEpisode(show, now)).toBe(3);
+    expect(scheduledAtForEpisode(show, 3).toISOString()).toBe("2026-06-17T02:00:00.000Z");
+  });
+
+  it("derives today, waiting, overdue, arrived, and missing schedule statuses", () => {
+    const show = {
+      key: "demo",
+      title: "Demo",
+      airing: {
+        weekday: 3,
+        time: "10:00",
+        timezone: "Asia/Shanghai",
+        firstAirDate: "2026-06-03",
+        firstEpisode: 1,
+      },
+    };
+    expect(deriveStatus(show, { lastArrivedEpisode: 3 }, new Date("2026-06-17T12:00:00+08:00"), 12).status).toBe(
+      "arrived",
+    );
+    expect(deriveStatus(show, { lastArrivedEpisode: 2 }, new Date("2026-06-17T09:00:00+08:00"), 12).status).toBe(
+      "today",
+    );
+    expect(deriveStatus(show, { lastArrivedEpisode: 2 }, new Date("2026-06-17T13:00:00+08:00"), 12).status).toBe(
+      "waiting",
+    );
+    expect(deriveStatus(show, { lastArrivedEpisode: 2 }, new Date("2026-06-18T00:30:00+08:00"), 12).status).toBe(
+      "overdue",
+    );
+    expect(deriveStatus({ key: "x", title: "X" }, {}, new Date("2026-06-17T12:00:00+08:00"), 12).status).toBe(
+      "missing_schedule",
+    );
+  });
+
+  it("builds timeline payload and records matched and unmatched arrivals", () => {
+    const schedule = {
+      ...DEFAULT_SCHEDULE,
+      shows: [
+        {
+          key: "demo",
+          title: "Demo Show",
+          aliases: ["Demo"],
+          airing: { weekday: 3, time: "10:00", timezone: "Asia/Shanghai", firstAirDate: "2026-06-03", firstEpisode: 1 },
+        },
+      ],
+    };
+    const state = { shows: {} };
+    const events = { events: [] };
+    const matched = recordArrivalInData(schedule, state, events, {
+      series_title: "Demo",
+      episode_numbers: [3],
+      path: "/Animation/Demo/Demo S01E03.mkv",
+      event_time: "2026-06-17T12:30:00+08:00",
+    });
+    expect(matched.matched).toBe(true);
+    expect(state.shows.demo).toBeUndefined();
+    expect(matched.state.shows.demo.lastArrivedEpisode).toBe(3);
+    const payload = makeTimelinePayload(schedule, matched.state, matched.events, new Date("2026-06-17T13:00:00+08:00"));
+    expect(payload.summary.arrived).toBe(1);
+    expect(payload.rows[0].title).toBe("Demo Show");
+    const unmatched = recordArrivalInData(schedule, matched.state, matched.events, {
+      series_title: "Other",
+      episode_display: "第1集",
+      event_time: "2026-06-17T13:30:00+08:00",
+    });
+    expect(unmatched.matched).toBe(false);
+    expect(matched.state.unmatchedEvents).toBeUndefined();
+    expect(unmatched.state.unmatchedEvents).toHaveLength(1);
+  });
+});

--- a/src/utils/bangumi/manage.js
+++ b/src/utils/bangumi/manage.js
@@ -23,7 +23,12 @@ function showSchedule(show) {
 
 function showTitleValues(show) {
   const showData = collectionObject(show);
-  return [showData.key, showData.title, ...collectionArray(showData.aliases), ...collectionArray(showData.autobangumiNames)]
+  return [
+    showData.key,
+    showData.title,
+    ...collectionArray(showData.aliases),
+    ...collectionArray(showData.autobangumiNames),
+  ]
     .map(normalizeTitle)
     .filter(Boolean);
 }
@@ -86,7 +91,8 @@ function applyEditableFields(show, payload) {
   if (title) next.title = title;
   if (payload.hidden !== undefined) next.hidden = payload.hidden;
   if (payload.finished !== undefined) next.finished = Boolean(payload.finished);
-  if (Array.isArray(payload.aliases)) next.aliases = payload.aliases.map((item) => scalarText(item).trim()).filter(Boolean);
+  if (Array.isArray(payload.aliases))
+    next.aliases = payload.aliases.map((item) => scalarText(item).trim()).filter(Boolean);
   if (Array.isArray(payload.autobangumiNames)) {
     next.autobangumiNames = payload.autobangumiNames.map((item) => scalarText(item).trim()).filter(Boolean);
   } else if (!collectionArray(next.autobangumiNames).length && title) {

--- a/src/utils/bangumi/manage.js
+++ b/src/utils/bangumi/manage.js
@@ -1,0 +1,184 @@
+import { DEFAULT_SCHEDULE, normalizeTitle } from "./core";
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value ?? {}));
+}
+
+function collectionArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function collectionObject(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+}
+
+function scalarText(value, fallback = "") {
+  if (value === null || value === undefined || typeof value === "object") return fallback;
+  return String(value);
+}
+
+function showSchedule(show) {
+  return collectionObject(collectionObject(show).airing);
+}
+
+function showTitleValues(show) {
+  const showData = collectionObject(show);
+  return [showData.key, showData.title, ...collectionArray(showData.aliases), ...collectionArray(showData.autobangumiNames)]
+    .map(normalizeTitle)
+    .filter(Boolean);
+}
+
+function scheduleShows(schedule) {
+  return collectionArray(collectionObject(schedule).shows);
+}
+
+function slugify(value) {
+  const slug = scalarText(value)
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9\u4e00-\u9fa5]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug || `show-${Date.now()}`;
+}
+
+function uniqueKey(schedule, title, requestedKey = "") {
+  const existing = new Set(scheduleShows(schedule).map((show) => scalarText(collectionObject(show).key)));
+  const base = slugify(requestedKey || title);
+  let key = base;
+  let index = 2;
+  while (existing.has(key)) {
+    key = `${base}-${index}`;
+    index += 1;
+  }
+  return key;
+}
+
+function assertBoolean(value, name) {
+  if (value !== undefined && typeof value !== "boolean") throw new Error(`${name} must be a boolean`);
+}
+
+function assertScheduleFields(payload) {
+  const weekday = payload.weekday === undefined ? undefined : Number(payload.weekday);
+  if (weekday !== undefined && (!Number.isInteger(weekday) || weekday < 1 || weekday > 7)) {
+    throw new Error("weekday must be between 1 and 7");
+  }
+  if (payload.time !== undefined) {
+    const match = String(payload.time).match(/^(\d{1,2}):(\d{2})$/);
+    if (!match) throw new Error("time is invalid");
+    const hour = Number(match[1]);
+    const minute = Number(match[2]);
+    if (hour < 0 || hour > 23 || minute < 0 || minute > 59) throw new Error("time is invalid");
+  }
+  if (payload.firstAirDate !== undefined && !/^\d{4}-\d{2}-\d{2}$/.test(String(payload.firstAirDate))) {
+    throw new Error("firstAirDate is invalid");
+  }
+  if (payload.firstEpisode !== undefined && !Number.isFinite(Number(payload.firstEpisode))) {
+    throw new Error("firstEpisode is invalid");
+  }
+  if (payload.totalEpisodes !== undefined && !Number.isFinite(Number(payload.totalEpisodes))) {
+    throw new Error("totalEpisodes is invalid");
+  }
+}
+
+function applyEditableFields(show, payload) {
+  const next = { ...show };
+  const title = scalarText(payload.title).trim();
+  if (title) next.title = title;
+  if (payload.hidden !== undefined) next.hidden = payload.hidden;
+  if (payload.finished !== undefined) next.finished = Boolean(payload.finished);
+  if (Array.isArray(payload.aliases)) next.aliases = payload.aliases.map((item) => scalarText(item).trim()).filter(Boolean);
+  if (Array.isArray(payload.autobangumiNames)) {
+    next.autobangumiNames = payload.autobangumiNames.map((item) => scalarText(item).trim()).filter(Boolean);
+  } else if (!collectionArray(next.autobangumiNames).length && title) {
+    next.autobangumiNames = [title];
+  }
+
+  if (payload.weekday !== undefined || payload.time !== undefined || payload.firstAirDate !== undefined) {
+    next.airing = {
+      ...collectionObject(next.airing),
+      timezone: scalarText(payload.timezone, collectionObject(next.airing).timezone || "Asia/Shanghai"),
+    };
+    if (payload.weekday !== undefined) next.airing.weekday = Number(payload.weekday);
+    if (payload.time !== undefined) next.airing.time = scalarText(payload.time).trim();
+    if (payload.firstAirDate !== undefined) next.airing.firstAirDate = scalarText(payload.firstAirDate).trim();
+    if (payload.firstEpisode !== undefined) next.airing.firstEpisode = Number(payload.firstEpisode);
+    if (payload.totalEpisodes !== undefined) next.airing.totalEpisodes = Number(payload.totalEpisodes);
+  }
+
+  return next;
+}
+
+export function managedShowSummary(show) {
+  const showData = collectionObject(show);
+  const airing = showSchedule(showData);
+  return {
+    key: scalarText(showData.key),
+    title: scalarText(showData.title, showData.key),
+    hidden: Boolean(showData.hidden),
+    finished: Boolean(showData.finished),
+    weekday: airing.weekday,
+    time: scalarText(airing.time),
+    timezone: scalarText(airing.timezone),
+    firstAirDate: scalarText(airing.firstAirDate),
+    autobangumiNames: collectionArray(showData.autobangumiNames),
+    hasSchedule: Boolean(airing.weekday && airing.time && airing.firstAirDate),
+  };
+}
+
+export function buildManagePayload(schedule, state) {
+  const stateData = collectionObject(state);
+  const configured = [];
+  const hidden = [];
+  const existingNames = new Set();
+
+  scheduleShows(schedule).forEach((show) => {
+    showTitleValues(show).forEach((value) => existingNames.add(value));
+    const summary = managedShowSummary(show);
+    if (summary.hidden) hidden.push(summary);
+    else configured.push(summary);
+  });
+
+  const missing = collectionArray(collectionObject(stateData.autobangumi).missingScheduleNames)
+    .filter((name) => !existingNames.has(normalizeTitle(name)))
+    .map((name) => ({ title: scalarText(name), autobangumiName: scalarText(name) }));
+
+  return {
+    configured,
+    hidden,
+    missing,
+    sync: {
+      lastSyncAt: scalarText(collectionObject(stateData.autobangumi).lastSyncAt),
+      error: scalarText(collectionObject(stateData.autobangumi).error),
+      missingSchedule: missing.length,
+    },
+  };
+}
+
+export function createManagedShow(schedule, payload) {
+  const scheduleData = { ...clone(DEFAULT_SCHEDULE), ...clone(collectionObject(schedule)) };
+  const shows = scheduleShows(scheduleData).map((show) => clone(show));
+  const title = scalarText(payload?.title).trim();
+  if (!title) throw new Error("title is required");
+  assertBoolean(payload.hidden, "hidden");
+  assertScheduleFields(payload);
+
+  const show = applyEditableFields({ key: uniqueKey(scheduleData, title, payload.key), title }, payload);
+  shows.push(show);
+  scheduleData.shows = shows;
+  return { schedule: scheduleData, show: managedShowSummary(show) };
+}
+
+export function patchManagedShow(schedule, key, payload) {
+  if (!key || String(key).includes("/")) return null;
+  assertBoolean(payload.hidden, "hidden");
+  assertScheduleFields(payload);
+
+  const scheduleData = { ...clone(DEFAULT_SCHEDULE), ...clone(collectionObject(schedule)) };
+  const shows = scheduleShows(scheduleData).map((show) => clone(show));
+  const index = shows.findIndex((show) => scalarText(collectionObject(show).key) === key);
+  if (index < 0) return null;
+
+  shows[index] = applyEditableFields(shows[index], payload || {});
+  scheduleData.shows = shows;
+  return { schedule: scheduleData, show: managedShowSummary(shows[index]) };
+}

--- a/src/utils/bangumi/paths.js
+++ b/src/utils/bangumi/paths.js
@@ -1,0 +1,82 @@
+import { promises as fs } from "fs";
+import path from "path";
+
+import { DEFAULT_SCHEDULE } from "./core";
+
+const SCHEDULE_FILE = "bangumi-schedule.json";
+const STATE_FILE = "bangumi-state.json";
+const EVENTS_FILE = "bangumi-events.json";
+
+const DEFAULT_STATE = {
+  updatedAt: "",
+  shows: {},
+  unmatchedEvents: [],
+  autobangumi: { lastSyncAt: "", error: "" },
+};
+
+const DEFAULT_EVENTS = { events: [] };
+
+function cloneDefault(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+export function schedulePath(configDir) {
+  return path.join(configDir, SCHEDULE_FILE);
+}
+
+export function dataDir(configDir) {
+  return process.env.HOMEPAGE_BANGUMI_DATA_DIR || path.join(configDir, "bangumi-data");
+}
+
+export function statePath(bangumiDataDir) {
+  return path.join(bangumiDataDir, STATE_FILE);
+}
+
+export function eventsPath(bangumiDataDir) {
+  return path.join(bangumiDataDir, EVENTS_FILE);
+}
+
+export async function loadJson(filePath, fallback) {
+  try {
+    return JSON.parse(await fs.readFile(filePath, "utf8"));
+  } catch (error) {
+    if (error?.code === "ENOENT" || error instanceof SyntaxError) return cloneDefault(fallback);
+    throw error;
+  }
+}
+
+export async function atomicWriteJson(filePath, data) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  const temporaryPath = path.join(
+    path.dirname(filePath),
+    `.${path.basename(filePath)}.${process.pid}.${Date.now()}.tmp`,
+  );
+
+  try {
+    await fs.writeFile(temporaryPath, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+    await fs.rename(temporaryPath, filePath);
+  } catch (error) {
+    await fs.rm(temporaryPath, { force: true });
+    throw error;
+  }
+}
+
+export async function ensureBangumiDataFiles(configDir) {
+  const bangumiDataDir = dataDir(configDir);
+  const paths = {
+    schedule: schedulePath(configDir),
+    dataDir: bangumiDataDir,
+    state: statePath(bangumiDataDir),
+    events: eventsPath(bangumiDataDir),
+  };
+
+  await fs.mkdir(bangumiDataDir, { recursive: true });
+
+  await Promise.all([
+    fs.access(paths.schedule).catch(() => atomicWriteJson(paths.schedule, DEFAULT_SCHEDULE)),
+    fs.access(paths.state).catch(() => atomicWriteJson(paths.state, DEFAULT_STATE)),
+    fs.access(paths.events).catch(() => atomicWriteJson(paths.events, DEFAULT_EVENTS)),
+  ]);
+
+  return paths;
+}

--- a/src/widgets/bangumi/component.jsx
+++ b/src/widgets/bangumi/component.jsx
@@ -1,0 +1,93 @@
+import classNames from "classnames";
+import Block from "components/services/widget/block";
+import Container from "components/services/widget/container";
+import useSWR from "swr";
+
+function statusClass(status) {
+  return {
+    arrived: "text-emerald-500 dark:text-emerald-300",
+    waiting: "text-amber-500 dark:text-amber-300",
+    today: "text-sky-500 dark:text-sky-300",
+    overdue: "text-rose-500 dark:text-rose-300",
+  }[status];
+}
+
+function episodeLabel(value) {
+  if (value === null || value === undefined || value === "") return "";
+  return `EP ${value}`;
+}
+
+function QueueRow({ item }) {
+  return (
+    <div className="flex items-center justify-between gap-2 rounded-sm bg-theme-200/50 dark:bg-theme-900/20 px-2 py-1 text-xs">
+      <div className="min-w-0">
+        <div className="truncate font-medium text-theme-900 dark:text-theme-100">{item.title}</div>
+        <div className="text-[11px] text-theme-500 dark:text-theme-400">
+          {[item.airTime, episodeLabel(item.expectedEpisode)].filter(Boolean).join(" · ")}
+        </div>
+      </div>
+      <span className={classNames("shrink-0 font-semibold uppercase", statusClass(item.status))}>{item.status}</span>
+    </div>
+  );
+}
+
+function RecentEvent({ event }) {
+  return (
+    <div className="flex items-center justify-between gap-2 rounded-sm px-2 py-1 text-xs">
+      <span className="truncate text-theme-700 dark:text-theme-200">{event.seriesTitle || event.showKey}</span>
+      <span className="shrink-0 text-theme-500 dark:text-theme-400">{event.episodeDisplay || episodeLabel(event.episodeNumbers?.[0])}</span>
+    </div>
+  );
+}
+
+export default function Component({ service }) {
+  const { data, error } = useSWR("/api/bangumi/status");
+
+  if (error || data?.error) {
+    return <Container service={service} error={error || data?.error} />;
+  }
+
+  if (!data) {
+    return (
+      <Container service={service}>
+        <Block label="Total" />
+        <Block label="Today" />
+        <Block label="Overdue" />
+        <Block label="Unmatched" />
+      </Container>
+    );
+  }
+
+  const summary = data.summary || {};
+  const queue = Array.isArray(data.todayQueue) ? data.todayQueue.slice(0, 4) : [];
+  const recentEvents = Array.isArray(data.recentEvents) ? data.recentEvents.slice(0, 2) : [];
+
+  return (
+    <Container service={service}>
+      <div className="flex w-full flex-col gap-1">
+        <div className="grid grid-cols-4 gap-1">
+          <Block label="Total" value={summary.total ?? 0} />
+          <Block label="Today" value={summary.today ?? 0} />
+          <Block label="Overdue" value={summary.overdue ?? 0} highlightValue={summary.overdue ?? 0} />
+          <Block label="Unmatched" value={summary.unmatchedEvents ?? 0} />
+        </div>
+
+        {queue.length > 0 && (
+          <div className="flex flex-col gap-1">
+            {queue.map((item) => (
+              <QueueRow key={item.key} item={item} />
+            ))}
+          </div>
+        )}
+
+        {recentEvents.length > 0 && (
+          <div className="mt-1 border-t border-theme-300/40 pt-1 dark:border-theme-700/40">
+            {recentEvents.map((event) => (
+              <RecentEvent key={event.id || `${event.seriesTitle}-${event.receivedAt}`} event={event} />
+            ))}
+          </div>
+        )}
+      </div>
+    </Container>
+  );
+}

--- a/src/widgets/bangumi/component.jsx
+++ b/src/widgets/bangumi/component.jsx
@@ -35,7 +35,9 @@ function RecentEvent({ event }) {
   return (
     <div className="flex items-center justify-between gap-2 rounded-sm px-2 py-1 text-xs">
       <span className="truncate text-theme-700 dark:text-theme-200">{event.seriesTitle || event.showKey}</span>
-      <span className="shrink-0 text-theme-500 dark:text-theme-400">{event.episodeDisplay || episodeLabel(event.episodeNumbers?.[0])}</span>
+      <span className="shrink-0 text-theme-500 dark:text-theme-400">
+        {event.episodeDisplay || episodeLabel(event.episodeNumbers?.[0])}
+      </span>
     </div>
   );
 }

--- a/src/widgets/bangumi/component.test.jsx
+++ b/src/widgets/bangumi/component.test.jsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+
+import { screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "test-utils/render-with-providers";
+
+const { useSWR } = vi.hoisted(() => ({ useSWR: vi.fn() }));
+vi.mock("swr", () => ({ default: useSWR }));
+
+import Component from "./component";
+
+describe("widgets/bangumi/component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders compact placeholders while loading", () => {
+    useSWR.mockReturnValue({ data: undefined, error: undefined });
+
+    const { container } = renderWithProviders(<Component service={{ widget: { type: "bangumi" } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expect(useSWR).toHaveBeenCalledWith("/api/bangumi/status");
+    expect(container.querySelectorAll(".service-block")).toHaveLength(4);
+    expect(screen.getByText("Today")).toBeInTheDocument();
+    expect(screen.getByText("Overdue")).toBeInTheDocument();
+  });
+
+  it("renders error UI when the status API fails", () => {
+    useSWR.mockReturnValue({ data: undefined, error: { message: "nope" } });
+
+    renderWithProviders(<Component service={{ widget: { type: "bangumi" } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expect(screen.getAllByText(/widget\.api_error/i).length).toBeGreaterThan(0);
+  });
+
+  it("renders summary, today queue, and recent arrivals", () => {
+    useSWR.mockReturnValue({
+      data: {
+        summary: { total: 3, today: 1, overdue: 1, unmatchedEvents: 2 },
+        todayQueue: [
+          { key: "demo", title: "Demo Show", airTime: "20:00", expectedEpisode: 4, status: "waiting" },
+          { key: "late", title: "Late Show", airTime: "21:30", expectedEpisode: 7, status: "overdue" },
+        ],
+        recentEvents: [{ id: "event-1", seriesTitle: "Arrived Show", episodeDisplay: "第 2 集" }],
+      },
+      error: undefined,
+    });
+
+    renderWithProviders(<Component service={{ widget: { type: "bangumi" } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.getByText("Demo Show")).toBeInTheDocument();
+    expect(screen.getByText("20:00 · EP 4")).toBeInTheDocument();
+    expect(screen.getByText("Late Show")).toBeInTheDocument();
+    expect(screen.getByText("Arrived Show")).toBeInTheDocument();
+    expect(screen.getByText("第 2 集")).toBeInTheDocument();
+  });
+});

--- a/src/widgets/bangumi/widget.js
+++ b/src/widgets/bangumi/widget.js
@@ -1,0 +1,5 @@
+const widget = {
+  local: true,
+};
+
+export default widget;

--- a/src/widgets/bangumi/widget.test.js
+++ b/src/widgets/bangumi/widget.test.js
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+
+import { expectWidgetConfigShape } from "test-utils/widget-config";
+
+import widget from "./widget";
+
+describe("bangumi widget config", () => {
+  it("exports a valid local widget config", () => {
+    expectWidgetConfigShape(widget);
+    expect(widget.local).toBe(true);
+  });
+});

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -11,6 +11,7 @@ const components = {
   autobrr: dynamic(() => import("./autobrr/component")),
   azuredevops: dynamic(() => import("./azuredevops/component")),
   backrest: dynamic(() => import("./backrest/component")),
+  bangumi: dynamic(() => import("./bangumi/component")),
   bazarr: dynamic(() => import("./bazarr/component")),
   beszel: dynamic(() => import("./beszel/component")),
   booklore: dynamic(() => import("./booklore/component")),

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -8,6 +8,7 @@ import authentik from "./authentik/widget";
 import autobrr from "./autobrr/widget";
 import azuredevops from "./azuredevops/widget";
 import backrest from "./backrest/widget";
+import bangumi from "./bangumi/widget";
 import bazarr from "./bazarr/widget";
 import beszel from "./beszel/widget";
 import booklore from "./booklore/widget";
@@ -165,6 +166,7 @@ const widgets = {
   autobrr,
   azuredevops,
   backrest,
+  bangumi,
   bazarr,
   booklore,
   beszel,


### PR DESCRIPTION
## Summary

- Adds a built-in Bangumi timeline data layer with schedule parsing, arrival matching, status derivation, and atomic JSON persistence.
- Adds AutoBangumi subscription sync support and local Next.js API routes for timeline status, arrival webhooks, and admin management actions.
- Registers a new `bangumi` service widget and documents the required `bangumi-schedule.json` configuration.

## Validation

- `pnpm vitest run src/utils/bangumi/core.test.js src/utils/bangumi/autobangumi.test.js src/__tests__/pages/api/bangumi/status.test.js src/__tests__/pages/api/admin/bangumi/manage.test.js src/widgets/bangumi/component.test.jsx src/widgets/bangumi/widget.test.js`
- Local Homepage dev server smoke test verified the Bangumi widget rendered `Bangumi Timeline`, summary blocks, and `Demo Show` without API errors.

## Notes

- Webhook writes require `HOMEPAGE_BANGUMI_WEBHOOK_TOKEN`.
- Admin write APIs require Homepage auth or `HOMEPAGE_BANGUMI_ADMIN_TOKEN`.
