### PR TITLE
feat(dockhand): support API token (Bearer) authentication

### DIFF
--- a/docs/widgets/services/dockhand.md
+++ b/docs/widgets/services/dockhand.md
@@ -5,10 +5,22 @@ description: Dockhand Widget Configuration
 
 Learn more about [Dockhand](https://dockhand.pro/).
 
-Note: The widget currently supports Dockhand's **local** authentication only.
+Authenticate with either a Dockhand [API token](https://dockhand.pro/manual/#api-authentication) (recommended) or Dockhand's local username/password. A token is scoped to the user that created it and can be revoked without changing your password, so it's preferable to storing account credentials in your config. If both are provided, the token is used.
 
 **Allowed fields:** (max 4): `running`, `stopped`, `paused`, `total`, `cpu`, `memory`, `images`, `volumes`, `events_today`, `pending_updates`, `stacks`.
 **Default fields:** `running`, `total`, `cpu`, `memory`.
+
+Using an API token:
+
+```yaml
+widget:
+  type: dockhand
+  url: http://localhost:3001
+  environment: local # optional: name or id; aggregates all when omitted
+  key: dockhandapitoken # generate under Settings in Dockhand
+```
+
+Using local authentication:
 
 ```yaml
 widget:

--- a/src/widgets/dockhand/proxy.js
+++ b/src/widgets/dockhand/proxy.js
@@ -38,12 +38,18 @@ export default async function dockhandProxyHandler(req, res) {
 
   const url = new URL(formatApiCall(widgets[widget.type].api, { endpoint, ...widget }));
 
+  // A Dockhand API token (Bearer) takes precedence over username/password. See
+  // https://dockhand.pro/manual/#api-authentication
+  const headers = widget.key ? { Authorization: `Bearer ${widget.key}` } : {};
+
   let [status, contentType, data] = await httpProxy(url, {
     method: req.method,
+    headers,
   });
 
-  // Attempt login and retrying once
-  if (status === 401) {
+  // Fall back to a username/password session login and retry once. Skipped when a
+  // token is configured, since a 401 there means the token itself is invalid.
+  if (status === 401 && !widget.key) {
     const loggedIn = await login(widget);
     if (loggedIn) {
       [status, contentType, data] = await httpProxy(url, {

--- a/src/widgets/dockhand/proxy.test.js
+++ b/src/widgets/dockhand/proxy.test.js
@@ -59,6 +59,45 @@ describe("widgets/dockhand/proxy", () => {
     expect(res.body).toEqual(Buffer.from("data"));
   });
 
+  it("sends a bearer token and does not log in when a key is configured", async () => {
+    getServiceWidget.mockResolvedValue({
+      type: "dockhand",
+      url: "http://dockhand/",
+      key: "dh_abc123",
+    });
+
+    httpProxy.mockResolvedValueOnce([200, "application/json", Buffer.from("data")]);
+
+    const req = { method: "GET", query: { group: "g", service: "svc", endpoint: "api/v1/status", index: "0" } };
+    const res = createMockRes();
+
+    await dockhandProxyHandler(req, res);
+
+    expect(httpProxy).toHaveBeenCalledTimes(1);
+    expect(httpProxy.mock.calls[0][1].headers).toEqual({ Authorization: "Bearer dh_abc123" });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(Buffer.from("data"));
+  });
+
+  it("does not fall back to login on a 401 when a key is configured", async () => {
+    getServiceWidget.mockResolvedValue({
+      type: "dockhand",
+      url: "http://dockhand/",
+      key: "dh_bad",
+    });
+
+    httpProxy.mockResolvedValueOnce([401, "application/json", Buffer.from("nope")]);
+
+    const req = { method: "GET", query: { group: "g", service: "svc", endpoint: "api/v1/status", index: "0" } };
+    const res = createMockRes();
+
+    await dockhandProxyHandler(req, res);
+
+    // Only the initial request — no login attempt, no retry.
+    expect(httpProxy).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(401);
+  });
+
   it("returns a sanitized error response for HTTP errors", async () => {
     getServiceWidget.mockResolvedValue({
       type: "dockhand",


### PR DESCRIPTION
## What

Adds an optional `key` to the Dockhand widget so it can authenticate with a Dockhand API token (sent as `Authorization: Bearer <key>`) instead of a username/password.

## Why

Dockhand added user-scoped API token auth in v1.0.25 (docs: https://dockhand.pro/manual/#api-authentication), but the widget still only supported local username/password login. Putting a full account username/password in `services.yaml` grants the widget the whole account for what is a read-only status readout. An API token is scoped to the creating user and can be revoked without changing the password — the safer, more conventional pattern for a dashboard integration.

Dockhand implemented this partly with homepage in mind (Finsys/dockhand#729, also #543 / #817 / #254).

## Behavior

- If `key` is set, it is sent as a bearer token and takes precedence over username/password.
- The existing 401 -> session-login retry is skipped when a token is used (a 401 with a token means the token itself is invalid, so retrying via login is wrong).
- No change to the existing username/password flow.

## Testing

**Unit** (`src/widgets/dockhand/proxy.test.js`) — added two cases: the bearer token is sent with no login call, and there is no login fallback on a 401 when a token is configured. Existing tests unchanged. `vitest run`, `prettier --check`, and `eslint` all pass.

**Verified against a real instance** — tested end-to-end against a live **Dockhand v1.0.36** deployment on the `/api/dashboard/stats` endpoint the widget uses:

| Scenario | Result |
| --- | --- |
| No auth header | `HTTP 401` (auth enforced) |
| Invalid bearer token | `HTTP 401` |
| Valid `Authorization: Bearer <token>` | `HTTP 200` + full stats JSON |

The returned JSON contained every field the widget maps (`running`, `stopped`, `paused`, `total`, `cpu`, `memory`, `images`, `volumes`, `events_today`, `pending_updates`, `stacks`), confirming the token path returns the same shape as the existing username/password path.

---

_Disclosure: this PR was drafted with the help of an AI coding assistant. All changes were reviewed by me and verified working against a real Dockhand instance as described above._
