### PR TITLE
Chore: simplify qbittorrent api key handling

### DIFF
--- a/docs/widgets/services/qbittorrent.md
+++ b/docs/widgets/services/qbittorrent.md
@@ -5,7 +5,7 @@ description: qBittorrent Widget Configuration
 
 Learn more about [qBittorrent](https://github.com/qbittorrent/qBittorrent).
 
-Authenticate using the WebUI username and password or the API key `(qBittorrent ≥ v5.2.0)`. If both are provided, the API key will be used.
+Authenticate using the WebUI username and password or the API Key `(qBittorrent ≥ v5.2.0)`.
 
 API Key is located in `Options > WebUI > Authentication > API Key`.
 
@@ -17,15 +17,7 @@ widget:
   url: http://qbittorrent.host.or.ip
   username: username
   password: password
-  enableLeechProgress: true # optional, defaults to false
-  enableLeechSize: true # optional, defaults to false
-```
-
-```yaml
-widget:
-  type: qbittorrent
-  url: http://qbittorrent.host.or.ip
-  key: qbt_apikey
+  key: qbt_apikey # required if using API key instead of username/password
   enableLeechProgress: true # optional, defaults to false
   enableLeechSize: true # optional, defaults to false
 ```

--- a/docs/widgets/services/qbittorrent.md
+++ b/docs/widgets/services/qbittorrent.md
@@ -5,7 +5,7 @@ description: qBittorrent Widget Configuration
 
 Learn more about [qBittorrent](https://github.com/qbittorrent/qBittorrent).
 
-Authenticate using the WebUI username and password or the API Key `(qBittorrent ≥ v5.2.0)`.
+Authenticate using the WebUI username and password or the API key `(qBittorrent ≥ v5.2.0)`. If both are provided, the API key will be used.
 
 API Key is located in `Options > WebUI > Authentication > API Key`.
 
@@ -17,7 +17,15 @@ widget:
   url: http://qbittorrent.host.or.ip
   username: username
   password: password
-  key: qbt_apikey # required if using API key instead of username/password
+  enableLeechProgress: true # optional, defaults to false
+  enableLeechSize: true # optional, defaults to false
+```
+
+```yaml
+widget:
+  type: qbittorrent
+  url: http://qbittorrent.host.or.ip
+  key: qbt_apikey
   enableLeechProgress: true # optional, defaults to false
   enableLeechSize: true # optional, defaults to false
 ```

--- a/src/widgets/qbittorrent/proxy.js
+++ b/src/widgets/qbittorrent/proxy.js
@@ -36,9 +36,7 @@ export default async function qbittorrentProxyHandler(req, res) {
 
   const url = new URL(formatApiCall("{url}/api/v2/{endpoint}", { endpoint, ...widget }));
   const params = { method: "GET", headers: {} };
-  if (widget.key) {
-    params.headers.Authorization = `Bearer ${widget.key}`;
-  }
+  if (widget.key) params.headers.Authorization = `Bearer ${widget.key}`;
 
   let [status, contentType, data] = await httpProxy(url, params);
   if (status === 403 && !widget.key) {

--- a/src/widgets/qbittorrent/proxy.js
+++ b/src/widgets/qbittorrent/proxy.js
@@ -9,17 +9,11 @@ async function login(widget) {
   logger.debug("qBittorrent is rejecting the request, logging in.");
   const loginUrl = new URL(`${widget.url}/api/v2/auth/login`).toString();
   const loginBody = `username=${encodeURIComponent(widget.username)}&password=${encodeURIComponent(widget.password)}`;
-  const loginKey = `${widget.key}`;
   const loginParams = {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: loginBody,
   };
-
-  if (widget.key) {
-    loginParams.headers.Authorization = `Bearer ${loginKey}`;
-  } else if (widget.username && widget.password) {
-    loginParams.body = loginBody;
-  }
 
   const [status, contentType, data] = await httpProxy(loginUrl, loginParams);
   return [status, data];
@@ -42,9 +36,12 @@ export default async function qbittorrentProxyHandler(req, res) {
 
   const url = new URL(formatApiCall("{url}/api/v2/{endpoint}", { endpoint, ...widget }));
   const params = { method: "GET", headers: {} };
+  if (widget.key) {
+    params.headers.Authorization = `Bearer ${widget.key}`;
+  }
 
   let [status, contentType, data] = await httpProxy(url, params);
-  if (status === 403) {
+  if (status === 403 && !widget.key) {
     [status, data] = await login(widget);
 
     if (![200, 204].includes(status)) {

--- a/src/widgets/qbittorrent/proxy.test.js
+++ b/src/widgets/qbittorrent/proxy.test.js
@@ -45,6 +45,11 @@ describe("widgets/qbittorrent/proxy", () => {
 
     expect(httpProxy).toHaveBeenCalledTimes(3);
     expect(httpProxy.mock.calls[1][0]).toBe("http://qb/api/v2/auth/login");
+    expect(httpProxy.mock.calls[1][1]).toEqual({
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: "username=u&password=p",
+    });
     expect(res.statusCode).toBe(200);
     expect(res.body).toEqual(Buffer.from("data"));
   });
@@ -84,23 +89,39 @@ describe("widgets/qbittorrent/proxy", () => {
     expect(res.body).toEqual(Buffer.from("Denied"));
   });
 
-  it("supports API keys by including them in the Authorization header and not the body", async () => {
+  it("uses an API key on the WebAPI request without attempting login", async () => {
     getServiceWidget.mockResolvedValue({ url: "http://qb", key: "abc123" });
 
-    httpProxy
-      .mockResolvedValueOnce([403, "application/json", Buffer.from("nope")])
-      .mockResolvedValueOnce([200, "text/plain", Buffer.from("Ok.")])
-      .mockResolvedValueOnce([200, "application/json", Buffer.from("data")]);
+    httpProxy.mockResolvedValueOnce([200, "application/json", Buffer.from("data")]);
 
     const req = { query: { group: "g", service: "svc", endpoint: "torrents/info", index: "0" } };
     const res = createMockRes();
 
     await qbittorrentProxyHandler(req, res);
 
-    expect(httpProxy).toHaveBeenCalledTimes(3);
-    expect(httpProxy.mock.calls[1][0]).toBe("http://qb/api/v2/auth/login");
-    expect(httpProxy.mock.calls[1][1].headers.Authorization).toBe("Bearer abc123");
+    expect(httpProxy).toHaveBeenCalledTimes(1);
+    expect(httpProxy.mock.calls[0][0].toString()).toBe("http://qb/api/v2/torrents/info");
+    expect(httpProxy.mock.calls[0][1]).toMatchObject({
+      headers: { Authorization: "Bearer abc123" },
+      method: "GET",
+    });
     expect(res.statusCode).toBe(200);
     expect(res.body).toEqual(Buffer.from("data"));
+  });
+
+  it("does not attempt username/password login when an API key is rejected", async () => {
+    getServiceWidget.mockResolvedValue({ url: "http://qb", username: "u", password: "p", key: "invalid" });
+
+    httpProxy.mockResolvedValueOnce([403, "application/json", Buffer.from("nope")]);
+
+    const req = { query: { group: "g", service: "svc", endpoint: "torrents/info", index: "0" } };
+    const res = createMockRes();
+
+    await qbittorrentProxyHandler(req, res);
+
+    expect(httpProxy).toHaveBeenCalledTimes(1);
+    expect(httpProxy.mock.calls[0][1].headers.Authorization).toBe("Bearer invalid");
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toEqual(Buffer.from("nope"));
   });
 });

--- a/src/widgets/qbittorrent/proxy.test.js
+++ b/src/widgets/qbittorrent/proxy.test.js
@@ -45,11 +45,6 @@ describe("widgets/qbittorrent/proxy", () => {
 
     expect(httpProxy).toHaveBeenCalledTimes(3);
     expect(httpProxy.mock.calls[1][0]).toBe("http://qb/api/v2/auth/login");
-    expect(httpProxy.mock.calls[1][1]).toEqual({
-      method: "POST",
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      body: "username=u&password=p",
-    });
     expect(res.statusCode).toBe(200);
     expect(res.body).toEqual(Buffer.from("data"));
   });
@@ -92,26 +87,6 @@ describe("widgets/qbittorrent/proxy", () => {
   it("uses an API key on the WebAPI request without attempting login", async () => {
     getServiceWidget.mockResolvedValue({ url: "http://qb", key: "abc123" });
 
-    httpProxy.mockResolvedValueOnce([200, "application/json", Buffer.from("data")]);
-
-    const req = { query: { group: "g", service: "svc", endpoint: "torrents/info", index: "0" } };
-    const res = createMockRes();
-
-    await qbittorrentProxyHandler(req, res);
-
-    expect(httpProxy).toHaveBeenCalledTimes(1);
-    expect(httpProxy.mock.calls[0][0].toString()).toBe("http://qb/api/v2/torrents/info");
-    expect(httpProxy.mock.calls[0][1]).toMatchObject({
-      headers: { Authorization: "Bearer abc123" },
-      method: "GET",
-    });
-    expect(res.statusCode).toBe(200);
-    expect(res.body).toEqual(Buffer.from("data"));
-  });
-
-  it("does not attempt username/password login when an API key is rejected", async () => {
-    getServiceWidget.mockResolvedValue({ url: "http://qb", username: "u", password: "p", key: "invalid" });
-
     httpProxy.mockResolvedValueOnce([403, "application/json", Buffer.from("nope")]);
 
     const req = { query: { group: "g", service: "svc", endpoint: "torrents/info", index: "0" } };
@@ -120,7 +95,8 @@ describe("widgets/qbittorrent/proxy", () => {
     await qbittorrentProxyHandler(req, res);
 
     expect(httpProxy).toHaveBeenCalledTimes(1);
-    expect(httpProxy.mock.calls[0][1].headers.Authorization).toBe("Bearer invalid");
+    expect(httpProxy.mock.calls[0][0].toString()).toBe("http://qb/api/v2/torrents/info");
+    expect(httpProxy.mock.calls[0][1].headers.Authorization).toBe("Bearer abc123");
     expect(res.statusCode).toBe(403);
     expect(res.body).toEqual(Buffer.from("nope"));
   });


### PR DESCRIPTION
## Proposed change

This improves the handling for the qBittorrent widget when API Key is set.

There is no reason for trying for trying to login with an api key, it should just try it directly

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] In the description above I have disclosed the use of AI tools in the coding of this PR.
