### PR TITLE
fix(calendar): show all days of multi-day ical events

### DIFF
--- a/src/widgets/calendar/integrations/ical.jsx
+++ b/src/widgets/calendar/integrations/ical.jsx
@@ -98,13 +98,14 @@ export default function Integration({ config, params, setEvents, hideErrors, tim
 
       const lastDay = end.clone();
       lastDay.isDate = true;
-      if (start.isDate) {
-        // All-day events have an exclusive DTEND per the iCal spec, so step
-        // back one day to reach the last day actually covered by the event.
-        lastDay.day -= 1;
-      } else if (end.hour === 0 && end.minute === 0 && end.second === 0 && end.compare(start) > 0) {
-        // A timed event ending exactly at midnight ends the instant the next
-        // day begins, so it does not actually occupy that day.
+      // A timed event ending exactly at midnight ends the instant the next day
+      // begins, so that day is not actually covered by the event.
+      const endsAtMidnight =
+        !end.isDate && end.compare(start) > 0 && end.hour === 0 && end.minute === 0 && end.second === 0;
+
+      if (start.isDate || endsAtMidnight) {
+        // All-day events have an exclusive DTEND per the iCal spec; likewise a
+        // midnight end is exclusive. Step back to the last day actually covered.
         lastDay.day -= 1;
       }
       // Guard against zero/negative spans (e.g. same-day timed events, where

--- a/src/widgets/calendar/integrations/ical.jsx
+++ b/src/widgets/calendar/integrations/ical.jsx
@@ -102,6 +102,10 @@ export default function Integration({ config, params, setEvents, hideErrors, tim
         // All-day events have an exclusive DTEND per the iCal spec, so step
         // back one day to reach the last day actually covered by the event.
         lastDay.day -= 1;
+      } else if (end.hour === 0 && end.minute === 0 && end.second === 0 && end.compare(start) > 0) {
+        // A timed event ending exactly at midnight ends the instant the next
+        // day begins, so it does not actually occupy that day.
+        lastDay.day -= 1;
       }
       // Guard against zero/negative spans (e.g. same-day timed events, where
       // truncating to day granularity leaves start === end): emit the start day.

--- a/src/widgets/calendar/integrations/ical.jsx
+++ b/src/widgets/calendar/integrations/ical.jsx
@@ -82,10 +82,63 @@ export default function Integration({ config, params, setEvents, hideErrors, tim
     const rangeStart = ICAL.Time.fromJSDate(startDate.toJSDate());
     const rangeEnd = ICAL.Time.fromJSDate(endDate.toJSDate());
 
+    // Expands a single (occurrence) start into one entry per day it spans,
+    // clipped to the visible range. `duration` is the length of the event.
+    // For all-day (date-only) events, DTEND is exclusive per the iCal spec,
+    // so the last displayed day is the day before dtend.
+    const expandDays = (start, duration, occurrences) => {
+      // Compute the last covered instant, then normalize to day granularity so
+      // the per-day loop and range clipping work identically for all-day and
+      // timed events (downstream views compare at day granularity anyway).
+      const end = start.clone();
+      end.addDuration(duration);
+
+      const startDay = start.clone();
+      startDay.isDate = true;
+
+      const lastDay = end.clone();
+      lastDay.isDate = true;
+      if (start.isDate) {
+        // All-day events have an exclusive DTEND per the iCal spec, so step
+        // back one day to reach the last day actually covered by the event.
+        lastDay.day -= 1;
+      }
+      // Guard against zero/negative spans (e.g. same-day timed events, where
+      // truncating to day granularity leaves start === end): emit the start day.
+      if (lastDay.compare(startDay) < 0) {
+        lastDay.day = startDay.day;
+        lastDay.month = startDay.month;
+        lastDay.year = startDay.year;
+      }
+
+      const rangeStartDay = rangeStart.clone();
+      rangeStartDay.isDate = true;
+      const rangeEndDay = rangeEnd.clone();
+      rangeEndDay.isDate = true;
+
+      const firstDayNum = startDay.dayOfYear();
+      const firstYear = startDay.year;
+      for (const day = startDay; day.compare(lastDay) <= 0; day.day += 1) {
+        const isFirst = day.year === firstYear && day.dayOfYear() === firstDayNum;
+        if (day.compare(rangeStartDay) < 0 || day.compare(rangeEndDay) > 0) {
+          continue;
+        }
+        // Preserve the original start time on the first day so timed events keep
+        // their time-of-day (used by the `showTime` option); subsequent days of
+        // a multi-day event are represented as plain dates.
+        occurrences.push(isFirst ? start.clone() : day.clone());
+      }
+    };
+
     const getOcurrencesFromRange = (event) => {
+      const duration = event.dtend.subtractDate(event.dtstart);
+
       if (!event.rrule) {
-        if (event.dtstart.compare(rangeStart) >= 0 && event.dtend.compare(rangeEnd) <= 0) {
-          return [event.dtstart];
+        // Include the event if it overlaps the visible range at all.
+        if (event.dtstart.compare(rangeEnd) <= 0 && event.dtend.compare(rangeStart) >= 0) {
+          const occurrences = [];
+          expandDays(event.dtstart, duration, occurrences);
+          return occurrences;
         }
 
         return [];
@@ -95,11 +148,14 @@ export default function Integration({ config, params, setEvents, hideErrors, tim
 
       const occurrences = [];
       for (let next = iterator.next(); next && next.compare(rangeEnd) < 0; next = iterator.next()) {
-        if (next.compare(rangeStart) < 0) {
+        // Each recurrence spans the same duration as the original event.
+        const occurrenceEnd = next.clone();
+        occurrenceEnd.addDuration(duration);
+        if (occurrenceEnd.compare(rangeStart) < 0) {
           continue;
         }
 
-        occurrences.push(next.clone());
+        expandDays(next, duration, occurrences);
       }
 
       return occurrences;

--- a/src/widgets/calendar/integrations/ical.jsx
+++ b/src/widgets/calendar/integrations/ical.jsx
@@ -123,11 +123,14 @@ export default function Integration({ config, params, setEvents, hideErrors, tim
 
       const firstDayNum = startDay.dayOfYear();
       const firstYear = startDay.year;
-      for (const day = startDay; day.compare(lastDay) <= 0; day.day += 1) {
+      // Clip the loop bounds to the visible range so iteration is bounded by the
+      // window, not the (potentially very long) event duration. `isFirst` is
+      // still compared against the true start day so the start time is only
+      // emitted when the event's real first day is within view.
+      const loopStart = startDay.compare(rangeStartDay) < 0 ? rangeStartDay.clone() : startDay;
+      const loopEnd = lastDay.compare(rangeEndDay) > 0 ? rangeEndDay.clone() : lastDay;
+      for (const day = loopStart; day.compare(loopEnd) <= 0; day.day += 1) {
         const isFirst = day.year === firstYear && day.dayOfYear() === firstDayNum;
-        if (day.compare(rangeStartDay) < 0 || day.compare(rangeEndDay) > 0) {
-          continue;
-        }
         // Preserve the original start time on the first day so timed events keep
         // their time-of-day (used by the `showTime` option); subsequent days of
         // a multi-day event are represented as plain dates.

--- a/src/widgets/calendar/integrations/ical.test.jsx
+++ b/src/widgets/calendar/integrations/ical.test.jsx
@@ -189,4 +189,45 @@ describe("widgets/calendar/integrations/ical", () => {
     expect(entries[0].date.toISODate()).toBe("2099-02-15");
     expect(entries[0].title).toBe("Birthday");
   });
+
+  it("does not spill a timed event ending at midnight into the next day", async () => {
+    // Monday 20:00 through Tuesday 00:00. The event ends the instant Tuesday
+    // begins, so it should only occupy Monday.
+    useWidgetAPI.mockReturnValue({
+      data: {
+        data: [
+          "BEGIN:VCALENDAR",
+          "VERSION:2.0",
+          "PRODID:-//Test//EN",
+          "BEGIN:VEVENT",
+          "UID:uid-midnight",
+          "DTSTAMP:20990101T000000Z",
+          "DTSTART:20990105T200000Z",
+          "DTEND:20990106T000000Z",
+          "SUMMARY:Evening",
+          "END:VEVENT",
+          "END:VCALENDAR",
+          "",
+        ].join("\n"),
+      },
+      error: undefined,
+    });
+
+    const setEvents = vi.fn();
+    render(
+      <Integration
+        config={{ name: "Calendar", type: "ical", color: "green", params: {} }}
+        params={{ start: "2099-01-01T00:00:00.000Z", end: "2099-02-01T00:00:00.000Z" }}
+        setEvents={setEvents}
+        hideErrors
+        timezone="utc"
+      />,
+    );
+
+    await waitFor(() => expect(setEvents).toHaveBeenCalled());
+
+    const entries = Object.values(setEvents.mock.calls[0][0]({}));
+    expect(entries).toHaveLength(1);
+    expect(entries[0].date.toUTC().toISODate()).toBe("2099-01-05");
+  });
 });

--- a/src/widgets/calendar/integrations/ical.test.jsx
+++ b/src/widgets/calendar/integrations/ical.test.jsx
@@ -61,4 +61,132 @@ describe("widgets/calendar/integrations/ical", () => {
     expect(event.url).toBe("https://example.com");
     expect(event.isCompleted).toBe(false);
   });
+
+  it("expands an all-day multi-day event into one entry per day (DTEND exclusive)", async () => {
+    // Typical of all-day PTO events: DTSTART/DTEND are date-only and DTEND is
+    // exclusive, so 20990101..20990104 covers Jan 1, 2 and 3 (three days).
+    useWidgetAPI.mockReturnValue({
+      data: {
+        data: [
+          "BEGIN:VCALENDAR",
+          "VERSION:2.0",
+          "PRODID:-//Test//EN",
+          "BEGIN:VEVENT",
+          "UID:uid-multi",
+          "DTSTAMP:20990101T000000Z",
+          "DTSTART;VALUE=DATE:20990101",
+          "DTEND;VALUE=DATE:20990104",
+          "SUMMARY:PTO",
+          "END:VEVENT",
+          "END:VCALENDAR",
+          "",
+        ].join("\n"),
+      },
+      error: undefined,
+    });
+
+    const setEvents = vi.fn();
+    render(
+      <Integration
+        config={{ name: "Calendar", type: "ical", color: "green", params: {} }}
+        params={{ start: "2099-01-01T00:00:00.000Z", end: "2099-02-01T00:00:00.000Z" }}
+        setEvents={setEvents}
+        hideErrors
+        timezone="utc"
+      />,
+    );
+
+    await waitFor(() => expect(setEvents).toHaveBeenCalled());
+
+    const entries = Object.values(setEvents.mock.calls[0][0]({}));
+    expect(entries).toHaveLength(3);
+
+    const days = entries.map((e) => e.date.toISODate()).sort();
+    expect(days).toEqual(["2099-01-01", "2099-01-02", "2099-01-03"]);
+    entries.forEach((e) => expect(e.title).toBe("PTO"));
+  });
+
+  it("clips a multi-day event to the visible range", async () => {
+    // Event spans Jan 28 .. Feb 9 (exclusive), but the range only shows up to
+    // Feb 1 (inclusive), so only Jan 28..Feb 1 should be produced.
+    useWidgetAPI.mockReturnValue({
+      data: {
+        data: [
+          "BEGIN:VCALENDAR",
+          "VERSION:2.0",
+          "PRODID:-//Test//EN",
+          "BEGIN:VEVENT",
+          "UID:uid-clip",
+          "DTSTAMP:20990101T000000Z",
+          "DTSTART;VALUE=DATE:20990128",
+          "DTEND;VALUE=DATE:20990209",
+          "SUMMARY:Long PTO",
+          "END:VEVENT",
+          "END:VCALENDAR",
+          "",
+        ].join("\n"),
+      },
+      error: undefined,
+    });
+
+    const setEvents = vi.fn();
+    render(
+      <Integration
+        config={{ name: "Calendar", type: "ical", color: "green", params: {} }}
+        params={{ start: "2099-01-01T00:00:00.000Z", end: "2099-02-01T00:00:00.000Z" }}
+        setEvents={setEvents}
+        hideErrors
+        timezone="utc"
+      />,
+    );
+
+    await waitFor(() => expect(setEvents).toHaveBeenCalled());
+
+    const entries = Object.values(setEvents.mock.calls[0][0]({}));
+    const days = entries.map((e) => e.date.toISODate()).sort();
+    expect(days).toEqual(["2099-01-28", "2099-01-29", "2099-01-30", "2099-01-31", "2099-02-01"]);
+  });
+
+  it("expands a yearly recurring single-day event to one entry per occurrence", async () => {
+    // Typical of yearly birthdays: FREQ=YEARLY, one-day span (DTEND exclusive).
+    useWidgetAPI.mockReturnValue({
+      data: {
+        data: [
+          "BEGIN:VCALENDAR",
+          "VERSION:2.0",
+          "PRODID:-//Test//EN",
+          "BEGIN:VEVENT",
+          "UID:uid-bday",
+          "DTSTAMP:20000101T000000Z",
+          "RRULE:FREQ=YEARLY",
+          "DTSTART;VALUE=DATE:19900215",
+          "DTEND;VALUE=DATE:19900216",
+          "SUMMARY:Birthday",
+          "END:VEVENT",
+          "END:VCALENDAR",
+          "",
+        ].join("\n"),
+      },
+      error: undefined,
+    });
+
+    const setEvents = vi.fn();
+    render(
+      <Integration
+        config={{ name: "Calendar", type: "ical", color: "green", params: {} }}
+        params={{ start: "2099-01-01T00:00:00.000Z", end: "2099-12-31T00:00:00.000Z" }}
+        setEvents={setEvents}
+        hideErrors
+        timezone="utc"
+      />,
+    );
+
+    await waitFor(() => expect(setEvents).toHaveBeenCalled());
+
+    const entries = Object.values(setEvents.mock.calls[0][0]({}));
+    // Exactly one occurrence (Feb 15) within the single year in range.
+    expect(entries).toHaveLength(1);
+    expect(entries[0].date.toISODate()).toBe("2099-02-15");
+    expect(entries[0].title).toBe("Birthday");
+  });
 });

--- a/src/widgets/calendar/integrations/ical.test.jsx
+++ b/src/widgets/calendar/integrations/ical.test.jsx
@@ -323,4 +323,208 @@ describe("widgets/calendar/integrations/ical", () => {
     const entries = Object.values(setEvents.mock.calls[0][0]({}));
     expect(entries.length).toBeLessThanOrEqual(32);
   });
+
+  it("emits a single day for a same-day timed event", async () => {
+    // Start and end fall on the same calendar day, so the zero/negative-span
+    // guard collapses the expansion to just the start day.
+    useWidgetAPI.mockReturnValue({
+      data: {
+        data: [
+          "BEGIN:VCALENDAR",
+          "VERSION:2.0",
+          "PRODID:-//Test//EN",
+          "BEGIN:VEVENT",
+          "UID:uid-sameday",
+          "DTSTAMP:20990101T000000Z",
+          "DTSTART:20990105T090000Z",
+          "DTEND:20990105T093000Z",
+          "SUMMARY:Standup",
+          "END:VEVENT",
+          "END:VCALENDAR",
+          "",
+        ].join("\n"),
+      },
+      error: undefined,
+    });
+
+    const setEvents = vi.fn();
+    render(
+      <Integration
+        config={{ name: "Calendar", type: "ical", color: "green", params: {} }}
+        params={{ start: "2099-01-01T00:00:00.000Z", end: "2099-02-01T00:00:00.000Z" }}
+        setEvents={setEvents}
+        hideErrors
+        timezone="utc"
+      />,
+    );
+
+    await waitFor(() => expect(setEvents).toHaveBeenCalled());
+
+    const entries = Object.values(setEvents.mock.calls[0][0]({}));
+    expect(entries).toHaveLength(1);
+    expect(entries[0].date.toUTC().toISODate()).toBe("2099-01-05");
+  });
+
+  it("produces no entries for an event entirely outside the range", async () => {
+    useWidgetAPI.mockReturnValue({
+      data: {
+        data: [
+          "BEGIN:VCALENDAR",
+          "VERSION:2.0",
+          "PRODID:-//Test//EN",
+          "BEGIN:VEVENT",
+          "UID:uid-outofrange",
+          "DTSTAMP:20990101T000000Z",
+          "DTSTART;VALUE=DATE:20990601",
+          "DTEND;VALUE=DATE:20990603",
+          "SUMMARY:Later",
+          "END:VEVENT",
+          "END:VCALENDAR",
+          "",
+        ].join("\n"),
+      },
+      error: undefined,
+    });
+
+    const setEvents = vi.fn();
+    render(
+      <Integration
+        config={{ name: "Calendar", type: "ical", color: "green", params: {} }}
+        params={{ start: "2099-01-01T00:00:00.000Z", end: "2099-02-01T00:00:00.000Z" }}
+        setEvents={setEvents}
+        hideErrors
+        timezone="utc"
+      />,
+    );
+
+    await waitFor(() => expect(setEvents).toHaveBeenCalled());
+
+    const entries = Object.values(setEvents.mock.calls[0][0]({}));
+    expect(entries).toHaveLength(0);
+  });
+
+  it("expands a multi-day recurring event across each day of every occurrence", async () => {
+    // A weekly 3-day (DTEND exclusive) recurring event. Each weekly occurrence
+    // within the range should contribute one entry per covered day.
+    useWidgetAPI.mockReturnValue({
+      data: {
+        data: [
+          "BEGIN:VCALENDAR",
+          "VERSION:2.0",
+          "PRODID:-//Test//EN",
+          "BEGIN:VEVENT",
+          "UID:uid-recur-multi",
+          "DTSTAMP:20990101T000000Z",
+          "RRULE:FREQ=WEEKLY;COUNT=2",
+          "DTSTART;VALUE=DATE:20990105",
+          "DTEND;VALUE=DATE:20990108",
+          "SUMMARY:Workshop",
+          "END:VEVENT",
+          "END:VCALENDAR",
+          "",
+        ].join("\n"),
+      },
+      error: undefined,
+    });
+
+    const setEvents = vi.fn();
+    render(
+      <Integration
+        config={{ name: "Calendar", type: "ical", color: "green", params: {} }}
+        params={{ start: "2099-01-01T00:00:00.000Z", end: "2099-02-01T00:00:00.000Z" }}
+        setEvents={setEvents}
+        hideErrors
+        timezone="utc"
+      />,
+    );
+
+    await waitFor(() => expect(setEvents).toHaveBeenCalled());
+
+    const entries = Object.values(setEvents.mock.calls[0][0]({}));
+    const days = entries.map((e) => e.date.toISODate()).sort();
+    // Week 1: Jan 5, 6, 7. Week 2: Jan 12, 13, 14.
+    expect(days).toEqual(["2099-01-05", "2099-01-06", "2099-01-07", "2099-01-12", "2099-01-13", "2099-01-14"]);
+  });
+
+  it("emits a single day for a zero-length all-day event", async () => {
+    // DTEND equals DTSTART. Treating the all-day DTEND as exclusive would step
+    // the last day before the start, so the zero/negative-span guard clamps it
+    // back to the start day (one entry).
+    useWidgetAPI.mockReturnValue({
+      data: {
+        data: [
+          "BEGIN:VCALENDAR",
+          "VERSION:2.0",
+          "PRODID:-//Test//EN",
+          "BEGIN:VEVENT",
+          "UID:uid-zerolen",
+          "DTSTAMP:20990101T000000Z",
+          "DTSTART;VALUE=DATE:20990105",
+          "DTEND;VALUE=DATE:20990105",
+          "SUMMARY:Marker",
+          "END:VEVENT",
+          "END:VCALENDAR",
+          "",
+        ].join("\n"),
+      },
+      error: undefined,
+    });
+
+    const setEvents = vi.fn();
+    render(
+      <Integration
+        config={{ name: "Calendar", type: "ical", color: "green", params: {} }}
+        params={{ start: "2099-01-01T00:00:00.000Z", end: "2099-02-01T00:00:00.000Z" }}
+        setEvents={setEvents}
+        hideErrors
+        timezone="utc"
+      />,
+    );
+
+    await waitFor(() => expect(setEvents).toHaveBeenCalled());
+
+    const entries = Object.values(setEvents.mock.calls[0][0]({}));
+    expect(entries).toHaveLength(1);
+    expect(entries[0].date.toISODate()).toBe("2099-01-05");
+  });
+
+  it("marks a completed VTODO as completed", async () => {
+    useWidgetAPI.mockReturnValue({
+      data: {
+        data: [
+          "BEGIN:VCALENDAR",
+          "VERSION:2.0",
+          "PRODID:-//Test//EN",
+          "BEGIN:VTODO",
+          "UID:uid-todo",
+          "DTSTAMP:20990101T000000Z",
+          "DTSTART:20990105T090000Z",
+          "DUE:20990105T100000Z",
+          "STATUS:COMPLETED",
+          "SUMMARY:Task",
+          "END:VTODO",
+          "END:VCALENDAR",
+          "",
+        ].join("\n"),
+      },
+      error: undefined,
+    });
+
+    const setEvents = vi.fn();
+    render(
+      <Integration
+        config={{ name: "Calendar", type: "ical", color: "green", params: {} }}
+        params={{ start: "2099-01-01T00:00:00.000Z", end: "2099-02-01T00:00:00.000Z" }}
+        setEvents={setEvents}
+        hideErrors
+        timezone="utc"
+      />,
+    );
+
+    await waitFor(() => expect(setEvents).toHaveBeenCalled());
+
+    const entries = Object.values(setEvents.mock.calls[0][0]({}));
+    expect(entries).toHaveLength(1);
+    expect(entries[0].isCompleted).toBe(true);
+  });
 });

--- a/src/widgets/calendar/integrations/ical.test.jsx
+++ b/src/widgets/calendar/integrations/ical.test.jsx
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
 
 import { render, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import ICAL from "ical.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 const { useWidgetAPI } = vi.hoisted(() => ({
   useWidgetAPI: vi.fn(),
@@ -12,6 +13,9 @@ vi.mock("utils/proxy/use-widget-api", () => ({ default: useWidgetAPI }));
 import Integration from "./ical";
 
 describe("widgets/calendar/integrations/ical", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
   it("adds parsed events within the date range", async () => {
     useWidgetAPI.mockReturnValue({
       data: {
@@ -229,5 +233,94 @@ describe("widgets/calendar/integrations/ical", () => {
     const entries = Object.values(setEvents.mock.calls[0][0]({}));
     expect(entries).toHaveLength(1);
     expect(entries[0].date.toUTC().toISODate()).toBe("2099-01-05");
+  });
+
+  it("only emits in-range days for an event starting before the window", async () => {
+    // Event starts before the visible window and ends far in the future. Only
+    // the days within the visible range should be produced.
+    useWidgetAPI.mockReturnValue({
+      data: {
+        data: [
+          "BEGIN:VCALENDAR",
+          "VERSION:2.0",
+          "PRODID:-//Test//EN",
+          "BEGIN:VEVENT",
+          "UID:uid-farfuture",
+          "DTSTAMP:20000101T000000Z",
+          "DTSTART;VALUE=DATE:20980101",
+          "DTEND;VALUE=DATE:22200101",
+          "SUMMARY:Long",
+          "END:VEVENT",
+          "END:VCALENDAR",
+          "",
+        ].join("\n"),
+      },
+      error: undefined,
+    });
+
+    const setEvents = vi.fn();
+    render(
+      <Integration
+        config={{ name: "Calendar", type: "ical", color: "green", params: {} }}
+        params={{ start: "2099-01-01T00:00:00.000Z", end: "2099-01-04T00:00:00.000Z" }}
+        setEvents={setEvents}
+        hideErrors
+        timezone="utc"
+      />,
+    );
+
+    await waitFor(() => expect(setEvents).toHaveBeenCalled());
+
+    const entries = Object.values(setEvents.mock.calls[0][0]({}));
+    const days = entries.map((e) => e.date.toISODate()).sort();
+    expect(days).toEqual(["2099-01-01", "2099-01-02", "2099-01-03", "2099-01-04"]);
+  });
+
+  it("does not iterate beyond the visible range for a far-future end date", async () => {
+    // A single all-day event spanning ~120 years. The per-day expansion must be
+    // bounded by the visible window, not the event's full duration, otherwise it
+    // performs tens of thousands of wasted iterations.
+    useWidgetAPI.mockReturnValue({
+      data: {
+        data: [
+          "BEGIN:VCALENDAR",
+          "VERSION:2.0",
+          "PRODID:-//Test//EN",
+          "BEGIN:VEVENT",
+          "UID:uid-perf",
+          "DTSTAMP:20000101T000000Z",
+          "DTSTART;VALUE=DATE:20990101",
+          "DTEND;VALUE=DATE:22200101",
+          "SUMMARY:Forever",
+          "END:VEVENT",
+          "END:VCALENDAR",
+          "",
+        ].join("\n"),
+      },
+      error: undefined,
+    });
+
+    const compareSpy = vi.spyOn(ICAL.Time.prototype, "compare");
+
+    const setEvents = vi.fn();
+    render(
+      <Integration
+        config={{ name: "Calendar", type: "ical", color: "green", params: {} }}
+        params={{ start: "2099-01-01T00:00:00.000Z", end: "2099-02-01T00:00:00.000Z" }}
+        setEvents={setEvents}
+        hideErrors
+        timezone="utc"
+      />,
+    );
+
+    await waitFor(() => expect(setEvents).toHaveBeenCalled());
+
+    // The visible window is ~31 days. Allow generous headroom for the range
+    // overlap checks, but far below the ~44,000 iterations a full 120-year span
+    // would require if the loop were not clipped to the range.
+    expect(compareSpy.mock.calls.length).toBeLessThan(500);
+
+    const entries = Object.values(setEvents.mock.calls[0][0]({}));
+    expect(entries.length).toBeLessThanOrEqual(32);
   });
 });


### PR DESCRIPTION
> Note: This PR was developed with the assistance of OpenCode using Claude Opus 4.8.

## Proposed change

Multi-day iCal events were only displayed on their first day. In `getOcurrencesFromRange`, a non-recurring event returned only `event.dtstart`, so a multi-day all-day event (for example multi-day PTO from an HR calendar) produced a single calendar entry. The parsed `dtend` was only used as a range filter and never to expand the event across the days it spans.

This PR expands each event into one occurrence per day it covers:

- All-day (date-only) events treat `DTEND` as exclusive per the iCal spec, so `DTSTART:20990101` / `DTEND:20990104` correctly covers Jan 1, 2 and 3.
- Timed events ending exactly at midnight are treated as exclusive too, so an event from Monday 20:00 to Tuesday 00:00 only occupies Monday.
- The original start time is preserved on the event's first day (used by the `showTime` option); subsequent days are plain dates.
- Recurring events are expanded by their duration as well, so multi-day recurring events also render every day.
- The non-recurring range filter was changed to an overlap check so partially visible multi-day events still render their visible days.
- The per-day expansion loop is clamped to the visible range instead of iterating the full event duration, so an event with a far-future `DTEND` no longer performs tens of thousands of wasted iterations.

No changes were needed in the calendar views: each expanded day flows through the existing per-occurrence rendering path.

### Testing

Added unit tests to `src/widgets/calendar/integrations/ical.test.jsx` covering:

- All-day multi-day expansion (one entry per day, `DTEND` exclusive)
- Clipping a multi-day event to the visible range
- Yearly recurring single-day events
- Timed event ending at midnight not spilling into the next day
- An event starting before the window with a far-future end date
- A performance guard asserting the day loop stays bounded to the visible window

All calendar tests pass and lint is clean.

Closes # (issue)

## Type of change

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] In the description above I have disclosed the use of AI tools in the coding of this PR.