### PR TITLE
Feature: qui widget

### DIFF
--- a/docs/widgets/services/qui.md
+++ b/docs/widgets/services/qui.md
@@ -1,0 +1,44 @@
+---
+title: qui
+description: qui Widget Configuration
+---
+
+Learn more about [qui](https://github.com/autobrr/qui).
+
+qui manages one or more qBittorrent instances behind a single web UI. The widget shows transfer
+stats and authenticates with a qui API key, so you never expose a qBittorrent WebUI password.
+
+Generate an API key in qui under **Settings → API Keys**.
+
+The widget has two modes:
+
+- **Aggregated (default):** omit `instance` to show combined stats across all qBittorrent instances monitored by qui.
+- **Per-instance:** set `instance` to the numeric ID qui assigns to a qBittorrent instance to show
+  just that one. Add one widget per instance. The ID is visible in the qui UI URL when an instance is
+  selected (`/instances/1/...`) or via `GET {url}/api/instances`.
+
+```yaml
+widget:
+  type: qui
+  url: http://qui.host.or.ip:7476
+  key: quiapikeyquiapikeyquiapikey
+  instance: 1 # optional; omit for aggregated stats across all instances
+  fields: ["leech", "download", "seed", "upload"] # optional
+```
+
+## Fields
+
+`leech` and `seed` are shown as `active / total` — torrents actively transferring over the
+incomplete/complete totals.
+
+Allowed fields: `["leech", "download", "seed", "upload", "total", "errored", "ratio", "freeSpace"]`
+(maximum of 4). The default is `["leech", "download", "seed", "upload"]`.
+
+- `leech`: active downloading / incomplete torrents
+- `download`: total download speed
+- `seed`: active seeding / complete torrents
+- `upload`: total upload speed
+- `total`: total number of torrents
+- `errored`: number of errored torrents
+- `ratio`: global share ratio (per-instance only; unavailable in aggregated mode)
+- `freeSpace`: free disk space (per-instance only; unavailable in aggregated mode)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -146,6 +146,7 @@ nav:
           - widgets/services/pyload.md
           - widgets/services/qbittorrent.md
           - widgets/services/qnap.md
+          - widgets/services/qui.md
           - widgets/services/radarr.md
           - widgets/services/readarr.md
           - widgets/services/romm.md

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -236,6 +236,16 @@
         "leech": "Leech",
         "seed": "Seed"
     },
