### PR TITLE
i18n(ko): add missing Proxmox Pulse widget translations

### DIFF
--- a/public/locales/ko/common.json
+++ b/public/locales/ko/common.json
@@ -466,6 +466,11 @@
         "lxc": "LXC",
         "vms": "가상머신"
     },
+    "pulse": {
+        "nodes": "노드",
+        "vms": "가상머신",
+        "lxcs": "LXC"
+    },
     "glances": {
         "cpu": "CPU",
         "load": "부하",


### PR DESCRIPTION
## Proposed change

The Proxmox Pulse widget introduced new strings (`pulse.nodes`, `pulse.vms`, `pulse.lxcs`) in `public/locales/en/common.json`, but the Korean locale (`public/locales/ko/common.json`) was never updated to include them, leaving the pulse widget partially untranslated for Korean users.

This PR adds the 3 missing keys to `public/locales/ko/common.json`, reusing the same terminology already used for the existing `proxmox` widget strings in the same file (`vms` → 가상머신, `lxc`/`lxcs` → LXC) and the `nodes` term used elsewhere (e.g. `pterodactyl.nodes` → 노드), for consistency.

After this change, `ko/common.json` has 100% key parity with `en/common.json` (893/893 keys).

No other files were touched.

Closes # (issue)

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [x] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [ ] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] In the description above I have disclosed the use of AI tools in the coding of this PR.

## Disclosure of AI tool use

This translation fill was drafted with the assistance of an AI coding tool (Claude), which identified the 3 missing keys by diffing `en/common.json` against `ko/common.json`, filled them by matching the terminology already used elsewhere in the same file, and verified 100% key parity afterward. I (the PR author) reviewed and take responsibility for the translated content before submitting.
