### PR TITLE
Add Tugtainer service widget

### DIFF
--- a/docs/widgets/services/index.md
+++ b/docs/widgets/services/index.md
@@ -141,6 +141,7 @@ You can also find a list of all available service widgets in the sidebar navigat
 - [Trilium](trilium.md)
 - [TrueNAS](truenas.md)
 - [TubeArchivist](tubearchivist.md)
+- [Tugtainer](tugtainer.md)
 - [UniFi Controller](unifi-controller.md)
 - [Unmanic](unmanic.md)
 - [Unraid](unraid.md)

--- a/docs/widgets/services/tugtainer.md
+++ b/docs/widgets/services/tugtainer.md
@@ -1,0 +1,16 @@
+---
+title: Tugtainer
+description: Tugtainer Widget Configuration
+---
+
+Learn more about [Tugtainer](https://github.com/Quenary/tugtainer).
+
+This widget uses Tugtainer's public API under `/api/public/*`.
+
+Allowed fields: fixed v1 layout with `total_containers`, `running_containers`, `update_count`.
+
+```yaml
+widget:
+  type: tugtainer
+  url: http://192.168.0.2:9011
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -173,6 +173,7 @@ nav:
           - widgets/services/trilium.md
           - widgets/services/truenas.md
           - widgets/services/tubearchivist.md
+          - widgets/services/tugtainer.md
           - widgets/services/unifi-controller.md
           - widgets/services/unifi-drive.md
           - widgets/services/unmanic.md

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -585,6 +585,11 @@
         "containers_updated": "Updated",
         "containers_failed": "Failed"
     },
+    "tugtainer": {
+        "total_containers": "Total",
+        "running_containers": "Running",
+        "update_count": "Updates"
+    },
     "autobrr": {
         "approvedPushes": "Approved",
         "rejectedPushes": "Rejected",

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -147,6 +147,7 @@ const components = {
   transmission: dynamic(() => import("./transmission/component")),
   trilium: dynamic(() => import("./trilium/component")),
   tubearchivist: dynamic(() => import("./tubearchivist/component")),
+  tugtainer: dynamic(() => import("./tugtainer/component")),
   truenas: dynamic(() => import("./truenas/component")),
   unifi: dynamic(() => import("./unifi/component")),
   unifi_drive: dynamic(() => import("./unifi_drive/component")),

--- a/src/widgets/tugtainer/component.jsx
+++ b/src/widgets/tugtainer/component.jsx
@@ -1,0 +1,67 @@
+import Block from "components/services/widget/block";
+import Container from "components/services/widget/container";
+import { useTranslation } from "next-i18next/pages";
+
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+function getSummaryError(summaryData) {
+  if (!summaryData) {
+    return null;
+  }
+
+  if (!Array.isArray(summaryData) || summaryData.length === 0) {
+    return { message: "Invalid data", data: summaryData };
+  }
+
+  const host = summaryData[0];
+  if (typeof host?.total_containers !== "number" || typeof host?.by_status !== "object" || host?.by_status === null) {
+    return { message: "Invalid data", data: summaryData };
+  }
+
+  return null;
+}
+
+function getUpdateCountError(updateCountData) {
+  if (!updateCountData) {
+    return null;
+  }
+
+  if (typeof updateCountData?.total_updates !== "number") {
+    return { message: "Invalid data", data: updateCountData };
+  }
+
+  return null;
+}
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+  const { widget } = service;
+
+  const { data: summaryData, error: summaryError } = useWidgetAPI(widget, "summary");
+  const { data: updateCountData, error: updateCountError } = useWidgetAPI(widget, "update_count");
+
+  const dataError = summaryError ?? updateCountError ?? getSummaryError(summaryData) ?? getUpdateCountError(updateCountData);
+  if (dataError) {
+    return <Container service={service} error={dataError} />;
+  }
+
+  if (!summaryData || !updateCountData) {
+    return (
+      <Container service={service}>
+        <Block label="tugtainer.total_containers" />
+        <Block label="tugtainer.running_containers" />
+        <Block label="tugtainer.update_count" />
+      </Container>
+    );
+  }
+
+  const host = summaryData[0];
+
+  return (
+    <Container service={service}>
+      <Block label="tugtainer.total_containers" value={t("common.number", { value: host.total_containers })} />
+      <Block label="tugtainer.running_containers" value={t("common.number", { value: host.by_status.running ?? 0 })} />
+      <Block label="tugtainer.update_count" value={t("common.number", { value: updateCountData.total_updates })} />
+    </Container>
+  );
+}

--- a/src/widgets/tugtainer/component.jsx
+++ b/src/widgets/tugtainer/component.jsx
@@ -40,7 +40,8 @@ export default function Component({ service }) {
   const { data: summaryData, error: summaryError } = useWidgetAPI(widget, "summary");
   const { data: updateCountData, error: updateCountError } = useWidgetAPI(widget, "update_count");
 
-  const dataError = summaryError ?? updateCountError ?? getSummaryError(summaryData) ?? getUpdateCountError(updateCountData);
+  const dataError =
+    summaryError ?? updateCountError ?? getSummaryError(summaryData) ?? getUpdateCountError(updateCountData);
   if (dataError) {
     return <Container service={service} error={dataError} />;
   }

--- a/src/widgets/tugtainer/component.test.jsx
+++ b/src/widgets/tugtainer/component.test.jsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+
+import { screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "test-utils/render-with-providers";
+import { expectBlockValue } from "test-utils/widget-assertions";
+
+const { useWidgetAPI } = vi.hoisted(() => ({ useWidgetAPI: vi.fn() }));
+vi.mock("utils/proxy/use-widget-api", () => ({ default: useWidgetAPI }));
+
+import Component from "./component";
+
+describe("widgets/tugtainer/component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders placeholders while loading", () => {
+    useWidgetAPI.mockReturnValue({ data: undefined, error: undefined });
+
+    const { container } = renderWithProviders(<Component service={{ widget: { type: "tugtainer" } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expect(container.querySelectorAll(".service-block")).toHaveLength(3);
+    expect(screen.getByText("tugtainer.total_containers")).toBeInTheDocument();
+    expect(screen.getByText("tugtainer.running_containers")).toBeInTheDocument();
+    expect(screen.getByText("tugtainer.update_count")).toBeInTheDocument();
+  });
+
+  it("renders metrics when loaded", () => {
+    useWidgetAPI.mockImplementation((_widget, endpoint) => {
+      if (endpoint === "summary") {
+        return {
+          data: [{ total_containers: 22, by_status: { running: 20 } }],
+          error: undefined,
+        };
+      }
+
+      if (endpoint === "update_count") {
+        return {
+          data: { total_updates: 3 },
+          error: undefined,
+        };
+      }
+
+      return { data: undefined, error: undefined };
+    });
+
+    const { container } = renderWithProviders(<Component service={{ widget: { type: "tugtainer" } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expectBlockValue(container, "tugtainer.total_containers", 22);
+    expectBlockValue(container, "tugtainer.running_containers", 20);
+    expectBlockValue(container, "tugtainer.update_count", 3);
+  });
+
+  it("renders error UI when either request errors", () => {
+    useWidgetAPI.mockImplementation((_widget, endpoint) => {
+      if (endpoint === "summary") {
+        return { data: undefined, error: { message: "summary failed" } };
+      }
+
+      return { data: { total_updates: 1 }, error: undefined };
+    });
+
+    renderWithProviders(<Component service={{ widget: { type: "tugtainer" } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expect(screen.getAllByText(/widget\.api_error/i).length).toBeGreaterThan(0);
+    expect(screen.getByText("summary failed")).toBeInTheDocument();
+  });
+
+  it("renders error UI when summary is empty", () => {
+    useWidgetAPI.mockImplementation((_widget, endpoint) => {
+      if (endpoint === "summary") {
+        return { data: [], error: undefined };
+      }
+
+      return { data: { total_updates: 1 }, error: undefined };
+    });
+
+    renderWithProviders(<Component service={{ widget: { type: "tugtainer" } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expect(screen.getAllByText(/widget\.api_error/i).length).toBeGreaterThan(0);
+    expect(screen.getByText("Invalid data")).toBeInTheDocument();
+  });
+});

--- a/src/widgets/tugtainer/component.test.jsx
+++ b/src/widgets/tugtainer/component.test.jsx
@@ -90,4 +90,44 @@ describe("widgets/tugtainer/component", () => {
     expect(screen.getAllByText(/widget\.api_error/i).length).toBeGreaterThan(0);
     expect(screen.getByText("Invalid data")).toBeInTheDocument();
   });
+
+  it("renders error UI when summary payload is malformed", () => {
+    useWidgetAPI.mockImplementation((_widget, endpoint) => {
+      if (endpoint === "summary") {
+        return {
+          data: [{ total_containers: "22", by_status: null }],
+          error: undefined,
+        };
+      }
+
+      return { data: { total_updates: 1 }, error: undefined };
+    });
+
+    renderWithProviders(<Component service={{ widget: { type: "tugtainer" } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expect(screen.getAllByText(/widget\.api_error/i).length).toBeGreaterThan(0);
+    expect(screen.getByText("Invalid data")).toBeInTheDocument();
+  });
+
+  it("renders error UI when update_count payload is malformed", () => {
+    useWidgetAPI.mockImplementation((_widget, endpoint) => {
+      if (endpoint === "summary") {
+        return {
+          data: [{ total_containers: 22, by_status: { running: 20 } }],
+          error: undefined,
+        };
+      }
+
+      return { data: { total_updates: "3" }, error: undefined };
+    });
+
+    renderWithProviders(<Component service={{ widget: { type: "tugtainer" } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expect(screen.getAllByText(/widget\.api_error/i).length).toBeGreaterThan(0);
+    expect(screen.getByText("Invalid data")).toBeInTheDocument();
+  });
 });

--- a/src/widgets/tugtainer/widget.js
+++ b/src/widgets/tugtainer/widget.js
@@ -1,0 +1,17 @@
+import genericProxyHandler from "utils/proxy/handlers/generic";
+
+const widget = {
+  api: "{url}/api/public/{endpoint}",
+  proxyHandler: genericProxyHandler,
+
+  mappings: {
+    summary: {
+      endpoint: "summary",
+    },
+    update_count: {
+      endpoint: "update_count",
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/tugtainer/widget.test.js
+++ b/src/widgets/tugtainer/widget.test.js
@@ -1,0 +1,11 @@
+import { describe, it } from "vitest";
+
+import { expectWidgetConfigShape } from "test-utils/widget-config";
+
+import widget from "./widget";
+
+describe("tugtainer widget config", () => {
+  it("exports a valid widget config", () => {
+    expectWidgetConfigShape(widget);
+  });
+});

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -138,6 +138,7 @@ import transmission from "./transmission/widget";
 import trilium from "./trilium/widget";
 import truenas from "./truenas/widget";
 import tubearchivist from "./tubearchivist/widget";
+import tugtainer from "./tugtainer/widget";
 import unifi from "./unifi/widget";
 import unifi_drive from "./unifi_drive/widget";
 import unmanic from "./unmanic/widget";
@@ -298,6 +299,7 @@ const widgets = {
   transmission,
   trilium,
   tubearchivist,
+  tugtainer,
   truenas,
   unifi,
   unifi_console: unifi,


### PR DESCRIPTION
## Summary
- add a new `tugtainer` service widget using Tugtainer's public API under `/api/public/*`
- render fixed blocks for total containers, running containers, and update count
- add widget tests, service docs, and docs navigation entries

## Notes
- the widget uses the documented API shape but targets the working runtime path `/api/public/...`
- local `.local-config` changes used for verification are intentionally not included in this PR

## Testing
- `pnpm vitest run src/widgets/tugtainer/widget.test.js src/widgets/tugtainer/component.test.jsx`

Related discussion: https://github.com/gethomepage/homepage/discussions/5967
