### PR TITLE
Fix: correctly handle date-only recurring ical events

### DIFF
--- a/src/widgets/calendar/integrations/ical.jsx
+++ b/src/widgets/calendar/integrations/ical.jsx
@@ -85,6 +85,14 @@ export default function Integration({ config, params, setEvents, hideErrors, tim
     const getOcurrencesFromRange = (event) => {
       if (!event.rrule) {
         if (event.dtstart.compare(rangeStart) >= 0 && event.dtend.compare(rangeEnd) <= 0) {
+          if (event.type === "vevent" && event.dtstart.isDate && event.dtend.isDate) {
+            const occurrences = [];
+            for (const date = event.dtstart.clone(); date.compare(event.dtend) < 0; date.day += 1) {
+              occurrences.push(date.clone());
+            }
+            return occurrences;
+          }
+
           return [event.dtstart];
         }
 

--- a/src/widgets/calendar/integrations/ical.test.jsx
+++ b/src/widgets/calendar/integrations/ical.test.jsx
@@ -61,4 +61,43 @@ describe("widgets/calendar/integrations/ical", () => {
     expect(event.url).toBe("https://example.com");
     expect(event.isCompleted).toBe(false);
   });
+
+  it("adds an all-day event on every day before its exclusive end date", async () => {
+    useWidgetAPI.mockReturnValue({
+      data: {
+        data: [
+          "BEGIN:VCALENDAR",
+          "VERSION:2.0",
+          "PRODID:-//Homepage Test//iCal Multi-Day Event//EN",
+          "BEGIN:VEVENT",
+          "UID:multi-day-all-day@example.test",
+          "DTSTAMP:20260716T000000Z",
+          "DTSTART;VALUE=DATE:20260716",
+          "DTEND;VALUE=DATE:20260719",
+          "SUMMARY:Three-day PTO",
+          "END:VEVENT",
+          "END:VCALENDAR",
+          "",
+        ].join("\n"),
+      },
+      error: undefined,
+    });
+
+    const setEvents = vi.fn();
+    render(
+      <Integration
+        config={{ name: "PTO", type: "ical", color: "red" }}
+        params={{ start: "2026-04-16", end: "2026-10-16" }}
+        setEvents={setEvents}
+        hideErrors
+        timezone="America/Los_Angeles"
+      />,
+    );
+
+    await waitFor(() => expect(setEvents).toHaveBeenCalled());
+
+    const updater = setEvents.mock.calls[0][0];
+    const entries = Object.values(updater({}));
+    expect(entries.map((event) => event.date.toISODate()).sort()).toEqual(["2026-07-16", "2026-07-17", "2026-07-18"]);
+  });
 });


### PR DESCRIPTION
<!--
==== STOP ====================
======== STOP ================
============ STOP ============
================ STOP ========
==================== STOP ====

⚠️ Before opening this pull request please review the guidelines in the checklist below.

If this PR does not meet those guidelines it will not be accepted, and everyone will be sad.
-->

<img width="454" height="375" alt="Screenshot 2026-07-16 at 2 29 51 PM" src="https://github.com/user-attachments/assets/a03c3b20-d18a-44bd-b439-2925b775a1d7" />
<img width="443" height="360" alt="Screenshot 2026-07-16 at 2 29 57 PM" src="https://github.com/user-attachments/assets/4ef81f1f-fbd2-4a79-94ce-0766b2d53fd4" />

Supersedes #6874

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [ ] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] In the description above I have disclosed the use of AI tools in the coding of this PR.
