### PR TITLE
Documentation: Drop Jellyfin proceeding 10 in the version

### DIFF
--- a/docs/widgets/services/jellyfin.md
+++ b/docs/widgets/services/jellyfin.md
@@ -11,8 +11,8 @@ As of v0.6.11 the widget supports fields `["movies", "series", "episodes", "song
 
 | Jellyfin Version | Homepage Widget Version |
 | ---------------- | ----------------------- |
-| < 10.12          | 1 (default)             |
-| >= 10.12         | 2                       |
+| < 12.0           | 1 (default)             |
+| >= 12.0          | 2                       |
 
 ```yaml
 widget:


### PR DESCRIPTION
## Proposed change
Starting with version 12, Jellyfin drops the preceeidng 10 in the version (10.11 --> 12.0).
See
https://github.com/jellyfin/jellyfin/releases#release-v12.0-rc1

Closes # (issue)
No issue

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [x] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [ ] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] In the description above I have disclosed the use of AI tools in the coding of this PR.
