### PR TITLE
Feat/unifi integration api

### DIFF
--- a/docs/widgets/info/unifi_controller.md
+++ b/docs/widgets/info/unifi_controller.md
@@ -26,4 +26,30 @@ An optional 'site' parameter can be supplied, if it is not the widget will use t
     username: user
     password: pass
     key: unifiapikey # required if using API key instead of username/password
+    version: 1 # optional, 1 (default) or 2, see below
+```
+
+## API versions
+
+| `version` | API                                             | Authentication           | Use for                   |
+| --------- | ----------------------------------------------- | ------------------------ | ------------------------- |
+| `1`       | Legacy Network API (`/api/...`) — **default**   | username/password or key | Unifi Network Application |
+| `2`       | Network Integration API (`/integration/v1/...`) | API key only             | UniFi OS Server           |
+
+Use `version: 2` for UniFi OS Server, where the legacy `stat/sites` endpoint is
+not available.
+
+The `site` parameter refers to the site name as reported by the Integration API,
+which is the display name (e.g. `Default`), not the internal slug.
+
+!!! note
+
+    UniFi OS Server listens on port 11443 by default.
+
+```yaml
+widget:
+  type: unifi
+  url: https://unifi.host.or.ip:11443
+  key: unifiapikey
+  version: 2
 ```

--- a/docs/widgets/services/unifi-controller.md
+++ b/docs/widgets/services/unifi-controller.md
@@ -29,4 +29,30 @@ widget:
   username: user
   password: pass
   key: unifiapikey # required if using API key instead of username/password
+  version: 1 # optional, 1 (default) or 2, see below
+```
+
+## API versions
+
+| `version` | API                                             | Authentication           | Use for                   |
+| --------- | ----------------------------------------------- | ------------------------ | ------------------------- |
+| `1`       | Legacy Network API (`/api/...`) — **default**   | username/password or key | Unifi Network Application |
+| `2`       | Network Integration API (`/integration/v1/...`) | API key only             | UniFi OS Server           |
+
+Use `version: 2` for UniFi OS Server, where the legacy `stat/sites` endpoint is
+not available.
+
+The `site` parameter refers to the site name as reported by the Integration API,
+which is the display name (e.g. `Default`), not the internal slug.
+
+!!! note
+
+    UniFi OS Server listens on port 11443 by default.
+
+```yaml
+widget:
+  type: unifi
+  url: https://unifi.host.or.ip:11443
+  key: unifiapikey
+  version: 2
 ```

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -585,6 +585,7 @@ export function cleanServiceGroups(groups) {
             "pfsense",
             "pihole",
             "speedtest",
+            "unifi",
             "wgeasy",
             "grafana",
             "gluetun",

--- a/src/utils/config/widget-helpers.js
+++ b/src/utils/config/widget-helpers.js
@@ -58,7 +58,7 @@ export async function getPrivateWidgetOptions(type, widgetIndex) {
 
   const privateOptions =
     widgets.map((widget) => {
-      const { index, url, username, password, key, apiKey } = widget.options;
+      const { index, url, username, password, key, apiKey, site, version } = widget.options;
 
       return {
         type: widget.type,
@@ -69,6 +69,8 @@ export async function getPrivateWidgetOptions(type, widgetIndex) {
           password,
           key,
           apiKey,
+          site,
+          version,
         },
       };
     }) || {};

--- a/src/utils/config/widget-helpers.test.js
+++ b/src/utils/config/widget-helpers.test.js
@@ -85,4 +85,20 @@ describe("utils/config/widget-helpers", () => {
     expect(Array.isArray(all)).toBe(true);
     expect(all[0].options.url).toBe("http://x");
   });
+
+  it("getPrivateWidgetOptions passes site and version through to the proxy", async () => {
+    fs.readFile.mockResolvedValueOnce("ignored");
+    yaml.load.mockReturnValueOnce([{ unifi_console: { url: "http://x", key: "k", site: "Site", version: 2 } }]);
+
+    const options = await getPrivateWidgetOptions("unifi_console", 0);
+    expect(options).toEqual(
+      expect.objectContaining({
+        index: 0,
+        url: "http://x",
+        key: "k",
+        site: "Site",
+        version: 2,
+      }),
+    );
+  });
 });