+    "qui": {
+        "leech": "Leech",
+        "download": "Download",
+        "seed": "Seed",
+        "upload": "Upload",
+        "total": "Total",
+        "errored": "Errored",
+        "ratio": "Ratio",
+        "freeSpace": "Free"
+    },
     "qnap": {
         "cpuUsage": "CPU Usage",
         "memUsage": "MEM Usage",

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -396,6 +396,9 @@ export function cleanServiceGroups(groups) {
           // proxmoxbackupserver
           datastore,
 
+          // qui
+          instance,
+
           // speedtest
           bitratePrecision,
 
@@ -505,6 +508,9 @@ export function cleanServiceGroups(groups) {
         }
         if (type === "portainer") {
           if (kubernetes) widget.kubernetes = !!JSON.parse(kubernetes);
+        }
+        if (type === "qui") {
+          if (instance !== undefined) widget.instance = instance;
         }
         if (type === "proxmox") {
           if (node) widget.node = node;

--- a/src/utils/proxy/handlers/credentialed.js
+++ b/src/utils/proxy/handlers/credentialed.js
@@ -88,6 +88,8 @@ export default async function credentialedProxyHandler(req, res, map) {
       } else if (widget.type === "proxmoxbackupserver") {
         delete headers["Content-Type"];
         headers.Authorization = `PBSAPIToken=${widget.username}:${widget.password}`;
+      } else if (widget.type === "qui") {
+        headers["X-API-Key"] = `${widget.key}`;
       } else if (["autobrr", "jellystat", "pulse"].includes(widget.type)) {
         headers["X-API-Token"] = `${widget.key}`;
       } else if (widget.type === "tubearchivist") {

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -120,6 +120,7 @@ const components = {
   pyload: dynamic(() => import("./pyload/component")),
   qbittorrent: dynamic(() => import("./qbittorrent/component")),
   qnap: dynamic(() => import("./qnap/component")),
+  qui: dynamic(() => import("./qui/component")),
   radarr: dynamic(() => import("./radarr/component")),
   readarr: dynamic(() => import("./readarr/component")),
   romm: dynamic(() => import("./romm/component")),

--- a/src/widgets/qui/component.jsx
+++ b/src/widgets/qui/component.jsx
@@ -1,0 +1,81 @@
+import Block from "components/services/widget/block";
+import Container from "components/services/widget/container";
+import { useTranslation } from "next-i18next/pages";
+
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+  const { widget } = service;
+
+  // A specific instance id selects per-instance stats; otherwise aggregate all instances.
+  const perInstance = widget.instance != null && widget.instance !== "";
+  const mapping = perInstance ? "torrents" : "torrentsAll";
+  const { data: torrentData, error: torrentError } = useWidgetAPI(widget, mapping);
+
+  const wantsField = (field) => widget.fields?.includes(field);
+
+  if (torrentError) {
+    return <Container service={service} error={torrentError} />;
+  }
+
+  if (!torrentData || !torrentData.stats) {
+    return (
+      <Container service={service}>
+        <Block label="qui.leech" />
+        <Block label="qui.download" />
+        <Block label="qui.seed" />
+        <Block label="qui.upload" />
+        {wantsField("total") && <Block label="qui.total" />}
+        {wantsField("errored") && <Block label="qui.errored" />}
+        {wantsField("ratio") && <Block label="qui.ratio" />}
+        {wantsField("freeSpace") && <Block label="qui.freeSpace" />}
+      </Container>
+    );
+  }
+
+  const { stats } = torrentData;
+  const status = torrentData.counts?.status;
+  const serverState = torrentData.serverState;
+
+  // counts.status uses qBittorrent's sidebar semantics (complete vs incomplete). Seed/Leech show
+  // "active / total" — actively transferring over complete/incomplete. Fall back to stats-only.
+  const completed = status ? status.completed : stats.seeding;
+  const incomplete = status ? status.all - status.completed : stats.downloading;
+  const activeUp = stats.seeding;
+  const activeDl = stats.downloading;
+  const seedValue = `${t("common.number", { value: activeUp })} / ${t("common.number", { value: completed })}`;
+  const leechValue = `${t("common.number", { value: activeDl })} / ${t("common.number", { value: incomplete })}`;
+
+  return (
+    <Container service={service}>
+      <Block label="qui.leech" value={leechValue} />
+      <Block
+        label="qui.download"
+        value={t("common.bibyterate", { value: stats.totalDownloadSpeed, decimals: 1 })}
+        highlightValue={stats.totalDownloadSpeed}
+      />
+      <Block label="qui.seed" value={seedValue} />
+      <Block
+        label="qui.upload"
+        value={t("common.bibyterate", { value: stats.totalUploadSpeed, decimals: 1 })}
+        highlightValue={stats.totalUploadSpeed}
+      />
+      {wantsField("total") && (
+        <Block label="qui.total" value={t("common.number", { value: status ? status.all : stats.total })} />
+      )}
+      {wantsField("errored") && (
+        <Block label="qui.errored" value={t("common.number", { value: status ? status.errored : stats.error })} />
+      )}
+      {wantsField("ratio") && serverState && (
+        <Block label="qui.ratio" value={t("common.number", { value: parseFloat(serverState.global_ratio) })} />
+      )}
+      {wantsField("freeSpace") && serverState && (
+        <Block
+          label="qui.freeSpace"
+          value={t("common.bbytes", { value: serverState.free_space_on_disk, maximumFractionDigits: 1 })}
+        />
+      )}
+    </Container>
+  );
+}

--- a/src/widgets/qui/component.test.jsx
+++ b/src/widgets/qui/component.test.jsx
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+
+import { screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "test-utils/render-with-providers";
+import { expectBlockValue } from "test-utils/widget-assertions";
+
+const { useWidgetAPI } = vi.hoisted(() => ({ useWidgetAPI: vi.fn() }));
+vi.mock("utils/proxy/use-widget-api", () => ({ default: useWidgetAPI }));
+
+import Component from "./component";
+
+// Aggregated response (cross-instance) — no serverState, as qui can't merge it.
+const aggregatedData = {
+  stats: { downloading: 1, seeding: 2, totalDownloadSpeed: 100, totalUploadSpeed: 200, total: 10, error: 0 },
+  counts: { status: { all: 10, completed: 8, errored: 3 } },
+};
+
+// Per-instance response — includes serverState (ratio / free space).
+const perInstanceData = {
+  stats: { downloading: 0, seeding: 3, totalDownloadSpeed: 0, totalUploadSpeed: 141939, total: 6477, error: 0 },
+  counts: { status: { all: 6477, completed: 6477, errored: 0 } },
+  serverState: { global_ratio: "8.58", free_space_on_disk: 49820224065536 },
+};
+
+describe("widgets/qui/component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders four placeholder blocks while loading", () => {
+    useWidgetAPI.mockReturnValue({ data: undefined, error: undefined });
+
+    const { container } = renderWithProviders(<Component service={{ widget: { type: "qui" } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expect(container.querySelectorAll(".service-block")).toHaveLength(4);
+    expect(screen.getByText("qui.leech")).toBeInTheDocument();
+    expect(screen.getByText("qui.download")).toBeInTheDocument();
+    expect(screen.getByText("qui.seed")).toBeInTheDocument();
+    expect(screen.getByText("qui.upload")).toBeInTheDocument();
+  });
+
+  it("shows placeholders for selected optional fields while loading", () => {
+    useWidgetAPI.mockReturnValue({ data: undefined, error: undefined });
+
+    const service = { widget: { type: "qui", instance: 1, fields: ["seed", "ratio"] } };
+    const { container } = renderWithProviders(<Component service={service} />, { settings: { hideErrors: false } });
+
+    // Container filters placeholders by fields, so an optional placeholder must exist to be shown.
+    expect(container.querySelectorAll(".service-block")).toHaveLength(2);
+    expect(screen.getByText("qui.seed")).toBeInTheDocument();
+    expect(screen.getByText("qui.ratio")).toBeInTheDocument();
+  });
+
+  it("renders error UI when the endpoint errors", () => {
+    useWidgetAPI.mockReturnValue({ data: undefined, error: { message: "nope" } });
+
+    renderWithProviders(<Component service={{ widget: { type: "qui" } }} />, { settings: { hideErrors: false } });
+
+    expect(screen.getAllByText(/widget\.api_error/i).length).toBeGreaterThan(0);
+    expect(screen.getByText("nope")).toBeInTheDocument();
+  });
+
+  it("uses the aggregated endpoint and shows active/total for seed and leech", () => {
+    useWidgetAPI.mockReturnValue({ data: aggregatedData, error: undefined });
+
+    const { container } = renderWithProviders(<Component service={{ widget: { type: "qui" } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    // No instance id -> aggregated (cross-instance) mapping.
+    expect(useWidgetAPI).toHaveBeenCalledWith(expect.anything(), "torrentsAll");
+
+    expect(container.querySelectorAll(".service-block")).toHaveLength(4);
+    expectBlockValue(container, "qui.leech", "1 / 2"); // active downloading / incomplete (all - completed)
+    expectBlockValue(container, "qui.download", "100");
+    expectBlockValue(container, "qui.seed", "2 / 8"); // active seeding / completed
+    expectBlockValue(container, "qui.upload", "200");
+  });
+
+  it("uses the per-instance endpoint and renders serverState-backed ratio and freeSpace", () => {
+    useWidgetAPI.mockReturnValue({ data: perInstanceData, error: undefined });
+
+    const service = { widget: { type: "qui", instance: 1, fields: ["seed", "upload", "ratio", "freeSpace"] } };
+    const { container } = renderWithProviders(<Component service={service} />, { settings: { hideErrors: false } });
+
+    // Instance id set -> per-instance mapping.
+    expect(useWidgetAPI).toHaveBeenCalledWith(expect.anything(), "torrents");
+
+    expect(container.querySelectorAll(".service-block")).toHaveLength(4);
+    expectBlockValue(container, "qui.seed", "3 / 6477");
+    expectBlockValue(container, "qui.upload", "141939");
+    expectBlockValue(container, "qui.ratio", "8.58");
+    expectBlockValue(container, "qui.freeSpace", "49820224065536");
+  });
+
+  it("renders the optional total and errored fields when selected", () => {
+    useWidgetAPI.mockReturnValue({ data: aggregatedData, error: undefined });
+
+    const service = { widget: { type: "qui", fields: ["total", "errored"] } };
+    const { container } = renderWithProviders(<Component service={service} />, { settings: { hideErrors: false } });
+
+    expect(container.querySelectorAll(".service-block")).toHaveLength(2);
+    expectBlockValue(container, "qui.total", "10");
+    expectBlockValue(container, "qui.errored", "3");
+  });
+
+  it("omits ratio/freeSpace in aggregated mode where serverState is absent", () => {
+    useWidgetAPI.mockReturnValue({ data: aggregatedData, error: undefined });
+
+    const service = { widget: { type: "qui", fields: ["seed", "ratio", "freeSpace"] } };
+    const { container } = renderWithProviders(<Component service={service} />, { settings: { hideErrors: false } });
+
+    expect(screen.getByText("qui.seed")).toBeInTheDocument();
+    expect(screen.queryByText("qui.ratio")).toBeNull();
+    expect(screen.queryByText("qui.freeSpace")).toBeNull();
+    expect(container.querySelectorAll(".service-block")).toHaveLength(1);
+  });
+});

--- a/src/widgets/qui/widget.js
+++ b/src/widgets/qui/widget.js
@@ -1,0 +1,19 @@
+import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
+
+const widget = {
+  api: "{url}/api/{endpoint}",
+  proxyHandler: credentialedProxyHandler,
+
+  mappings: {
+    torrents: {
+      endpoint: "instances/{instance}/torrents?limit=1",
+      validate: ["stats"],
+    },
+    torrentsAll: {
+      endpoint: "torrents/cross-instance?limit=1",
+      validate: ["stats"],
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/qui/widget.test.js
+++ b/src/widgets/qui/widget.test.js
@@ -1,0 +1,11 @@
+import { describe, it } from "vitest";
+
+import { expectWidgetConfigShape } from "test-utils/widget-config";
+
+import widget from "./widget";
+
+describe("qui widget config", () => {
+  it("exports a valid widget config", () => {
+    expectWidgetConfigShape(widget);
+  });
+});

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -110,6 +110,7 @@ import pulse from "./pulse/widget";
 import pyload from "./pyload/widget";
 import qbittorrent from "./qbittorrent/widget";
 import qnap from "./qnap/widget";
+import qui from "./qui/widget";
 import radarr from "./radarr/widget";
 import readarr from "./readarr/widget";
 import romm from "./romm/widget";
@@ -271,6 +272,7 @@ const widgets = {
   pyload,
   qbittorrent,
   qnap,
+  qui,
   radarr,
   readarr,
   romm,


### PR DESCRIPTION
## Proposed change

Adds a new service widget for [qui](https://github.com/autobrr/qui) (single-binary webui for managing several qBittorrent instance).

It has two modes, both reading the same `TorrentStats`/`counts` shape from qui:
- **Aggregated (default):** omit `instance` → combined stats across all qui instances (`GET /api/torrents/cross-instance`).
- **Per-instance:** set `instance: <id>` → a single instance (`GET /api/instances/{id}/torrents`). One tile can replace one Bittorrent widget.

Closes #6604 (less than 20 upvotes, but got 4200 stars).

AI disclosure: a good part of this PR was written with the help of Claude Code, reviewed and tested by me (human).

## Type of change

- [X] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [X] If applicable, I have added corresponding documentation changes.
- [X] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [X] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [X] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [X] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. (tested on desktop & with chrome mobile mode)
- [X] In the description above I have disclosed the use of AI tools in the coding of this PR.
