### PR TITLE
Enhancement: add data-group attribute and data-/class passthrough to service groups and items

### DIFF
--- a/docs/configs/custom-css-js.md
+++ b/docs/configs/custom-css-js.md
@@ -15,3 +15,102 @@ Service:
     icon: icon.png
     ...
 ```
+
+## Targeting Service Groups by Name
+
+Each service group wrapper `<div>` contains a `data-group` attribute set to the group's name,
+allowing you to target specific groups in custom CSS:
+
+```css
+/* Target a specific service group by name */
+div[data-group="My Services"] {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+}
+
+div[data-group="My Services"] .service-group-name {
+  color: #f0c040;
+}
+```
+
+## Custom Data Attributes on Groups and Services
+
+You can pass arbitrary `data-*` attributes to service groups and individual services
+using the `data:` key in your config. This enables powerful CSS and JS targeting
+without modifying Homepage's code.
+
+### On Service Groups
+
+Add `data:` to a group's layout block to attach custom attributes to the group wrapper `<div>`:
+
+```yaml
+My Group:
+  icon: mdi:folder
+  data:
+    environment: production
+    region: us-west
+  services:
+    - ...
+```
+
+This renders `<div data-group="My Group" data-environment="production" data-region="us-west" ...>`.
+
+### On Services
+
+Add `data:` to a service definition:
+
+```yaml
+- name: My App
+  href: https://example.com
+  icon: mdi:web
+  data:
+    tier: critical
+    team: platform
+```
+
+## Custom CSS Classes on Groups and Services
+
+You can add extra CSS classes to service groups and individual service items
+using the `class:` key:
+
+### On Service Groups
+
+```yaml
+My Group:
+  icon: mdi:folder
+  class: bordered highlight
+  services:
+    - ...
+```
+
+The `class` value is added to the group wrapper `<div>` alongside the built-in classes.
+
+### On Services
+
+```yaml
+- name: My App
+  href: https://example.com
+  icon: mdi:web
+  class: pulse-animation
+```
+
+The `class` value is added to the service `<li>` alongside the default `service` class.
+
+### CSS Examples
+
+```css
+/* Target services in production with a green left border */
+.service-card[data-tier="critical"] {
+  border-left: 4px solid #e74c3c;
+}
+
+/* Apply animation to specific service */
+.pulse-animation {
+  animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.7; }
+}
+```

--- a/src/components/services/group.jsx
+++ b/src/components/services/group.jsx
@@ -25,15 +25,22 @@ export default function ServicesGroup({
   let groupPadding = layout?.header === false ? "px-1" : "p-1 pb-0";
   if (isSubgroup) groupPadding = "";
 
+  const dataAttrs = Object.fromEntries(
+    Object.entries(layout?.data ?? {}).map(([key, value]) => [`data-${key}`, value]),
+  );
+
   return (
     <div
       key={group.name}
+      data-group={group.name || ""}
+      {...dataAttrs}
       className={classNames(
         "services-group flex-1",
         layout?.style === "row" ? "basis-full" : "basis-full md:basis-1/2 lg:basis-1/3 xl:basis-1/4",
         layout?.style !== "row" && maxGroupColumns ? `3xl:basis-1/${maxGroupColumns}` : "",
         groupPadding,
         isSubgroup ? "subgroup" : "",
+        layout?.class,
       )}
     >
       <Disclosure defaultOpen={!(layout?.initiallyCollapsed ?? groupsInitiallyCollapsed)}>

--- a/src/components/services/group.test.jsx
+++ b/src/components/services/group.test.jsx
@@ -70,6 +70,136 @@ describe("components/services/group", () => {
     expect(screen.getByText("Sub")).toBeInTheDocument();
   });
 
+  it("renders data-group attribute on the group wrapper div", () => {
+    const { container } = render(
+      <ServicesGroup
+        group={{ name: "My Services", services: [], groups: [] }}
+        layout={{}}
+        groupsInitiallyCollapsed={false}
+      />,
+    );
+
+    const groupDiv = container.querySelector('[data-group="My Services"]');
+    expect(groupDiv).toBeInTheDocument();
+    expect(groupDiv).toHaveClass("services-group");
+  });
+
+  it("renders data-group attribute on subgroups", () => {
+    const { container } = render(
+      <ServicesGroup
+        group={{
+          name: "Main",
+          services: [],
+          groups: [{ name: "SubGroup", services: [], groups: [] }],
+        }}
+        layout={{}}
+        groupsInitiallyCollapsed={false}
+      />,
+    );
+
+    const mainDiv = container.querySelector('[data-group="Main"]');
+    expect(mainDiv).toBeInTheDocument();
+    const subDiv = container.querySelector('[data-group="SubGroup"]');
+    expect(subDiv).toBeInTheDocument();
+  });
+
+  it("handles empty group name in data-group", () => {
+    const { container } = render(
+      <ServicesGroup
+        group={{ name: "", services: [], groups: [] }}
+        layout={{}}
+        groupsInitiallyCollapsed={false}
+      />,
+    );
+
+    const groupDiv = container.querySelector('[data-group=""]');
+    expect(groupDiv).toBeInTheDocument();
+  });
+
+  it("handles special characters in group name", () => {
+    const { container } = render(
+      <ServicesGroup
+        group={{ name: "Group & Co.", services: [], groups: [] }}
+        layout={{}}
+        groupsInitiallyCollapsed={false}
+      />,
+    );
+
+    const groupDivs = container.querySelectorAll(".services-group");
+    const found = Array.from(groupDivs).find((el) => el.getAttribute("data-group") === "Group & Co.");
+    expect(found).toBeTruthy();
+  });
+
+  it("renders custom data-* attributes from layout.data", () => {
+    const { container } = render(
+      <ServicesGroup
+        group={{ name: "Test", services: [], groups: [] }}
+        layout={{ data: { foo: "bar", baz: "qux" } }}
+        groupsInitiallyCollapsed={false}
+      />,
+    );
+
+    const groupDiv = container.querySelector('[data-group="Test"]');
+    expect(groupDiv).toHaveAttribute("data-foo", "bar");
+    expect(groupDiv).toHaveAttribute("data-baz", "qux");
+  });
+
+  it("does not add unexpected data-* attributes when layout.data is empty", () => {
+    const { container } = render(
+      <ServicesGroup
+        group={{ name: "Test", services: [], groups: [] }}
+        layout={{ data: {} }}
+        groupsInitiallyCollapsed={false}
+      />,
+    );
+
+    const groupDiv = container.querySelector('[data-group="Test"]');
+    // Should have data-group but not data-foo
+    expect(groupDiv).toHaveAttribute("data-group", "Test");
+    expect(groupDiv).not.toHaveAttribute("data-foo");
+  });
+
+  it("renders layout.class on the group wrapper", () => {
+    const { container } = render(
+      <ServicesGroup
+        group={{ name: "Test", services: [], groups: [] }}
+        layout={{ class: "my-custom-class" }}
+        groupsInitiallyCollapsed={false}
+      />,
+    );
+
+    const groupDiv = container.querySelector('[data-group="Test"]');
+    expect(groupDiv).toHaveClass("my-custom-class");
+  });
+
+  it("layout.class merges with default classes", () => {
+    const { container } = render(
+      <ServicesGroup
+        group={{ name: "Test", services: [], groups: [] }}
+        layout={{ class: "my-custom-class" }}
+        groupsInitiallyCollapsed={false}
+      />,
+    );
+
+    const groupDiv = container.querySelector('[data-group="Test"]');
+    expect(groupDiv).toHaveClass("services-group");
+    expect(groupDiv).toHaveClass("flex-1");
+    expect(groupDiv).toHaveClass("my-custom-class");
+  });
+
+  it("handles undefined layout without error", () => {
+    const { container } = render(
+      <ServicesGroup
+        group={{ name: "Test", services: [], groups: [] }}
+        groupsInitiallyCollapsed={false}
+      />,
+    );
+
+    const groupDiv = container.querySelector('[data-group="Test"]');
+    expect(groupDiv).toBeInTheDocument();
+    expect(groupDiv).toHaveClass("services-group");
+  });
+
   it("sets the panel height to 0 when initially collapsed", async () => {
     render(
       <ServicesGroup

--- a/src/components/services/item.jsx
+++ b/src/components/services/item.jsx
@@ -32,8 +32,18 @@ export default function Item({ service, groupName, useEqualHeights }) {
     }
   };
 
+  const dataAttrs = Object.fromEntries(
+    Object.entries(service.data ?? {}).map(([key, value]) => [`data-${key}`, value]),
+  );
+
   return (
-    <li key={service.name} id={service.id} className="service" data-name={service.name || ""}>
+    <li
+      key={service.name}
+      id={service.id}
+      className={classNames("service", service.class)}
+      data-name={service.name || ""}
+      {...dataAttrs}
+    >
       <div
         className={classNames(
           settings.cardBlur !== undefined && `backdrop-blur${settings.cardBlur.length ? "-" : ""}${settings.cardBlur}`,

--- a/src/components/services/item.test.jsx
+++ b/src/components/services/item.test.jsx
@@ -227,6 +227,103 @@ describe("components/services/item", () => {
     expect(screen.getByTestId("proxmoxvm-widget")).toBeInTheDocument();
   });
 
+  it("renders custom data-* attributes from service.data", () => {
+    const { container } = renderWithProviders(
+      <Item
+        groupName="G"
+        useEqualHeights={false}
+        service={{
+          id: "s1",
+          name: "Test",
+          data: { foo: "bar", track: "main" },
+          widgets: [],
+        }}
+      />,
+      { settings: { showStats: false, statusStyle: "basic" } },
+    );
+
+    const li = container.querySelector('[data-name="Test"]');
+    expect(li).toHaveAttribute("data-foo", "bar");
+    expect(li).toHaveAttribute("data-track", "main");
+  });
+
+  it("does not add unexpected data-* attributes when service.data is undefined", () => {
+    const { container } = renderWithProviders(
+      <Item
+        groupName="G"
+        useEqualHeights={false}
+        service={{
+          id: "s1",
+          name: "Test",
+          widgets: [],
+        }}
+      />,
+      { settings: { showStats: false, statusStyle: "basic" } },
+    );
+
+    const li = container.querySelector('[data-name="Test"]');
+    expect(li).toHaveAttribute("data-name", "Test");
+    expect(li).not.toHaveAttribute("data-foo");
+  });
+
+  it("renders service.class on the li element", () => {
+    const { container } = renderWithProviders(
+      <Item
+        groupName="G"
+        useEqualHeights={false}
+        service={{
+          id: "s1",
+          name: "Test",
+          class: "highlighted",
+          widgets: [],
+        }}
+      />,
+      { settings: { showStats: false, statusStyle: "basic" } },
+    );
+
+    const li = container.querySelector('[data-name="Test"]');
+    expect(li).toHaveClass("highlighted");
+  });
+
+  it("service.class merges with default class", () => {
+    const { container } = renderWithProviders(
+      <Item
+        groupName="G"
+        useEqualHeights={false}
+        service={{
+          id: "s1",
+          name: "Test",
+          class: "highlighted",
+          widgets: [],
+        }}
+      />,
+      { settings: { showStats: false, statusStyle: "basic" } },
+    );
+
+    const li = container.querySelector('[data-name="Test"]');
+    expect(li).toHaveClass("service");
+    expect(li).toHaveClass("highlighted");
+  });
+
+  it("service.class handles undefined without error", () => {
+    const { container } = renderWithProviders(
+      <Item
+        groupName="G"
+        useEqualHeights={false}
+        service={{
+          id: "s1",
+          name: "Test",
+          widgets: [],
+        }}
+      />,
+      { settings: { showStats: false, statusStyle: "basic" } },
+    );
+
+    const li = container.querySelector('[data-name="Test"]');
+    expect(li).toBeInTheDocument();
+    expect(li).toHaveClass("service");
+  });
+
   it("does not render the app status tag when the service is marked external", () => {
     renderWithProviders(
       <Item


### PR DESCRIPTION
This PR adds CSS/JS customization surfaces to service groups and service items, building on community discussion #6729.

### Changes

1. **`data-group` attribute** (from draft PR #6880): Each service group wrapper `<div>` now includes a `data-group="{group.name}"` attribute, allowing users to target specific groups by name in custom CSS/JS.

2. **Custom `data-*` attribute passthrough** (from draft PR #6881): Service groups and individual services can now pass arbitrary `data-*` attributes using the `data:` key in config:
   ```yaml
   My Group:
     data:
       environment: production
       region: us-west
   ```

3. **Custom CSS class passthrough** (from draft PR #6881): Service groups and services accept a `class:` key to add extra CSS classes:
   ```yaml
   My Group:
     class: bordered highlight
   ```

### Tests

- Comprehensive widget tests cover `data-group`, `data-*` passthrough, and `class` passthrough for both groups and service items, including edge cases (empty/undefined values, special characters, subgroups).
- All tests pass (`pnpm test`), lint passes (`pnpm lint`), build passes (`pnpm build`).

### Documentation

`docs/configs/custom-css-js.md` has been updated with sections for targeting groups by name, custom data attributes, and custom CSS classes, with YAML config examples and CSS usage examples.

Closes #6880
Closes #6881
Refs #6729
