### PR TITLE
Data class passthrough

### DIFF
--- a/src/components/services/group.jsx
+++ b/src/components/services/group.jsx
@@ -25,16 +25,22 @@ export default function ServicesGroup({
   let groupPadding = layout?.header === false ? "px-1" : "p-1 pb-0";
   if (isSubgroup) groupPadding = "";
 
+  const dataAttrs = Object.fromEntries(
+    Object.entries(layout?.data ?? {}).map(([key, value]) => [`data-${key}`, value]),
+  );
+
   return (
     <div
       key={group.name}
       data-group={group.name || ""}
+      {...dataAttrs}
       className={classNames(
         "services-group flex-1",
         layout?.style === "row" ? "basis-full" : "basis-full md:basis-1/2 lg:basis-1/3 xl:basis-1/4",
         layout?.style !== "row" && maxGroupColumns ? `3xl:basis-1/${maxGroupColumns}` : "",
         groupPadding,
         isSubgroup ? "subgroup" : "",
+        layout?.class,
       )}
     >
       <Disclosure defaultOpen={!(layout?.initiallyCollapsed ?? groupsInitiallyCollapsed)}>

--- a/src/components/services/group.jsx
+++ b/src/components/services/group.jsx
@@ -28,6 +28,7 @@ export default function ServicesGroup({
   return (
     <div
       key={group.name}
+      data-group={group.name || ""}
       className={classNames(
         "services-group flex-1",
         layout?.style === "row" ? "basis-full" : "basis-full md:basis-1/2 lg:basis-1/3 xl:basis-1/4",

--- a/src/components/services/item.jsx
+++ b/src/components/services/item.jsx
@@ -32,8 +32,18 @@ export default function Item({ service, groupName, useEqualHeights }) {
     }
   };
 
+  const dataAttrs = Object.fromEntries(
+    Object.entries(service.data ?? {}).map(([key, value]) => [`data-${key}`, value]),
+  );
+
   return (
-    <li key={service.name} id={service.id} className="service" data-name={service.name || ""}>
+    <li
+      key={service.name}
+      id={service.id}
+      className={classNames("service", service.class)}
+      data-name={service.name || ""}
+      {...dataAttrs}
+    >
       <div
         className={classNames(
           settings.cardBlur !== undefined && `backdrop-blur${settings.cardBlur.length ? "-" : ""}${settings.cardBlur}`,


### PR DESCRIPTION
## Proposed change

Builds on #6880. Exposes any key under a group's `layout.<group>.data` (or a service's own `data:` field) as `data-*` attributes, and l`ayout.<group>.class`/a service's `class:` as an extra CSS class. Neither `layout:` nor a service entry gets schema-stripped before reaching these components today, so unrecognized keys already survive to the props. This just makes them usable instead of silently unused. Enables theming/layout customization (see [gethomepage/homepage discussion #6729](https://github.com/gethomepage/homepage/discussions/6729)) entirely from `custom.css`/`custom.js`.

_Solution by me, code by Claude Code._

Closes #6729

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] In the description above I have disclosed the use of AI tools in the coding of this PR.
