### PR TITLE
Add Kimai time tracker widget

### DIFF
--- a/docs/widgets/services/kimai.md
+++ b/docs/widgets/services/kimai.md
@@ -1,0 +1,21 @@
+---
+title: Kimai
+description: Kimai Widget Configuration
+---
+
+Learn more about [Kimai](https://www.kimai.org/).
+
+Generate an API token under `My Profile > API Access > Create new API token`. The token inherits the permissions of the user that owns it, so the widget reports that user's timesheet totals.
+
+Allowed fields: `["active", "today", "week"]`.
+
+- `active`: the currently running timer, shown as the project or activity name with elapsed time, or an idle label when no timer is running.
+- `today`: total tracked time since midnight.
+- `week`: total tracked time since the start of the current week (Monday).
+
+```yaml
+widget:
+  type: kimai
+  url: https://kimai.host.or.ip
+  key: kimai-api-token
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,7 @@ nav:
           - widgets/services/jellyfin.md
           - widgets/services/jellystat.md
           - widgets/services/kavita.md
+          - widgets/services/kimai.md
           - widgets/services/komga.md
           - widgets/services/komodo.md
           - widgets/services/kopia.md

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -857,6 +857,13 @@
         "seriesCount": "Series",
         "totalFiles": "Files"
     },
+    "kimai": {
+        "active": "Active",
+        "today": "Today",
+        "week": "Week",
+        "idle": "No timer running",
+        "tracking": "Tracking"
+    },
     "azuredevops": {
         "result": "Result",
         "status": "Status",

--- a/src/utils/proxy/handlers/credentialed.js
+++ b/src/utils/proxy/handlers/credentialed.js
@@ -58,6 +58,7 @@ export default async function credentialedProxyHandler(req, res, map) {
           "headscale",
           "hoarder",
           "karakeep",
+          "kimai",
           "linkwarden",
           "mealie",
           "netalertx",

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -69,6 +69,7 @@ const components = {
   jellyseerr: dynamic(() => import("./seerr/component")),
   jellystat: dynamic(() => import("./jellystat/component")),
   kavita: dynamic(() => import("./kavita/component")),
+  kimai: dynamic(() => import("./kimai/component")),
   komga: dynamic(() => import("./komga/component")),
   komodo: dynamic(() => import("./komodo/component")),
   kopia: dynamic(() => import("./kopia/component")),

--- a/src/widgets/kimai/component.jsx
+++ b/src/widgets/kimai/component.jsx
@@ -1,0 +1,96 @@
+import Block from "components/services/widget/block";
+import Container from "components/services/widget/container";
+import { useTranslation } from "next-i18next/pages";
+
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+function toKimaiDateTime(date) {
+  const pad = (n) => String(n).padStart(2, "0");
+  return (
+    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
+    `T${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`
+  );
+}
+
+function startOfToday(now) {
+  const d = new Date(now);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function startOfWeek(now) {
+  const d = startOfToday(now);
+  const day = d.getDay();
+  const diff = (day + 6) % 7;
+  d.setDate(d.getDate() - diff);
+  return d;
+}
+
+function sumDurationSeconds(entries) {
+  if (!Array.isArray(entries)) return 0;
+  return entries.reduce((acc, e) => acc + (typeof e.duration === "number" ? e.duration : 0), 0);
+}
+
+function formatHours(seconds) {
+  if (seconds <= 0) return "0h";
+  const totalMinutes = Math.floor(seconds / 60);
+  const h = Math.floor(totalMinutes / 60);
+  const m = totalMinutes % 60;
+  if (h === 0) return `${m}m`;
+  if (m === 0) return `${h}h`;
+  return `${h}h ${m}m`;
+}
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+  const { widget } = service;
+  const now = new Date();
+
+  const todayBegin = toKimaiDateTime(startOfToday(now));
+  const weekBegin = toKimaiDateTime(startOfWeek(now));
+  const end = toKimaiDateTime(now);
+
+  const { data: todayData, error: todayError } = useWidgetAPI(widget, "timesheets", {
+    begin: todayBegin,
+    end,
+    size: 200,
+  });
+
+  const { data: weekData, error: weekError } = useWidgetAPI(widget, "timesheets", {
+    begin: weekBegin,
+    end,
+    size: 200,
+  });
+
+  const { data: activeData, error: activeError } = useWidgetAPI(widget, "active");
+
+  if (todayError || weekError || activeError) {
+    return <Container service={service} error={todayError ?? weekError ?? activeError} />;
+  }
+
+  if (!todayData || !weekData || !activeData) {
+    return (
+      <Container service={service}>
+        <Block label="kimai.active" />
+        <Block label="kimai.today" />
+        <Block label="kimai.week" />
+      </Container>
+    );
+  }
+
+  const activeEntry = Array.isArray(activeData) && activeData.length > 0 ? activeData[0] : null;
+  let activeValue = t("kimai.idle");
+  if (activeEntry) {
+    const elapsedSeconds = Math.max(0, Math.floor((now - new Date(activeEntry.begin)) / 1000));
+    const projectName = activeEntry.project?.name ?? activeEntry.activity?.name ?? t("kimai.tracking");
+    activeValue = `${projectName} · ${t("common.duration", { value: elapsedSeconds })}`;
+  }
+
+  return (
+    <Container service={service}>
+      <Block label="kimai.active" value={activeValue} />
+      <Block label="kimai.today" value={formatHours(sumDurationSeconds(todayData))} />
+      <Block label="kimai.week" value={formatHours(sumDurationSeconds(weekData))} />
+    </Container>
+  );
+}

--- a/src/widgets/kimai/component.test.jsx
+++ b/src/widgets/kimai/component.test.jsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+
+import { screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "test-utils/render-with-providers";
+
+const { useWidgetAPI } = vi.hoisted(() => ({
+  useWidgetAPI: vi.fn(),
+}));
+
+vi.mock("utils/proxy/use-widget-api", () => ({
+  default: useWidgetAPI,
+}));
+
+import Component from "./component";
+
+describe("widgets/kimai/component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders placeholders while loading", () => {
+    useWidgetAPI.mockReturnValue({ data: undefined, error: undefined });
+
+    const { container } = renderWithProviders(<Component service={{ widget: { type: "kimai" } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expect(container.querySelectorAll(".service-block")).toHaveLength(3);
+    expect(screen.getByText("kimai.active")).toBeInTheDocument();
+    expect(screen.getByText("kimai.today")).toBeInTheDocument();
+    expect(screen.getByText("kimai.week")).toBeInTheDocument();
+  });
+
+  it("renders error UI when any request errors", () => {
+    useWidgetAPI
+      .mockReturnValueOnce({ data: undefined, error: { message: "nope" } })
+      .mockReturnValueOnce({ data: undefined, error: undefined })
+      .mockReturnValueOnce({ data: undefined, error: undefined });
+
+    renderWithProviders(<Component service={{ widget: { type: "kimai" } }} />, { settings: { hideErrors: false } });
+
+    expect(screen.getAllByText(/widget\.api_error/i).length).toBeGreaterThan(0);
+  });
+
+  it("sums timesheet durations into hours and shows the active timer", () => {
+    useWidgetAPI
+      .mockReturnValueOnce({ data: [{ duration: 3600 }, { duration: 1800 }], error: undefined })
+      .mockReturnValueOnce({ data: [{ duration: 7200 }, { duration: 3600 }], error: undefined })
+      .mockReturnValueOnce({
+        data: [
+          {
+            begin: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+            project: { name: "Lighting Design" },
+            activity: { name: "Programming" },
+          },
+        ],
+        error: undefined,
+      });
+
+    renderWithProviders(<Component service={{ widget: { type: "kimai" } }} />, { settings: { hideErrors: false } });
+
+    expect(screen.getByText(/Lighting Design/)).toBeInTheDocument();
+    expect(screen.getByText("1h 30m")).toBeInTheDocument();
+    expect(screen.getByText("3h")).toBeInTheDocument();
+  });
+
+  it("shows idle when no timer is active", () => {
+    useWidgetAPI
+      .mockReturnValueOnce({ data: [], error: undefined })
+      .mockReturnValueOnce({ data: [], error: undefined })
+      .mockReturnValueOnce({ data: [], error: undefined });
+
+    renderWithProviders(<Component service={{ widget: { type: "kimai" } }} />, { settings: { hideErrors: false } });
+
+    expect(screen.getByText("kimai.idle")).toBeInTheDocument();
+  });
+});

--- a/src/widgets/kimai/widget.js
+++ b/src/widgets/kimai/widget.js
@@ -1,0 +1,18 @@
+import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
+
+const widget = {
+  api: "{url}/api/{endpoint}",
+  proxyHandler: credentialedProxyHandler,
+
+  mappings: {
+    timesheets: {
+      endpoint: "timesheets",
+      params: ["begin", "end", "size"],
+    },
+    active: {
+      endpoint: "timesheets/active",
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/kimai/widget.test.js
+++ b/src/widgets/kimai/widget.test.js
@@ -1,0 +1,11 @@
+import { describe, it } from "vitest";
+
+import { expectWidgetConfigShape } from "test-utils/widget-config";
+
+import widget from "./widget";
+
+describe("kimai widget config", () => {
+  it("exports a valid widget config", () => {
+    expectWidgetConfigShape(widget);
+  });
+});

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -60,6 +60,7 @@ import jellyfin from "./jellyfin/widget";
 import jellystat from "./jellystat/widget";
 import karakeep from "./karakeep/widget";
 import kavita from "./kavita/widget";
+import kimai from "./kimai/widget";
 import komga from "./komga/widget";
 import komodo from "./komodo/widget";
 import kopia from "./kopia/widget";
@@ -221,6 +222,7 @@ const widgets = {
   jellyseerr: seerr,
   jellystat,
   kavita,
+  kimai,
   komga,
   komodo,
   kopia,


### PR DESCRIPTION
## Proposed change

Adds a service widget for [Kimai](https://www.kimai.org/), a self-hosted time tracker. The tile shows three values:

- **Active**: the currently running timer, shown as the project or activity name with elapsed time, or an idle label when nothing is running.
- **Today**: total tracked time since midnight.
- **Week**: total tracked time since Monday.

The widget authenticates with a Kimai API token (Bearer auth through the credentialed proxy handler) and reads two endpoints: `timesheets` for the day and week sums, and `timesheets/active` for the running timer. It ships with a docs page, an mkdocs nav entry, English translation strings, and unit tests for the widget definition and the component.

Built with AI assistance; I reviewed, tested, and run it against my own Kimai instance.

### Screenshot

Screenshot attached in the PR description below. Rendered against a live Kimai instance: Active "No timer running", Today "1h 58m", Week "6h 28m".

### Example API output

`GET {url}/api/timesheets?begin=...&end=...&size=200`

```json
[
  { "id": 1234, "begin": "2026-07-22T08:30:00-0400", "duration": 7080, "project": 5, "activity": 12 }
]
```

The widget sums the `duration` field (seconds) across the returned entries and formats the total as hours and minutes.

`GET {url}/api/timesheets/active`

```json
[
  { "begin": "2026-07-22T14:00:00-0400", "project": { "name": "Example Project" }, "activity": { "name": "Example Activity" } }
]
```

Returns an empty array when no timer is running, which the widget shows as the idle label.

## Type of change

- [x] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] In the description above I have disclosed the use of AI tools in the coding of this PR.
