### PR TITLE
Add Guacamole widget

### DIFF
--- a/docs/widgets/services/guacamole.md
+++ b/docs/widgets/services/guacamole.md
@@ -1,0 +1,21 @@
+---
+title: Guacamole
+description: Guacamole Widget Configuration
+---
+
+Learn more about [Apache Guacamole](https://guacamole.apache.org/).
+
+This widget shows the number of active sessions, total configured connections, and total users for a Guacamole server.
+
+Use the username and password of an account that has permission to view connections and users on the data source you want to report on.
+
+```yaml
+widget:
+  type: guacamole
+  url: http://guacamole.host.or.ip:8080/guacamole
+  username: guacadmin
+  password: guacadminpassword
+  datasource: mysql # optional
+```
+
+By default the widget uses the primary data source returned for the authenticated user. If your Guacamole instance has multiple data sources (e.g. multiple database or LDAP auth providers) and you want to report on a specific one, set the optional `datasource` field to its identifier, as configured in `guacamole.properties`.

--- a/docs/widgets/services/index.md
+++ b/docs/widgets/services/index.md
@@ -55,6 +55,7 @@ You can also find a list of all available service widgets in the sidebar navigat
 - [Gluetun](gluetun.md)
 - [Gotify](gotify.md)
 - [Grafana](grafana.md)
+- [Guacamole](guacamole.md)
 - [HDHomeRun](hdhomerun.md)
 - [Headscale](headscale.md)
 - [Healthchecks](healthchecks.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,6 +80,7 @@ nav:
           - widgets/services/gluetun.md
           - widgets/services/gotify.md
           - widgets/services/grafana.md
+          - widgets/services/guacamole.md
           - widgets/services/hdhomerun.md
           - widgets/services/headscale.md
           - widgets/services/healthchecks.md

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -771,6 +771,11 @@
         "totalalerts": "Total Alerts",
         "alertstriggered": "Alerts Triggered"
     },
+    "guacamole": {
+        "active": "Active Sessions",
+        "connections": "Connections",
+        "users": "Users"
+    },
     "nextcloud": {
         "cpuload": "Cpu Load",
         "memoryusage": "Memory Usage",

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -52,6 +52,7 @@ const components = {
   gluetun: dynamic(() => import("./gluetun/component")),
   gotify: dynamic(() => import("./gotify/component")),
   grafana: dynamic(() => import("./grafana/component")),
+  guacamole: dynamic(() => import("./guacamole/component")),
   hdhomerun: dynamic(() => import("./hdhomerun/component")),
   headscale: dynamic(() => import("./headscale/component")),
   hoarder: dynamic(() => import("./karakeep/component")),

--- a/src/widgets/guacamole/component.jsx
+++ b/src/widgets/guacamole/component.jsx
@@ -1,0 +1,43 @@
+import { useTranslation } from "next-i18next/pages";
+
+import Block from "components/services/widget/block";
+import Container from "components/services/widget/container";
+
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+
+  const { widget } = service;
+
+  const { data: activeData, error: activeError } = useWidgetAPI(widget, "activeConnections");
+  const { data: connectionsData, error: connectionsError } = useWidgetAPI(widget, "connections");
+  const { data: usersData, error: usersError } = useWidgetAPI(widget, "users");
+
+  const error = activeError ?? connectionsError ?? usersError;
+  if (error) {
+    return <Container service={service} error={error} />;
+  }
+
+  if (!activeData || !connectionsData || !usersData) {
+    return (
+      <Container service={service}>
+        <Block label="guacamole.active" />
+        <Block label="guacamole.connections" />
+        <Block label="guacamole.users" />
+      </Container>
+    );
+  }
+
+  const active = Object.keys(activeData).length;
+  const connections = Object.keys(connectionsData).length;
+  const users = Object.keys(usersData).length;
+
+  return (
+    <Container service={service}>
+      <Block label="guacamole.active" value={t("common.number", { value: active })} />
+      <Block label="guacamole.connections" value={t("common.number", { value: connections })} />
+      <Block label="guacamole.users" value={t("common.number", { value: users })} />
+    </Container>
+  );
+}

--- a/src/widgets/guacamole/component.test.jsx
+++ b/src/widgets/guacamole/component.test.jsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+
+import { screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "test-utils/render-with-providers";
+import { expectBlockValue } from "test-utils/widget-assertions";
+
+const { useWidgetAPI } = vi.hoisted(() => ({ useWidgetAPI: vi.fn() }));
+vi.mock("utils/proxy/use-widget-api", () => ({ default: useWidgetAPI }));
+
+import Component from "./component";
+
+describe("widgets/guacamole/component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders placeholders while loading", () => {
+    useWidgetAPI.mockReturnValue({ data: undefined, error: undefined });
+
+    const { container } = renderWithProviders(<Component service={{ widget: { type: "guacamole" } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expect(container.querySelectorAll(".service-block")).toHaveLength(3);
+    expect(screen.getByText("guacamole.active")).toBeInTheDocument();
+    expect(screen.getByText("guacamole.connections")).toBeInTheDocument();
+    expect(screen.getByText("guacamole.users")).toBeInTheDocument();
+  });
+
+  it("renders error UI when an endpoint errors", () => {
+    useWidgetAPI.mockImplementation((widgetConfig, endpoint) => {
+      if (endpoint === "activeConnections") {
+        return { data: undefined, error: { message: "nope" } };
+      }
+      return { data: {}, error: undefined };
+    });
+
+    renderWithProviders(<Component service={{ widget: { type: "guacamole" } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expect(screen.getAllByText(/widget\.api_error/i).length).toBeGreaterThan(0);
+    expect(screen.getByText("nope")).toBeInTheDocument();
+  });
+
+  it("renders active session, connection, and user counts", () => {
+    useWidgetAPI.mockImplementation((widgetConfig, endpoint) => {
+      if (endpoint === "activeConnections") {
+        return { data: { 1: {}, 2: {} }, error: undefined };
+      }
+      if (endpoint === "connections") {
+        return { data: { 1: {}, 2: {}, 3: {}, 4: {} }, error: undefined };
+      }
+      if (endpoint === "users") {
+        return { data: { 1: {}, 2: {}, 3: {} }, error: undefined };
+      }
+      return { data: undefined, error: undefined };
+    });
+
+    const { container } = renderWithProviders(<Component service={{ widget: { type: "guacamole" } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expectBlockValue(container, "guacamole.active", 2);
+    expectBlockValue(container, "guacamole.connections", 4);
+    expectBlockValue(container, "guacamole.users", 3);
+  });
+});

--- a/src/widgets/guacamole/proxy.js
+++ b/src/widgets/guacamole/proxy.js
@@ -1,0 +1,106 @@
+import cache from "memory-cache";
+
+import getServiceWidget from "utils/config/service-helpers";
+import createLogger from "utils/logger";
+import { formatApiCall } from "utils/proxy/api-helpers";
+import { httpProxy } from "utils/proxy/http";
+import widgets from "widgets/widgets";
+
+const proxyName = "guacamoleProxyHandler";
+const tokenCacheKey = `${proxyName}__token`;
+const dataSourceCacheKey = `${proxyName}__dataSource`;
+const logger = createLogger(proxyName);
+
+async function login(widget, service) {
+  const loginUrl = `${widget.url.replace(/\/+$/, "")}/api/tokens`;
+  const body = new URLSearchParams({ username: widget.username, password: widget.password }).toString();
+
+  const [status, , data] = await httpProxy(loginUrl, {
+    method: "POST",
+    body,
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+  });
+
+  if (status !== 200) {
+    return [status, null, null, data];
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(Buffer.from(data).toString());
+  } catch (e) {
+    logger.error("Error parsing Guacamole login response: %s", e);
+    return [500, null, null, data];
+  }
+
+  const dataSource = widget.datasource || parsed.dataSource;
+  cache.put(`${tokenCacheKey}.${service}`, parsed.authToken);
+  cache.put(`${dataSourceCacheKey}.${service}`, dataSource);
+
+  return [status, parsed.authToken, dataSource, data];
+}
+
+export default async function guacamoleProxyHandler(req, res) {
+  const { group, service, endpoint, index } = req.query;
+
+  if (!group || !service) {
+    logger.debug("Invalid or missing service '%s' or group '%s'", service, group);
+    return res.status(400).json({ error: "Invalid proxy service type" });
+  }
+
+  const widget = await getServiceWidget(group, service, index);
+
+  if (!widget) {
+    logger.debug("Invalid or missing widget for service '%s' in group '%s'", service, group);
+    return res.status(400).json({ error: "Invalid proxy service type" });
+  }
+
+  if (!widgets?.[widget.type]?.api) {
+    return res.status(403).json({ error: "Service does not support API calls" });
+  }
+
+  let token = cache.get(`${tokenCacheKey}.${service}`);
+  let dataSource = cache.get(`${dataSourceCacheKey}.${service}`);
+
+  if (!token || !dataSource) {
+    let status;
+    let data;
+    [status, token, dataSource, data] = await login(widget, service);
+    if (status !== 200) {
+      logger.debug(`HTTP ${status} logging into Guacamole api: ${data}`);
+      return res.status(status).send(data);
+    }
+  }
+
+  const buildUrl = () => {
+    const url = new URL(formatApiCall(widgets[widget.type].api, { endpoint, ...widget, datasource: dataSource }));
+    url.searchParams.set("token", token);
+    return url;
+  };
+
+  let [status, contentType, data] = await httpProxy(buildUrl(), { method: "GET" });
+
+  if (status === 401 || status === 403) {
+    logger.debug(`HTTP ${status} retrieving data from Guacamole api, logging in and trying again.`);
+    cache.del(`${tokenCacheKey}.${service}`);
+    cache.del(`${dataSourceCacheKey}.${service}`);
+
+    let loginStatus;
+    [loginStatus, token, dataSource, data] = await login(widget, service);
+
+    if (loginStatus !== 200) {
+      logger.debug(`HTTP ${loginStatus} logging into Guacamole api: ${data}`);
+      return res.status(loginStatus).send(data);
+    }
+
+    [status, contentType, data] = await httpProxy(buildUrl(), { method: "GET" });
+  }
+
+  if (status !== 200) {
+    logger.error("HTTP %d getting data from Guacamole endpoint %s", status, endpoint);
+    return res.status(status).send(data);
+  }
+
+  if (contentType) res.setHeader("Content-Type", contentType);
+  return res.status(status).send(data);
+}

--- a/src/widgets/guacamole/proxy.test.js
+++ b/src/widgets/guacamole/proxy.test.js
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import createMockRes from "test-utils/create-mock-res";
+
+const { httpProxy, getServiceWidget, cache, logger } = vi.hoisted(() => {
+  const store = new Map();
+
+  return {
+    httpProxy: vi.fn(),
+    getServiceWidget: vi.fn(),
+    cache: {
+      get: vi.fn((k) => store.get(k)),
+      put: vi.fn((k, v) => store.set(k, v)),
+      del: vi.fn((k) => store.delete(k)),
+      _reset: () => store.clear(),
+    },
+    logger: {
+      debug: vi.fn(),
+      error: vi.fn(),
+    },
+  };
+});
+
+vi.mock("utils/logger", () => ({
+  default: () => logger,
+}));
+
+vi.mock("utils/config/service-helpers", () => ({
+  default: getServiceWidget,
+}));
+
+vi.mock("utils/proxy/http", () => ({
+  httpProxy,
+}));
+
+vi.mock("memory-cache", () => ({
+  default: cache,
+  ...cache,
+}));
+
+vi.mock("widgets/widgets", () => ({
+  default: {
+    guacamole: {
+      api: "{url}/api/session/data/{datasource}/{endpoint}",
+    },
+  },
+}));
+
+import guacamoleProxyHandler from "./proxy";
+
+describe("widgets/guacamole/proxy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cache._reset();
+  });
+
+  it("logs in when no session is cached and requests data using the returned token and dataSource", async () => {
+    getServiceWidget.mockResolvedValue({
+      type: "guacamole",
+      url: "http://guacamole",
+      username: "u",
+      password: "p",
+    });
+
+    httpProxy
+      .mockResolvedValueOnce([
+        200,
+        "application/json",
+        Buffer.from(JSON.stringify({ authToken: "t1", dataSource: "mysql" })),
+      ])
+      .mockResolvedValueOnce([200, "application/json", Buffer.from("data")]);
+
+    const req = { query: { group: "g", service: "svc", endpoint: "activeConnections", index: "0" } };
+    const res = createMockRes();
+
+    await guacamoleProxyHandler(req, res);
+
+    expect(httpProxy).toHaveBeenCalledTimes(2);
+    expect(httpProxy.mock.calls[0][0]).toBe("http://guacamole/api/tokens");
+
+    const dataUrl = httpProxy.mock.calls[1][0];
+    expect(dataUrl.toString()).toBe("http://guacamole/api/session/data/mysql/activeConnections?token=t1");
+    expect(res.body).toEqual(Buffer.from("data"));
+  });
+
+  it("retries after a 403 response by clearing the cached session and logging in again", async () => {
+    cache.put("guacamoleProxyHandler__token.svc", "old");
+    cache.put("guacamoleProxyHandler__dataSource.svc", "mysql");
+
+    getServiceWidget.mockResolvedValue({
+      type: "guacamole",
+      url: "http://guacamole",
+      username: "u",
+      password: "p",
+    });
+
+    httpProxy
+      .mockResolvedValueOnce([403, "application/json", Buffer.from("nope")])
+      .mockResolvedValueOnce([
+        200,
+        "application/json",
+        Buffer.from(JSON.stringify({ authToken: "new", dataSource: "mysql" })),
+      ])
+      .mockResolvedValueOnce([200, "application/json", Buffer.from("ok")]);
+
+    const req = { query: { group: "g", service: "svc", endpoint: "activeConnections", index: "0" } };
+    const res = createMockRes();
+
+    await guacamoleProxyHandler(req, res);
+
+    expect(httpProxy).toHaveBeenCalledTimes(3);
+    expect(httpProxy.mock.calls[0][0].toString()).toContain("token=old");
+    expect(httpProxy.mock.calls[1][0]).toBe("http://guacamole/api/tokens");
+    expect(httpProxy.mock.calls[2][0].toString()).toContain("token=new");
+    expect(res.body).toEqual(Buffer.from("ok"));
+  });
+
+  it("prefers an explicitly configured dataSource over the one returned at login", async () => {
+    getServiceWidget.mockResolvedValue({
+      type: "guacamole",
+      url: "http://guacamole",
+      username: "u",
+      password: "p",
+      datasource: "ldap",
+    });
+
+    httpProxy
+      .mockResolvedValueOnce([
+        200,
+        "application/json",
+        Buffer.from(JSON.stringify({ authToken: "t1", dataSource: "mysql" })),
+      ])
+      .mockResolvedValueOnce([200, "application/json", Buffer.from("data")]);
+
+    const req = { query: { group: "g", service: "svc", endpoint: "users", index: "0" } };
+    const res = createMockRes();
+
+    await guacamoleProxyHandler(req, res);
+
+    expect(httpProxy.mock.calls[1][0].toString()).toBe("http://guacamole/api/session/data/ldap/users?token=t1");
+  });
+});

--- a/src/widgets/guacamole/widget.js
+++ b/src/widgets/guacamole/widget.js
@@ -1,0 +1,20 @@
+import guacamoleProxyHandler from "./proxy";
+
+const widget = {
+  api: "{url}/api/session/data/{datasource}/{endpoint}",
+  proxyHandler: guacamoleProxyHandler,
+
+  mappings: {
+    activeConnections: {
+      endpoint: "activeConnections",
+    },
+    connections: {
+      endpoint: "connections",
+    },
+    users: {
+      endpoint: "users",
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/guacamole/widget.test.js
+++ b/src/widgets/guacamole/widget.test.js
@@ -1,0 +1,11 @@
+import { describe, it } from "vitest";
+
+import { expectWidgetConfigShape } from "test-utils/widget-config";
+
+import widget from "./widget";
+
+describe("guacamole widget config", () => {
+  it("exports a valid widget config", () => {
+    expectWidgetConfigShape(widget);
+  });
+});

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -46,6 +46,7 @@ import glances from "./glances/widget";
 import gluetun from "./gluetun/widget";
 import gotify from "./gotify/widget";
 import grafana from "./grafana/widget";
+import guacamole from "./guacamole/widget";
 import hdhomerun from "./hdhomerun/widget";
 import headscale from "./headscale/widget";
 import healthchecks from "./healthchecks/widget";
@@ -202,6 +203,7 @@ const widgets = {
   gluetun,
   gotify,
   grafana,
+  guacamole,
   hdhomerun,
   headscale,
   hoarder: karakeep,


### PR DESCRIPTION
## Summary
- Adds a `guacamole` widget that shows active session, connection, and user counts for an [Apache Guacamole](https://guacamole.apache.org/) server.
- Guacamole's REST API authenticates via `POST /api/tokens` (username/password) and requires the returned token as a `?token=` query param on every subsequent request, so this adds a custom proxy handler (`src/widgets/guacamole/proxy.js`) that logs in, caches the token + resolved data source, and re-authenticates automatically on a 401/403 — modeled on the existing `npm` widget's login/retry pattern.
- An optional `datasource` config field lets users pin a specific auth provider (e.g. `ldap`) instead of the default one returned at login.

## Test plan
- [x] `pnpm vitest run src/widgets/guacamole` — 7 tests passing (widget config shape, proxy login/retry/datasource-override, component loading/error/data states)
- [x] `pnpm eslint` / `pnpm prettier --check` clean on new files
- [x] Ran `pnpm dev` locally against a live Guacamole instance and hit `/api/services/proxy` directly for all three mappings (`activeConnections`, `connections`, `users`); each returned real data (correct auth token flow, correct counts) matching the instance's actual state

🤖 Generated with [Claude Code](https://claude.com/claude-code)