### PR TITLE
Add Netbird widget

### DIFF
--- a/docs/widgets/services/netbird.md
+++ b/docs/widgets/services/netbird.md
@@ -1,0 +1,17 @@
+---
+title: Netbird
+description: Netbird Widget Configuration
+---
+
+Learn more about [Netbird](https://netbird.io/).
+
+This widget connects to a self-hosted Netbird management instance using the Netbird Management API.
+
+You will need to generate an API access token from the Netbird dashboard under **User settings &rarr; Access Tokens**. The token is sent to the API as an `Authorization: Token {key}` header.
+
+```yaml
+widget:
+  type: netbird
+  url: https://netbird.example.com
+  key: your-netbird-api-token
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,6 +112,7 @@ nav:
           - widgets/services/mylar.md
           - widgets/services/myspeed.md
           - widgets/services/navidrome.md
+          - widgets/services/netbird.md
           - widgets/services/netdata.md
           - widgets/services/netalertx.md
           - widgets/services/nextcloud.md

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -941,6 +941,12 @@
       "warnings": "Warnings",
       "criticals": "Criticals"
     },
+    "netbird": {
+      "online": "Online",
+      "offline": "Offline",
+      "total": "Total",
+      "routes": "Routes"
+    },
     "ntfy": {
       "title": "Title",
       "priority": "Priority",

--- a/src/utils/proxy/handlers/credentialed.js
+++ b/src/utils/proxy/handlers/credentialed.js
@@ -90,7 +90,7 @@ export default async function credentialedProxyHandler(req, res, map) {
         headers.Authorization = `PBSAPIToken=${widget.username}:${widget.password}`;
       } else if (["autobrr", "jellystat", "pulse"].includes(widget.type)) {
         headers["X-API-Token"] = `${widget.key}`;
-      } else if (widget.type === "tubearchivist") {
+      } else if (["netbird", "tubearchivist"].includes(widget.type)) {
         headers.Authorization = `Token ${widget.key}`;
       } else if (widget.type === "miniflux") {
         headers["X-Auth-Token"] = `${widget.key}`;

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -87,6 +87,7 @@ const components = {
   myspeed: dynamic(() => import("./myspeed/component")),
   navidrome: dynamic(() => import("./navidrome/component")),
   netalertx: dynamic(() => import("./netalertx/component")),
+  netbird: dynamic(() => import("./netbird/component")),
   netdata: dynamic(() => import("./netdata/component")),
   nextcloud: dynamic(() => import("./nextcloud/component")),
   nextdns: dynamic(() => import("./nextdns/component")),

--- a/src/widgets/netbird/component.jsx
+++ b/src/widgets/netbird/component.jsx
@@ -1,0 +1,41 @@
+import Block from "components/services/widget/block";
+import Container from "components/services/widget/container";
+
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { widget } = service;
+
+  const { data: peersData, error: peersError } = useWidgetAPI(widget, "peers");
+  const { data: routesData, error: routesError } = useWidgetAPI(widget, "routes");
+
+  if (peersError || routesError) {
+    const finalError = peersError ?? routesError;
+    return <Container service={service} error={finalError} />;
+  }
+
+  if (!peersData || !routesData) {
+    return (
+      <Container service={service}>
+        <Block label="netbird.online" />
+        <Block label="netbird.offline" />
+        <Block label="netbird.total" />
+        <Block label="netbird.routes" />
+      </Container>
+    );
+  }
+
+  const totalPeers = peersData.length;
+  const onlinePeers = peersData.filter((peer) => peer.connected === true).length;
+  const offlinePeers = totalPeers - onlinePeers;
+  const totalRoutes = routesData.length;
+
+  return (
+    <Container service={service}>
+      <Block label="netbird.online" value={onlinePeers} />
+      <Block label="netbird.offline" value={offlinePeers} />
+      <Block label="netbird.total" value={totalPeers} />
+      <Block label="netbird.routes" value={totalRoutes} />
+    </Container>
+  );
+}

--- a/src/widgets/netbird/widget.js
+++ b/src/widgets/netbird/widget.js
@@ -1,0 +1,17 @@
+import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
+
+const widget = {
+  api: "{url}/api/{endpoint}",
+  proxyHandler: credentialedProxyHandler,
+
+  mappings: {
+    peers: {
+      endpoint: "peers",
+    },
+    routes: {
+      endpoint: "routes",
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -78,6 +78,7 @@ import mylar from "./mylar/widget";
 import myspeed from "./myspeed/widget";
 import navidrome from "./navidrome/widget";
 import netalertx from "./netalertx/widget";
+import netbird from "./netbird/widget";
 import netdata from "./netdata/widget";
 import nextcloud from "./nextcloud/widget";
 import nextdns from "./nextdns/widget";
@@ -237,6 +238,7 @@ const widgets = {
   myspeed,
   navidrome,
   netalertx,
+  netbird,
   netdata,
   nextcloud,
   nextdns,


### PR DESCRIPTION
Adds a new service widget for Netbird (self-hosted), showing peer counts 
(online/offline/total) and route count.

- Uses Token-based auth (Authorization: Token {key}) via credentialedProxyHandler, 
  following the same pattern as headscale/tubearchivist
- Endpoints: GET /api/peers, GET /api/routes
- Docs added under docs/widgets/services/netbird.md

Tested locally against a self-hosted Netbird instance.