### PR TITLE
Fix: add clear sky icon mapping for Open-Meteo

### DIFF
--- a/src/utils/weather/openmeteo-condition-map.js
+++ b/src/utils/weather/openmeteo-condition-map.js
@@ -4,6 +4,13 @@ import * as Icons from "react-icons/wi";
 
 const conditions = [
   {
+    code: 0,
+    icon: {
+      day: Icons.WiDaySunny,
+      night: Icons.WiNightClear,
+    },
+  },
+  {
     code: 1,
     icon: {
       day: Icons.WiDayCloudy,

--- a/src/utils/weather/openmeteo-condition-map.test.js
+++ b/src/utils/weather/openmeteo-condition-map.test.js
@@ -4,6 +4,11 @@ import { describe, expect, it } from "vitest";
 import mapIcon from "./openmeteo-condition-map";
 
 describe("utils/weather/openmeteo-condition-map", () => {
+  it("maps clear sky (code 0) to sun during the day and clear-night icon at night", () => {
+    expect(mapIcon(0, "day")).toBe(Icons.WiDaySunny);
+    expect(mapIcon(0, "night")).toBe(Icons.WiNightClear);
+  });
+
   it("maps known condition codes to day/night icons", () => {
     expect(mapIcon(95, "day")).toBe(Icons.WiDayThunderstorm);
     expect(mapIcon(95, "night")).toBe(Icons.WiNightAltThunderstorm);


### PR DESCRIPTION
## Proposed change

WMO weather code 0 (clear sky) is missing from the Open-Meteo condition map, so `mapIcon(0, "night")` falls through to the default `WiDaySunny` and the widget shows a sun icon on a clear night - while the label next to it correctly says "Clear" (`wmo.0-night`).

This adds the missing entry, mapping code 0 to `WiDaySunny` (day) / `WiNightClear` (night), matching how the other weather providers handle clear sky (OpenWeatherMap code 800 and WeatherAPI code 1000 both use `WiNightClear` at night). Follows up on the icon-mapping fixes in #6869. A regression test is included; it fails before the fix and passes after.

This PR was written with the assistance of an AI tool (Claude), with human review.

## Type of change

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [ ] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] In the description above I have disclosed the use of AI tools in the coding of this PR.