--- a/src/widgets/unifi/proxy.js
+++ b/src/widgets/unifi/proxy.js
@@ -1,11 +1,18 @@
 import getServiceWidget from "utils/config/service-helpers";
 import { getPrivateWidgetOptions } from "utils/config/widget-helpers";
+import createLogger from "utils/logger";
+import { asJson, formatApiCall, parseVersionForUrl } from "utils/proxy/api-helpers";
 import createUnifiProxyHandler from "utils/proxy/handlers/unifi";
 import { httpProxy } from "utils/proxy/http";
+import widgets from "widgets/widgets";
+
+const proxyName = "unifiProxyHandler";
+const logger = createLogger(proxyName);
 
 const udmpPrefix = "/proxy/network";
+const integrationPageLimit = 200;
 
-async function getWidget(req, logger) {
+async function getWidget(req, log) {
   const { group, service, index } = req.query;
 
   let widget = null;
@@ -14,20 +21,20 @@ async function getWidget(req, logger) {
     const infowidgetIndex = req.query?.query ? JSON.parse(req.query.query).index : undefined;
     widget = await getPrivateWidgetOptions("unifi_console", infowidgetIndex);
     if (!widget) {
-      logger.debug("Error retrieving settings for this Unifi widget");
+      log.debug("Error retrieving settings for this Unifi widget");
       return null;
     }
     widget.type = "unifi";
   } else {
     if (!group || !service) {
-      logger.debug("Invalid or missing service '%s' or group '%s'", service, group);
+      log.debug("Invalid or missing service '%s' or group '%s'", service, group);
       return null;
     }
 
     widget = await getServiceWidget(group, service, index);
 
     if (!widget) {
-      logger.debug("Invalid or missing widget for service '%s' in group '%s'", service, group);
+      log.debug("Invalid or missing widget for service '%s' in group '%s'", service, group);
       return null;
     }
   }
@@ -62,9 +69,208 @@ async function resolveRequestContext({ cachedPrefix, widget }) {
   return { csrfToken, headers, prefix };
 }
 
-export default createUnifiProxyHandler({
-  proxyName: "unifiProxyHandler",
+// ---------------------------------------------------------------------------
+// version 2: UniFi Network Integration API
+// ---------------------------------------------------------------------------
+
+function getWidgetVersion(widget) {
+  return parseVersionForUrl(widget.version, 1) ?? 1;
+}
+
+async function integrationGet(widget, endpoint) {
+  const url = formatApiCall(widgets[widget.type].apiv2, { endpoint, ...widget });
+  const [status, , data] = await httpProxy(url, {
+    method: "GET",
+    headers: {
+      "X-API-KEY": widget.key,
+      Accept: "application/json",
+    },
+  });
+
+  if (status !== 200) {
+    logger.error("HTTP %d getting data from UniFi integration endpoint %s. Data: %s", status, url, data);
+    const error = new Error(`HTTP Error ${status}`);
+    error.status = status;
+    error.url = url;
+    error.data = data;
+    throw error;
+  }
+
+  return asJson(data);
+}
+
+// The integration API pages every list endpoint (offset/limit/totalCount).
+async function integrationGetAll(widget, endpoint) {
+  const items = [];
+  let offset = 0;
+
+  for (;;) {
+    const separator = endpoint.includes("?") ? "&" : "?";
+    // eslint-disable-next-line no-await-in-loop
+    const page = await integrationGet(widget, `${endpoint}${separator}offset=${offset}&limit=${integrationPageLimit}`);
+    const data = page?.data ?? [];
+    items.push(...data);
+
+    offset += integrationPageLimit;
+    if (data.length < integrationPageLimit) break;
+    if (page?.totalCount !== undefined && offset >= page.totalCount) break;
+  }
+
+  return items;
+}
+
+// Only the total is needed, so request a single item and read totalCount.
+async function integrationCount(widget, endpoint) {
+  const page = await integrationGet(widget, endpoint);
+  return page?.totalCount ?? page?.count ?? page?.data?.length ?? 0;
+}
+
+// The integration API returns features as a string array (e.g. ["accessPoint"]),
+// but older/newer builds have used an object map - accept both.
+function hasFeature(device, feature) {
+  const features = device?.features;
+  if (Array.isArray(features)) {
+    return features.includes(feature);
+  }
+  const value = features?.[feature];
+  return value !== undefined && value !== null && value !== false;
+}
+
+function isAccessPoint(device) {
+  return hasFeature(device, "accessPoint") || (device?.interfaces?.radios?.length ?? 0) > 0;
+}
+
+function isSwitch(device) {
+  return hasFeature(device, "switching");
+}
+
+// The integration API has no explicit "this is the gateway" flag, so try a few
+// signals in order of reliability. Returns undefined when no gateway is adopted
+// (common on UniFi OS Server setups with access points only).
+function findGateway(devices) {
+  const byFeature = devices.find((device) => hasFeature(device, "gateway") || hasFeature(device, "routing"));
+  if (byFeature) return byFeature;
+
+  const byModel = devices.find((device) => /^(UDM|UDR|UDW|UCG|UXG|USG|UX)/i.test(device?.model ?? ""));
+  if (byModel) return byModel;
+
+  // Root of the topology - only trustworthy if uplink data is actually present.
+  if (devices.some((device) => device?.uplink?.deviceId)) {
+    return devices.find((device) => !device?.uplink?.deviceId);
+  }
+
+  return undefined;
+}
+
+function subsystemStatus(devices, userCount) {
+  if (devices.length === 0) {
+    return userCount > 0 ? "ok" : "unknown";
+  }
+  return devices.every((device) => device.state === "ONLINE") ? "ok" : "error";
+}
+
+async function handleIntegrationRequest(req, res, widget) {
+  if (!widget.key) {
+    logger.error("UniFi widget version 2 requires an API key");
+    return res.status(400).json({
+      error: { message: "UniFi widget version 2 requires an API key. Set 'key' instead of username/password." },
+    });
+  }
+
+  const sitesPage = await integrationGet(widget, "sites");
+  const sites = sitesPage?.data ?? [];
+  const site = widget.site ? sites.find((s) => s.name === widget.site) : sites[0];
+
+  if (!site) {
+    return res.status(404).json({ error: { message: `Site '${widget.site ?? "default"}' not found` } });
+  }
+
+  const wiredFilter = encodeURIComponent("type.eq('WIRED')");
+  const wirelessFilter = encodeURIComponent("type.eq('WIRELESS')");
+
+  const [wiredUsers, wirelessUsers, devices] = await Promise.all([
+    integrationCount(widget, `sites/${site.id}/clients?limit=1&filter=${wiredFilter}`),
+    integrationCount(widget, `sites/${site.id}/clients?limit=1&filter=${wirelessFilter}`),
+    integrationGetAll(widget, `sites/${site.id}/devices`),
+  ]);
+
+  const accessPoints = devices.filter(isAccessPoint);
+  const switches = devices.filter(isSwitch);
+  const gateway = findGateway(devices);
+
+  let gatewayStats;
+  if (gateway) {
+    try {
+      gatewayStats = await integrationGet(widget, `sites/${site.id}/devices/${gateway.id}/statistics/latest`);
+    } catch {
+      logger.debug("Could not read statistics for gateway %s", gateway.id);
+    }
+  }
+
+  let wanStatus = "unknown";
+  if (gateway) {
+    wanStatus = gateway.state === "ONLINE" ? "ok" : "error";
+  }
+
+  const health = [
+    {
+      subsystem: "wan",
+      status: wanStatus,
+      ...(gatewayStats?.uptimeSec ? { "gw_system-stats": { uptime: gatewayStats.uptimeSec } } : {}),
+    },
+    {
+      subsystem: "lan",
+      status: subsystemStatus(switches, wiredUsers),
+      num_user: wiredUsers,
+      num_adopted: switches.length,
+    },
+    {
+      subsystem: "wlan",
+      status: subsystemStatus(accessPoints, wirelessUsers),
+      num_user: wirelessUsers,
+      num_adopted: accessPoints.length,
+    },
+  ];
+
+  // Shaped like the legacy stat/sites response so component.jsx stays unchanged.
+  return res.status(200).json({
+    meta: { rc: "ok" },
+    data: [
+      {
+        name: "default",
+        desc: site.name,
+        health,
+      },
+    ],
+  });
+}
+
+// ---------------------------------------------------------------------------
+
+const legacyProxyHandler = createUnifiProxyHandler({
+  proxyName,
   resolveWidget: getWidget,
   resolveRequestContext,
   getLoginEndpoint: ({ prefix }) => (prefix === udmpPrefix ? "auth/login" : "login"),
 });
+
+export default async function unifiProxyHandler(req, res) {
+  const widget = await getWidget(req, logger);
+
+  if (!widget) {
+    return res.status(400).json({ error: "Invalid proxy service type" });
+  }
+
+  if (getWidgetVersion(widget) < 2) {
+    return legacyProxyHandler(req, res);
+  }
+
+  try {
+    return await handleIntegrationRequest(req, res, widget);
+  } catch (error) {
+    const status = error.status ?? 500;
+    return res.status(status).json({
+      error: { message: error.message, url: error.url, data: error.data },
+    });
+  }
+}

--- a/src/widgets/unifi/proxy.test.js
+++ b/src/widgets/unifi/proxy.test.js
@@ -43,6 +43,7 @@ vi.mock("widgets/widgets", () => ({
   default: {
     unifi: {
       api: "{url}{prefix}/api/{endpoint}",
+      apiv2: "{url}/proxy/network/integration/v1/{endpoint}",
     },
   },
 }));
@@ -145,5 +146,197 @@ describe("widgets/unifi/proxy", () => {
       method: "GET",
     });
     expect(res.statusCode).toBe(200);
+  });
+
+  it("reshapes integration API responses into the legacy stat/sites structure", async () => {
+    getServiceWidget.mockResolvedValue({
+      type: "unifi",
+      url: "http://unifi",
+      key: "secret",
+      version: 2,
+    });
+
+    httpProxy
+      // sites
+      .mockResolvedValueOnce([
+        200,
+        "application/json",
+        Buffer.from(JSON.stringify({ totalCount: 1, data: [{ id: "site-1", name: "Mahrnet" }] })),
+        {},
+      ])
+      // wired client count
+      .mockResolvedValueOnce([200, "application/json", Buffer.from(JSON.stringify({ totalCount: 0, data: [] })), {}])
+      // wireless client count
+      .mockResolvedValueOnce([200, "application/json", Buffer.from(JSON.stringify({ totalCount: 28, data: [] })), {}])
+      // devices
+      .mockResolvedValueOnce([
+        200,
+        "application/json",
+        Buffer.from(
+          JSON.stringify({
+            totalCount: 1,
+            data: [{ id: "ap-1", name: "ap01", model: "U6 Pro", state: "ONLINE", features: ["accessPoint"] }],
+          }),
+        ),
+        {},
+      ]);
+
+    const req = { query: { group: "g", service: "svc", endpoint: "stat/sites", index: "0" } };
+    const res = createMockRes();
+
+    await unifiProxyHandler(req, res);
+
+    expect(httpProxy).toHaveBeenCalledTimes(4);
+    expect(httpProxy.mock.calls[0][0].toString()).toBe("http://unifi/proxy/network/integration/v1/sites");
+    expect(httpProxy.mock.calls[1][0].toString()).toContain("/sites/site-1/clients?limit=1&filter=type.eq(");
+    expect(httpProxy.mock.calls[3][0].toString()).toContain("/sites/site-1/devices?offset=0&limit=200");
+    expect(httpProxy.mock.calls[0][1]).toMatchObject({
+      headers: { "X-API-KEY": "secret", Accept: "application/json" },
+      method: "GET",
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      meta: { rc: "ok" },
+      data: [
+        {
+          name: "default",
+          desc: "Mahrnet",
+          health: [
+            { subsystem: "wan", status: "unknown" },
+            { subsystem: "lan", status: "unknown", num_user: 0, num_adopted: 0 },
+            { subsystem: "wlan", status: "ok", num_user: 28, num_adopted: 1 },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("reports gateway uptime and wan status when a gateway is adopted", async () => {
+    getServiceWidget.mockResolvedValue({
+      type: "unifi",
+      url: "http://unifi",
+      key: "secret",
+      version: 2,
+    });
+
+    httpProxy
+      .mockResolvedValueOnce([
+        200,
+        "application/json",
+        Buffer.from(JSON.stringify({ totalCount: 1, data: [{ id: "site-1", name: "Mahrnet" }] })),
+        {},
+      ])
+      .mockResolvedValueOnce([200, "application/json", Buffer.from(JSON.stringify({ totalCount: 3, data: [] })), {}])
+      .mockResolvedValueOnce([200, "application/json", Buffer.from(JSON.stringify({ totalCount: 28, data: [] })), {}])
+      .mockResolvedValueOnce([
+        200,
+        "application/json",
+        Buffer.from(
+          JSON.stringify({
+            totalCount: 2,
+            data: [
+              { id: "ap-1", name: "ap01", model: "U6 Pro", state: "ONLINE", features: ["accessPoint"] },
+              { id: "gw-1", name: "gw", model: "UCG-Ultra", state: "ONLINE", features: [] },
+            ],
+          }),
+        ),
+        {},
+      ])
+      // latest statistics for the gateway
+      .mockResolvedValueOnce([200, "application/json", Buffer.from(JSON.stringify({ uptimeSec: 172800 })), {}]);
+
+    const req = { query: { group: "g", service: "svc", endpoint: "stat/sites", index: "0" } };
+    const res = createMockRes();
+
+    await unifiProxyHandler(req, res);
+
+    expect(httpProxy).toHaveBeenCalledTimes(5);
+    expect(httpProxy.mock.calls[4][0].toString()).toContain("/devices/gw-1/statistics/latest");
+    expect(res.body.data[0].health[0]).toEqual({
+      subsystem: "wan",
+      status: "ok",
+      "gw_system-stats": { uptime: 172800 },
+    });
+    expect(res.body.data[0].health[1]).toMatchObject({ status: "ok", num_user: 3 });
+  });
+
+  it("returns 404 when the configured site name doesn't exist", async () => {
+    getServiceWidget.mockResolvedValue({
+      type: "unifi",
+      url: "http://unifi",
+      key: "secret",
+      version: 2,
+      site: "Nope",
+    });
+
+    httpProxy.mockResolvedValueOnce([
+      200,
+      "application/json",
+      Buffer.from(JSON.stringify({ totalCount: 1, data: [{ id: "site-1", name: "Mahrnet" }] })),
+      {},
+    ]);
+
+    const req = { query: { group: "g", service: "svc", endpoint: "stat/sites", index: "0" } };
+    const res = createMockRes();
+
+    await unifiProxyHandler(req, res);
+
+    expect(httpProxy).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(404);
+    expect(res.body.error.message).toContain("Nope");
+  });
+
+  it("returns 400 when version 2 is configured without an API key", async () => {
+    getServiceWidget.mockResolvedValue({
+      type: "unifi",
+      url: "http://unifi",
+      username: "u",
+      password: "p",
+      version: 2,
+    });
+
+    const req = { query: { group: "g", service: "svc", endpoint: "stat/sites", index: "0" } };
+    const res = createMockRes();
+
+    await unifiProxyHandler(req, res);
+
+    expect(httpProxy).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("propagates upstream errors from the integration API", async () => {
+    getServiceWidget.mockResolvedValue({
+      type: "unifi",
+      url: "http://unifi",
+      key: "secret",
+      version: 2,
+    });
+
+    httpProxy.mockResolvedValueOnce([403, "application/json", Buffer.from("denied"), {}]);
+
+    const req = { query: { group: "g", service: "svc", endpoint: "stat/sites", index: "0" } };
+    const res = createMockRes();
+
+    await unifiProxyHandler(req, res);
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("uses the legacy API when version is 1", async () => {
+    getServiceWidget.mockResolvedValue({
+      type: "unifi",
+      url: "http://unifi",
+      key: "secret",
+      version: 1,
+    });
+
+    httpProxy.mockResolvedValueOnce([200, "application/json", Buffer.from("data"), {}]);
+
+    const req = { query: { group: "g", service: "svc", endpoint: "stat/sites", index: "0" } };
+    const res = createMockRes();
+
+    await unifiProxyHandler(req, res);
+
+    expect(httpProxy.mock.calls[0][0].toString()).toContain("/proxy/network/api/stat/sites");
   });
 });

--- a/src/widgets/unifi/widget.js
+++ b/src/widgets/unifi/widget.js
@@ -1,7 +1,10 @@
 import unifiProxyHandler from "./proxy";
 
 const widget = {
+  // version 1 (default): legacy UniFi Network API
   api: "{url}{prefix}/api/{endpoint}",
+  // version 2: official UniFi Network Integration API (UniFi OS / UniFi OS Server)
+  apiv2: "{url}/proxy/network/integration/v1/{endpoint}",
   proxyHandler: unifiProxyHandler,
 
   mappings: {


### PR DESCRIPTION
## Proposed change

Adds a `version` option to the `unifi` service widget and the `unifi_console`
info widget.

- `version: 1` (default) — unchanged behaviour, legacy Network API (`/api/...`)
- `version: 2` — official Network Integration API (`/proxy/network/integration/v1/...`)

UniFi OS Server does not expose the legacy `stat/sites` endpoint, so
the existing widget cannot be used there. The Integration API is available on
Network 9.0+ and authenticates with an API key instead of a session login,
which also removes the need for a local admin account without MFA.

Following the pi-hole v5/v6 pattern, the proxy reshapes the Integration API
responses into the legacy `stat/sites` structure, so both components are
unchanged:

| Block | Source |
| --- | --- |
| `wlan_users` / `lan_users` | `clients?filter=type.eq('WIRELESS'\|'WIRED')` → `totalCount` |
| `wlan_devices` / `lan_devices` | `devices`, filtered on `features` |
| `wan`, `uptime` | gateway `state` and `statistics/latest.uptimeSec` |

Two supporting changes:

- `service-helpers.js`: added `unifi` to the list of widget types that accept `version`
- `widget-helpers.js`: `getPrivateWidgetOptions` now passes `site` and `version`
  through, which it previously dropped for info widgets

Example response from `GET /proxy/network/integration/v1/sites/{siteId}/devices`:

    {
      "name": "ap01",
      "model": "U6 Pro",
      "state": "ONLINE",
      "features": ["accessPoint"],
      "uplink": null
    }

Note that `site` refers to the Integration API's `name` field, which is the
display name — there is no separate internal slug as in the legacy API.

## Type of change

- [x] New feature or enhancement (non-breaking change which adds functionality)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have added or updated tests for new features and bug fixes
- [x] If applicable, I have reviewed the feature / enhancement guidelines
- [x] I have checked that all code style checks pass
- [x] If applicable, I have tested my code for new features & regressions
- [x] In the description above I have disclosed the use of AI tools in the coding of this PR.

## Testing

Verified against UniFi OS Server 5.1.21:
five access points, no gateway adopted. Service widget and info widget both
render with `version: 2`. Legacy path (no `version` set) unchanged.

Adds 6 proxy tests covering the version 2 path (reshape, gateway uptime, site
resolution, missing key, upstream errors, version 1 fallback) and 1 test for
the option passthrough. Full suite passes: 1531 tests.

Not covered by live testing: setups with an adopted gateway or switches. The
gateway is identified heuristically (`features` → model prefix → root of the
uplink chain) because the Integration API exposes no explicit gateway flag.
Switch detection relies on `features: ["switching"]`, which is taken from the
API documentation rather than an observed response. Happy to adjust if someone
can test against a UDM/UCG or a site with switches.

## AI disclosure

A significant portion of this change was drafted with AI assistance (Claude).
I tested it against a live installation and corrected two bugs found that way:
`features` is returned as a string array rather than an object map, and the
info widget's options were being stripped before reaching the proxy.