### PR TITLE
Fix: auto-scale binary rate units instead of pinning to MiB/s

### DIFF
--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -136,7 +136,7 @@ module.exports = {
 
           const dm = options.decimals ? options.decimals : 0;
 
-          const i = options.binary ? 2 : Math.floor(Math.log(value) / Math.log(k));
+          const i = Math.floor(Math.log(value) / Math.log(k));
 
           const formatted = new Intl.NumberFormat(lng, { maximumFractionDigits: dm, minimumFractionDigits: dm }).format(
             parseFloat(value / k ** i),

--- a/src/utils/rate-formatter.test.js
+++ b/src/utils/rate-formatter.test.js
@@ -27,11 +27,11 @@ describe("rate formatter", () => {
   it.each([
     ["zero bytes", 0, { binary: true, bits: false, decimals: 1 }, "0 B/s"],
     ["decimal bytes", 15_000, { binary: false, bits: false, decimals: 1 }, "15.0 kB/s"],
-    ["binary bytes as mebibytes", 512, { binary: true, bits: false, decimals: 1 }, "0.0 MiB/s"],
-    ["binary kibibytes as mebibytes", 15 * 1024, { binary: true, bits: false, decimals: 1 }, "0.0 MiB/s"],
+    ["binary bytes", 512, { binary: true, bits: false, decimals: 1 }, "512.0 B/s"],
+    ["binary kibibytes", 15 * 1024, { binary: true, bits: false, decimals: 1 }, "15.0 kiB/s"],
     ["binary mebibytes", 15 * 1024 ** 2, { binary: true, bits: false, decimals: 1 }, "15.0 MiB/s"],
-    ["binary gibibytes as mebibytes", 2 * 1024 ** 3, { binary: true, bits: false, decimals: 1 }, "2,048.0 MiB/s"],
-    ["binary bits as mebibits", 15 * 1024, { binary: true, bits: true, decimals: 1 }, "0.0 Mibit/s"],
+    ["binary gibibytes", 2 * 1024 ** 3, { binary: true, bits: false, decimals: 1 }, "2.0 GiB/s"],
+    ["binary bits", 15 * 1024, { binary: true, bits: true, decimals: 1 }, "15.0 kibit/s"],
   ])("formats %s", (_description, value, options, expected) => {
     expect(formatRate(value, "en", options)).toBe(expected);
   });


### PR DESCRIPTION
## Proposed change

The `rate` i18n formatter hardcoded the unit index to `2` (MiB/s) whenever `binary: true`, so binary byte/bit rates never scaled with the value. The qbittorrent widget uses this via `common.bibyterate`, so a 15 KiB/s download rendered as `0.0 MiB/s`, 300 KB/s as `0.3 MiB/s`, and 2 GiB/s as `2,048.0 MiB/s`.

The unit index is now computed from the value with the correct base (`k` is already `1024` for binary / `1000` for decimal), matching the existing non-binary path. The regression was introduced in "Fix rate unit displays" (712fbb53).

Before → after (binary byte rate): `15 KiB/s`: `0.0 MiB/s` → `15.0 kiB/s`; `800 KiB/s`: `0.8 MiB/s` → `800.0 kiB/s`; `2 GiB/s`: `2,048.0 MiB/s` → `2.0 GiB/s`. Decimal and bit paths are unchanged; the full `pnpm test` suite passes (1467 tests).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Code style checks pass (prettier + eslint) on the changed file.
- [x] AI tool disclosure: this fix was prepared with AI assistance (Claude) and reviewed and verified by me before submitting.
