### PR TITLE
feat: add Netbird widget

### DIFF
--- a/docs/widgets/services/netbird.md
+++ b/docs/widgets/services/netbird.md
@@ -1,0 +1,17 @@
+---
+title: Netbird
+description: Netbird Widget Configuration
+---
+
+Learn more about [Netbird](https://netbird.io/).
+
+This widget connects to a self-hosted Netbird management instance using the Netbird Management API.
+
+You will need to generate an API access token from the Netbird dashboard under **User settings &rarr; Access Tokens**. The token is sent to the API as an `Authorization: Token {key}` header.
+
+```yaml
+widget:
+  type: netbird
+  url: https://netbird.example.com
+  key: your-netbird-api-token
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,6 +112,7 @@ nav:
           - widgets/services/mylar.md
           - widgets/services/myspeed.md
           - widgets/services/navidrome.md
+          - widgets/services/netbird.md
           - widgets/services/netdata.md
           - widgets/services/netalertx.md
           - widgets/services/nextcloud.md

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -941,6 +941,12 @@
       "warnings": "Warnings",
       "criticals": "Criticals"
     },
+    "netbird": {
+      "online": "Online",
+      "offline": "Offline",
+      "total": "Total",
+      "routes": "Routes"
+    },
     "ntfy": {
       "title": "Title",
       "priority": "Priority",

--- a/src/utils/proxy/handlers/credentialed.js
+++ b/src/utils/proxy/handlers/credentialed.js
@@ -90,7 +90,7 @@ export default async function credentialedProxyHandler(req, res, map) {
         headers.Authorization = `PBSAPIToken=${widget.username}:${widget.password}`;
       } else if (["autobrr", "jellystat", "pulse"].includes(widget.type)) {
         headers["X-API-Token"] = `${widget.key}`;
-      } else if (widget.type === "tubearchivist") {
+      } else if (["netbird", "tubearchivist"].includes(widget.type)) {
         headers.Authorization = `Token ${widget.key}`;
       } else if (widget.type === "miniflux") {
         headers["X-Auth-Token"] = `${widget.key}`;

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -87,6 +87,7 @@ const components = {
   myspeed: dynamic(() => import("./myspeed/component")),
   navidrome: dynamic(() => import("./navidrome/component")),
   netalertx: dynamic(() => import("./netalertx/component")),
+  netbird: dynamic(() => import("./netbird/component")),
   netdata: dynamic(() => import("./netdata/component")),
   nextcloud: dynamic(() => import("./nextcloud/component")),
   nextdns: dynamic(() => import("./nextdns/component")),

--- a/src/widgets/netbird/component.jsx
+++ b/src/widgets/netbird/component.jsx
@@ -1,0 +1,41 @@
+import Block from "components/services/widget/block";
+import Container from "components/services/widget/container";
+
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { widget } = service;
+
+  const { data: peersData, error: peersError } = useWidgetAPI(widget, "peers");
+  const { data: routesData, error: routesError } = useWidgetAPI(widget, "routes");
+
+  if (peersError || routesError) {
+    const finalError = peersError ?? routesError;
+    return <Container service={service} error={finalError} />;
+  }
+
+  if (!peersData || !routesData) {
+    return (
+      <Container service={service}>
+        <Block label="netbird.online" />
+        <Block label="netbird.offline" />
+        <Block label="netbird.total" />
+        <Block label="netbird.routes" />
+      </Container>
+    );
+  }
+
+  const totalPeers = peersData.length;
+  const onlinePeers = peersData.filter((peer) => peer.connected === true).length;
+  const offlinePeers = totalPeers - onlinePeers;
+  const totalRoutes = routesData.length;
+
+  return (
+    <Container service={service}>
+      <Block label="netbird.online" value={onlinePeers} />
+      <Block label="netbird.offline" value={offlinePeers} />
+      <Block label="netbird.total" value={totalPeers} />
+      <Block label="netbird.routes" value={totalRoutes} />
+    </Container>
+  );
+}

--- a/src/widgets/netbird/component.test.jsx
+++ b/src/widgets/netbird/component.test.jsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+
+import { screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "test-utils/render-with-providers";
+import { expectBlockValue } from "test-utils/widget-assertions";
+
+const { useWidgetAPI } = vi.hoisted(() => ({ useWidgetAPI: vi.fn() }));
+
+vi.mock("utils/proxy/use-widget-api", () => ({
+  default: useWidgetAPI,
+}));
+
+import Component from "./component";
+
+describe("widgets/netbird/component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders placeholders while loading", () => {
+    useWidgetAPI.mockReturnValue({ data: undefined, error: undefined });
+
+    const { container } = renderWithProviders(<Component service={{ widget: { type: "netbird", url: "http://x" } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expect(container.querySelectorAll(".service-block")).toHaveLength(4);
+    expect(screen.getByText("netbird.online")).toBeInTheDocument();
+    expect(screen.getByText("netbird.offline")).toBeInTheDocument();
+    expect(screen.getByText("netbird.total")).toBeInTheDocument();
+    expect(screen.getByText("netbird.routes")).toBeInTheDocument();
+  });
+
+  it("renders error UI when the peers API errors", () => {
+    useWidgetAPI.mockImplementation((widget, endpoint) => {
+      if (endpoint === "peers") return { data: undefined, error: { message: "peers down" } };
+      return { data: [], error: undefined };
+    });
+
+    renderWithProviders(<Component service={{ widget: { type: "netbird", url: "http://x" } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expect(screen.getAllByText(/widget\.api_error/i).length).toBeGreaterThan(0);
+    expect(screen.getByText("peers down")).toBeInTheDocument();
+  });
+
+  it("renders error UI when the routes API errors", () => {
+    useWidgetAPI.mockImplementation((widget, endpoint) => {
+      if (endpoint === "routes") return { data: undefined, error: { message: "routes down" } };
+      return { data: [], error: undefined };
+    });
+
+    renderWithProviders(<Component service={{ widget: { type: "netbird", url: "http://x" } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expect(screen.getAllByText(/widget\.api_error/i).length).toBeGreaterThan(0);
+    expect(screen.getByText("routes down")).toBeInTheDocument();
+  });
+
+  it("computes online/offline/total peers and routes count when loaded", () => {
+    const peers = [{ connected: true }, { connected: true }, { connected: false }];
+    const routes = [{ id: "r1" }, { id: "r2" }];
+
+    useWidgetAPI.mockImplementation((widget, endpoint) => {
+      if (endpoint === "peers") return { data: peers, error: undefined };
+      if (endpoint === "routes") return { data: routes, error: undefined };
+      return { data: undefined, error: undefined };
+    });
+
+    const { container } = renderWithProviders(<Component service={{ widget: { type: "netbird", url: "http://x" } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expectBlockValue(container, "netbird.online", 2);
+    expectBlockValue(container, "netbird.offline", 1);
+    expectBlockValue(container, "netbird.total", 3);
+    expectBlockValue(container, "netbird.routes", 2);
+  });
+});

--- a/src/widgets/netbird/component.test.jsx
+++ b/src/widgets/netbird/component.test.jsx
@@ -22,9 +22,12 @@ describe("widgets/netbird/component", () => {
   it("renders placeholders while loading", () => {
     useWidgetAPI.mockReturnValue({ data: undefined, error: undefined });
 
-    const { container } = renderWithProviders(<Component service={{ widget: { type: "netbird", url: "http://x" } }} />, {
-      settings: { hideErrors: false },
-    });
+    const { container } = renderWithProviders(
+      <Component service={{ widget: { type: "netbird", url: "http://x" } }} />,
+      {
+        settings: { hideErrors: false },
+      },
+    );
 
     expect(container.querySelectorAll(".service-block")).toHaveLength(4);
     expect(screen.getByText("netbird.online")).toBeInTheDocument();
@@ -71,9 +74,12 @@ describe("widgets/netbird/component", () => {
       return { data: undefined, error: undefined };
     });
 
-    const { container } = renderWithProviders(<Component service={{ widget: { type: "netbird", url: "http://x" } }} />, {
-      settings: { hideErrors: false },
-    });
+    const { container } = renderWithProviders(
+      <Component service={{ widget: { type: "netbird", url: "http://x" } }} />,
+      {
+        settings: { hideErrors: false },
+      },
+    );
 
     expectBlockValue(container, "netbird.online", 2);
     expectBlockValue(container, "netbird.offline", 1);

--- a/src/widgets/netbird/widget.js
+++ b/src/widgets/netbird/widget.js
@@ -1,0 +1,17 @@
+import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
+
+const widget = {
+  api: "{url}/api/{endpoint}",
+  proxyHandler: credentialedProxyHandler,
+
+  mappings: {
+    peers: {
+      endpoint: "peers",
+    },
+    routes: {
+      endpoint: "routes",
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/netbird/widget.test.js
+++ b/src/widgets/netbird/widget.test.js
@@ -1,0 +1,11 @@
+import { describe, it } from "vitest";
+
+import { expectWidgetConfigShape } from "test-utils/widget-config";
+
+import widget from "./widget";
+
+describe("netbird widget config", () => {
+  it("exports a valid widget config", () => {
+    expectWidgetConfigShape(widget);
+  });
+});

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -78,6 +78,7 @@ import mylar from "./mylar/widget";
 import myspeed from "./myspeed/widget";
 import navidrome from "./navidrome/widget";
 import netalertx from "./netalertx/widget";
+import netbird from "./netbird/widget";
 import netdata from "./netdata/widget";
 import nextcloud from "./nextcloud/widget";
 import nextdns from "./nextdns/widget";
@@ -237,6 +238,7 @@ const widgets = {
   myspeed,
   navidrome,
   netalertx,
+  netbird,
   netdata,
   nextcloud,
   nextdns,


### PR DESCRIPTION
## Proposed change

Adds a new service widget for Netbird (self-hosted). The widget shows peer 
counts (online/offline/total) and active route count, pulled from the 
Netbird Management API.

- API endpoints: `GET /api/peers`, `GET /api/routes`
- Auth: Token-based (`Authorization: Token {key}`), via `credentialedProxyHandler`, 
  following the same pattern as `headscale`/`tubearchivist`
- Docs added: `docs/widgets/services/netbird.md`
- Tested manually against a self-hosted Netbird instance (`pnpm dev`), 
  verified peer counts and empty routes response (`[]`) render correctly

Example API output (`/api/peers`, abbreviated):
```json
[
  { "id": "...", "name": "peer1", "connected": true, ... },
  { "id": "...", "name": "peer2", "connected": false, ... }
]
```

## Type of change

- [x] New service widget

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have added or updated tests for new features and bug fixes
- [x] If applicable, I have reviewed the feature / enhancement and / or service widget guidelines.
- [ ] I have checked that all code style checks pass using pre-commit hooks and linting checks.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] In the description above I have disclosed the use of AI tools in the coding of this PR.

**AI tool disclosure:** This widget was developed with assistance from Claude 
(Anthropic), used for code generation and debugging under my direction and review.