### PR TITLE
Feature: clash service widget

### DIFF
--- a/docs/widgets/services/clash.md
+++ b/docs/widgets/services/clash.md
@@ -1,0 +1,27 @@
+---
+title: Clash
+description: Clash Widget Configuration
+---
+
+Learn more about the [Clash RESTful API](https://wiki.metacubex.one/api/).
+
+This widget talks to the Clash RESTful API, so it works with any Clash-compatible core — including mihomo (formerly Clash Meta), the core used by OpenClash on OpenWrt. Point it at the external controller (port `9090` by default) and provide the API secret if one is configured. The API secret is the `secret` field of the running core config.
+
+Allowed fields: `["mode", "active", "up", "down", "connections", "latency", "version"]`.
+Default fields: `["mode", "active", "up", "down"]`.
+
+The `active` field shows the node currently selected in a strategy group. By default the `GLOBAL` group is used; set `group` to any Selector / URLTest / Fallback group name in your config to watch that group instead.
+
+- `up` / `down` show the cumulative upload/download totals since the core started.
+- `connections` shows the number of active connections.
+- `latency` shows the last known delay of the active node, taken from the core's proxy history — it is read-only and does not trigger any latency tests.
+- `version` shows the core version string.
+
+```yaml
+widget:
+  type: clash
+  url: http://clash.host.or.ip:9090
+  key: apisecret # optional, only required if the API has a secret
+  group: PROXY # optional, strategy group to show the current selection for, default is GLOBAL
+  fields: [mode, active, up, down] # optional, defaults to all four
+```

--- a/docs/widgets/services/index.md
+++ b/docs/widgets/services/index.md
@@ -23,6 +23,7 @@ You can also find a list of all available service widgets in the sidebar navigat
 - [Caddy](caddy.md)
 - [Calendar](calendar.md)
 - [Calibre-Web](calibre-web.md)
+- [Clash](clash.md)
 - [ChangeDetection.io](changedetectionio.md)
 - [Channels DVR Server](channelsdvrserver.md)
 - [Checkmk](checkmk.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ nav:
           - widgets/services/caddy.md
           - widgets/services/calendar.md
           - widgets/services/calibre-web.md
+          - widgets/services/clash.md
           - widgets/services/changedetectionio.md
           - widgets/services/channelsdvrserver.md
           - widgets/services/checkmk.md

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -685,6 +685,15 @@
         "relativePower": "Power %",
         "limit": "Limit"
     },
+    "clash": {
+        "mode": "Mode",
+        "active": "Active",
+        "up": "Up",
+        "down": "Down",
+        "connections": "Connections",
+        "latency": "Latency",
+        "version": "Version"
+    },
     "opnsense": {
         "cpu": "CPU Load",
         "memory": "Active Memory",

--- a/src/utils/config/service-helpers.js
+++ b/src/utils/config/service-helpers.js
@@ -375,6 +375,9 @@ export function cleanServiceGroups(groups) {
           fit,
           stream,
 
+          // clash
+          group,
+
           // openmediavault
           method,
 
@@ -607,6 +610,9 @@ export function cleanServiceGroups(groups) {
         if (type === "mjpeg") {
           if (stream) widget.stream = stream;
           if (fit) widget.fit = fit;
+        }
+        if (type === "clash") {
+          if (group) widget.group = group;
         }
         if (type === "openmediavault") {
           if (method) widget.method = method;

--- a/src/utils/config/service-helpers.test.js
+++ b/src/utils/config/service-helpers.test.js
@@ -298,6 +298,7 @@ describe("utils/config/service-helpers", () => {
               { type: "glances", version: "4", metric: "cpu", refreshInterval: 2000, pointsLimit: 5, diskUnits: "gb" },
               { type: "mjpeg", stream: "s", fit: "contain" },
               { type: "openmediavault", method: "foo.bar" },
+              { type: "clash", group: "PROXY" },
               { type: "customapi", mappings: { x: 1 }, display: { y: 2 }, refreshInterval: 5000 },
               {
                 type: "calendar",
@@ -369,6 +370,7 @@ describe("utils/config/service-helpers", () => {
     );
     expect(widgets.find((w) => w.type === "jellystat")).toEqual(expect.objectContaining({ days: 7 }));
     expect(widgets.find((w) => w.type === "lubelogger")).toEqual(expect.objectContaining({ vehicleID: 12 }));
+    expect(widgets.find((w) => w.type === "clash")).toEqual(expect.objectContaining({ group: "PROXY" }));
   });
 
   it("cleanServiceGroups removes calendar integration urls from frontend widget payload", async () => {

--- a/src/utils/proxy/handlers/credentialed.js
+++ b/src/utils/proxy/handlers/credentialed.js
@@ -42,6 +42,10 @@ export default async function credentialedProxyHandler(req, res, map) {
         if (widget.provider === "finnhub" && providers?.finnhub) {
           headers["X-Finnhub-Token"] = `${providers?.finnhub}`;
         }
+      } else if (widget.type === "clash") {
+        if (widget.key) {
+          headers.Authorization = `Bearer ${widget.key}`;
+        }
       } else if (widget.type === "coinmarketcap") {
         headers["X-CMC_PRO_API_KEY"] = `${widget.key}`;
       } else if (widget.type === "gotify") {

--- a/src/utils/proxy/handlers/credentialed.test.js
+++ b/src/utils/proxy/handlers/credentialed.test.js
@@ -27,6 +27,7 @@ vi.mock("widgets/widgets", () => ({
     plantit: { api: "{url}/{endpoint}" },
     myspeed: { api: "{url}/{endpoint}" },
     esphome: { api: "{url}/{endpoint}" },
+    clash: { api: "{url}/{endpoint}" },
     wgeasy: { api: "{url}/{endpoint}" },
     linkwarden: { api: "{url}/api/v1/{endpoint}" },
     miniflux: { api: "{url}/{endpoint}" },
@@ -295,6 +296,32 @@ describe("utils/proxy/handlers/credentialed", () => {
     expect(params.headers.Authorization).toMatch(/^Basic /);
   });
 
+  it("uses Bearer auth for clash when key is provided", async () => {
+    getServiceWidget.mockResolvedValue({ type: "clash", url: "http://x", key: "secret" });
+    httpProxy.mockResolvedValue([200, "application/json", { ok: true }]);
+
+    const req = { method: "GET", query: { group: "g", service: "s", endpoint: "proxies", index: 0 } };
+    const res = createMockRes();
+
+    await credentialedProxyHandler(req, res);
+
+    const [, params] = httpProxy.mock.calls.at(-1);
+    expect(params.headers.Authorization).toBe("Bearer secret");
+  });
+
+  it("sends no auth header for clash when no key is configured", async () => {
+    getServiceWidget.mockResolvedValue({ type: "clash", url: "http://x" });
+    httpProxy.mockResolvedValue([200, "application/json", { ok: true }]);
+
+    const req = { method: "GET", query: { group: "g", service: "s", endpoint: "configs", index: 0 } };
+    const res = createMockRes();
+
+    await credentialedProxyHandler(req, res);
+
+    const [, params] = httpProxy.mock.calls.at(-1);
+    expect(params.headers.Authorization).toBeUndefined();
+  });
+
   it("covers additional auth/header modes for common widgets", async () => {
     const cases = [
       [{ type: "coinmarketcap", url: "http://x", key: "k" }, { "X-CMC_PRO_API_KEY": "k" }],
@@ -309,6 +336,7 @@ describe("utils/proxy/handlers/credentialed", () => {
       [{ type: "trilium", url: "http://x", key: "k" }, { Authorization: "k" }],
       [{ type: "gitlab", url: "http://x", key: "k" }, { "PRIVATE-TOKEN": "k" }],
       [{ type: "speedtest", url: "http://x", key: "k" }, { Authorization: "Bearer k" }],
+      [{ type: "clash", url: "http://x", key: "k" }, { Authorization: "Bearer k" }],
       [
         { type: "azuredevops", url: "http://x", key: "k" },
         { Authorization: `Basic ${Buffer.from("$:k").toString("base64")}` },

--- a/src/widgets/clash/component.jsx
+++ b/src/widgets/clash/component.jsx
@@ -1,0 +1,72 @@
+import Block from "components/services/widget/block";
+import Container from "components/services/widget/container";
+import { useTranslation } from "next-i18next/pages";
+
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+const DEFAULT_FIELDS = ["mode", "active", "up", "down"];
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+  const { widget } = service;
+
+  if (!widget.fields?.length) {
+    widget.fields = DEFAULT_FIELDS;
+  }
+
+  const includeConnections = ["up", "down", "connections"].some((field) => widget.fields.includes(field));
+  const includeVersion = widget.fields.includes("version");
+
+  const { data: configsData, error: configsError } = useWidgetAPI(widget, "configs");
+  const { data: proxiesData, error: proxiesError } = useWidgetAPI(widget, "proxies");
+  const { data: connectionsData, error: connectionsError } = useWidgetAPI(
+    widget,
+    includeConnections ? "connections" : "",
+  );
+  const { data: versionData, error: versionError } = useWidgetAPI(widget, includeVersion ? "version" : "");
+
+  if (configsError || proxiesError || connectionsError || versionError) {
+    const finalError = configsError ?? proxiesError ?? connectionsError ?? versionError;
+    return <Container service={service} error={finalError} />;
+  }
+
+  if (!configsData || !proxiesData || (includeConnections && !connectionsData) || (includeVersion && !versionData)) {
+    return (
+      <Container service={service}>
+        <Block label="clash.mode" />
+        <Block label="clash.active" />
+        <Block label="clash.up" />
+        <Block label="clash.down" />
+        <Block label="clash.connections" />
+        <Block label="clash.latency" />
+        <Block label="clash.version" />
+      </Container>
+    );
+  }
+
+  const groupName = widget.group || "GLOBAL";
+  const activeProxy = proxiesData.proxies?.[groupName]?.now;
+  const history = proxiesData.proxies?.[activeProxy]?.history;
+  const latency = history?.length ? history[history.length - 1].delay : undefined;
+  const latencyValue = latency > 0 ? t("common.ms", { value: latency }) : "-";
+
+  return (
+    <Container service={service}>
+      <Block field="clash.mode" label="clash.mode" value={configsData.mode} />
+      <Block field="clash.active" label="clash.active" value={activeProxy} />
+      <Block field="clash.up" label="clash.up" value={t("common.bytes", { value: connectionsData?.uploadTotal })} />
+      <Block
+        field="clash.down"
+        label="clash.down"
+        value={t("common.bytes", { value: connectionsData?.downloadTotal })}
+      />
+      <Block
+        field="clash.connections"
+        label="clash.connections"
+        value={t("common.number", { value: connectionsData?.connections?.length })}
+      />
+      <Block field="clash.latency" label="clash.latency" value={latencyValue} />
+      <Block field="clash.version" label="clash.version" value={versionData?.version} />
+    </Container>
+  );
+}

--- a/src/widgets/clash/component.test.jsx
+++ b/src/widgets/clash/component.test.jsx
@@ -1,0 +1,224 @@
+// @vitest-environment jsdom
+
+import { screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "test-utils/render-with-providers";
+import { expectBlockValue } from "test-utils/widget-assertions";
+
+const { useWidgetAPI } = vi.hoisted(() => ({ useWidgetAPI: vi.fn() }));
+vi.mock("utils/proxy/use-widget-api", () => ({ default: useWidgetAPI }));
+
+import Component from "./component";
+
+function proxiesPayload(overrides = {}) {
+  return {
+    data: {
+      proxies: {
+        GLOBAL: { type: "Selector", now: "Node 01", all: ["Node 01", "DIRECT"] },
+        PROXY: { type: "Selector", now: "DIRECT", all: ["Node 01", "DIRECT"] },
+        "Node 01": {
+          type: "Shadowsocks",
+          history: [
+            { time: "t1", delay: 42 },
+            { time: "t2", delay: 38 },
+          ],
+        },
+        DIRECT: { type: "Direct", history: [] },
+        ...overrides,
+      },
+    },
+    error: undefined,
+  };
+}
+
+function connectionsPayload(overrides = {}) {
+  return {
+    data: {
+      uploadTotal: 12345,
+      downloadTotal: 67890,
+      connections: [{ id: "1" }, { id: "2" }, { id: "3" }],
+      ...overrides,
+    },
+    error: undefined,
+  };
+}
+
+describe("widgets/clash/component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("defaults fields to mode, active, up and down and renders placeholders while loading", () => {
+    useWidgetAPI.mockReturnValue({ data: undefined, error: undefined });
+
+    const service = { widget: { type: "clash", url: "http://x" } };
+    const { container } = renderWithProviders(<Component service={service} />, { settings: { hideErrors: false } });
+
+    expect(service.widget.fields).toEqual(["mode", "active", "up", "down"]);
+    expect(container.querySelectorAll(".service-block")).toHaveLength(4);
+    expect(screen.getByText("clash.mode")).toBeInTheDocument();
+    expect(screen.getByText("clash.active")).toBeInTheDocument();
+    expect(screen.getByText("clash.up")).toBeInTheDocument();
+    expect(screen.getByText("clash.down")).toBeInTheDocument();
+  });
+
+  it("fetches configs, proxies and connections but not version by default", () => {
+    useWidgetAPI.mockReturnValue({ data: undefined, error: undefined });
+
+    renderWithProviders(<Component service={{ widget: { type: "clash", url: "http://x" } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expect(useWidgetAPI.mock.calls.map((call) => call[1])).toEqual(["configs", "proxies", "connections", ""]);
+  });
+
+  it("fetches the version endpoint when the version field is selected", () => {
+    useWidgetAPI.mockReturnValue({ data: undefined, error: undefined });
+
+    renderWithProviders(
+      <Component service={{ widget: { type: "clash", fields: ["mode", "active", "up", "down", "version"] } }} />,
+      { settings: { hideErrors: false } },
+    );
+
+    expect(useWidgetAPI.mock.calls.map((call) => call[1])).toEqual(["configs", "proxies", "connections", "version"]);
+  });
+
+  it("skips the connections call when none of its fields are selected", () => {
+    useWidgetAPI.mockReturnValue({ data: undefined, error: undefined });
+
+    renderWithProviders(<Component service={{ widget: { type: "clash", fields: ["mode", "active", "latency"] } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expect(useWidgetAPI.mock.calls.map((call) => call[1])).toEqual(["configs", "proxies", "", ""]);
+  });
+
+  it("renders mode, active proxy and cumulative up/down totals by default", () => {
+    useWidgetAPI.mockImplementation((_widget, endpoint) => {
+      if (endpoint === "configs") return { data: { mode: "rule" }, error: undefined };
+      if (endpoint === "proxies") return proxiesPayload();
+      if (endpoint === "connections") return connectionsPayload();
+      return { data: undefined, error: undefined };
+    });
+
+    const { container } = renderWithProviders(<Component service={{ widget: { type: "clash" } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expect(container.querySelectorAll(".service-block")).toHaveLength(4);
+    expectBlockValue(container, "clash.mode", "rule");
+    expectBlockValue(container, "clash.active", "Node 01");
+    expectBlockValue(container, "clash.up", 12345);
+    expectBlockValue(container, "clash.down", 67890);
+  });
+
+  it("uses the configured strategy group to determine the active proxy", () => {
+    useWidgetAPI.mockImplementation((_widget, endpoint) => {
+      if (endpoint === "configs") return { data: { mode: "global" }, error: undefined };
+      if (endpoint === "proxies") return proxiesPayload();
+      if (endpoint === "connections") return connectionsPayload();
+      return { data: undefined, error: undefined };
+    });
+
+    const { container } = renderWithProviders(<Component service={{ widget: { type: "clash", group: "PROXY" } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expectBlockValue(container, "clash.active", "DIRECT");
+  });
+
+  it("renders the active connection count when the connections field is selected", () => {
+    useWidgetAPI.mockImplementation((_widget, endpoint) => {
+      if (endpoint === "configs") return { data: { mode: "rule" }, error: undefined };
+      if (endpoint === "proxies") return proxiesPayload();
+      if (endpoint === "connections") return connectionsPayload();
+      return { data: undefined, error: undefined };
+    });
+
+    const { container } = renderWithProviders(
+      <Component service={{ widget: { type: "clash", fields: ["mode", "active", "up", "connections"] } }} />,
+      { settings: { hideErrors: false } },
+    );
+
+    expectBlockValue(container, "clash.connections", 3);
+  });
+
+  it("renders the last known latency of the active node", () => {
+    useWidgetAPI.mockImplementation((_widget, endpoint) => {
+      if (endpoint === "configs") return { data: { mode: "rule" }, error: undefined };
+      if (endpoint === "proxies") return proxiesPayload();
+      return { data: undefined, error: undefined };
+    });
+
+    const { container } = renderWithProviders(
+      <Component service={{ widget: { type: "clash", fields: ["mode", "active", "latency"] } }} />,
+      { settings: { hideErrors: false } },
+    );
+
+    expectBlockValue(container, "clash.latency", 38);
+  });
+
+  it("shows a dash for latency when the active proxy has no known delay", () => {
+    useWidgetAPI.mockImplementation((_widget, endpoint) => {
+      if (endpoint === "configs") return { data: { mode: "rule" }, error: undefined };
+      if (endpoint === "proxies") return proxiesPayload();
+      return { data: undefined, error: undefined };
+    });
+
+    const { container } = renderWithProviders(
+      <Component service={{ widget: { type: "clash", fields: ["mode", "active", "latency"], group: "PROXY" } }} />,
+      { settings: { hideErrors: false } },
+    );
+
+    expectBlockValue(container, "clash.latency", "-");
+  });
+
+  it("renders the version when the version field is selected", () => {
+    useWidgetAPI.mockImplementation((_widget, endpoint) => {
+      if (endpoint === "configs") return { data: { mode: "rule" }, error: undefined };
+      if (endpoint === "proxies") return proxiesPayload();
+      if (endpoint === "connections") return connectionsPayload();
+      if (endpoint === "version") return { data: { meta: true, version: "v1.19.10" }, error: undefined };
+      return { data: undefined, error: undefined };
+    });
+
+    const { container } = renderWithProviders(
+      <Component service={{ widget: { type: "clash", fields: ["mode", "active", "up", "version"] } }} />,
+      { settings: { hideErrors: false } },
+    );
+
+    expectBlockValue(container, "clash.version", "v1.19.10");
+  });
+
+  it("respects the fields selection", () => {
+    useWidgetAPI.mockImplementation((_widget, endpoint) => {
+      if (endpoint === "configs") return { data: { mode: "rule" }, error: undefined };
+      if (endpoint === "proxies") return proxiesPayload();
+      if (endpoint === "connections") return connectionsPayload();
+      return { data: undefined, error: undefined };
+    });
+
+    const { container } = renderWithProviders(
+      <Component service={{ widget: { type: "clash", fields: ["mode", "active"] } }} />,
+      { settings: { hideErrors: false } },
+    );
+
+    expect(container.querySelectorAll(".service-block")).toHaveLength(2);
+    expectBlockValue(container, "clash.mode", "rule");
+    expectBlockValue(container, "clash.active", "Node 01");
+  });
+
+  it("renders the error state when an endpoint fails", () => {
+    useWidgetAPI.mockImplementation((_widget, endpoint) => {
+      if (endpoint === "proxies") return { data: undefined, error: { message: "unauthorized" } };
+      return { data: undefined, error: undefined };
+    });
+
+    renderWithProviders(<Component service={{ widget: { type: "clash" } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expect(screen.getAllByText(/widget\.api_error/i).length).toBeGreaterThan(0);
+  });
+});

--- a/src/widgets/clash/widget.js
+++ b/src/widgets/clash/widget.js
@@ -1,0 +1,27 @@
+import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
+
+const widget = {
+  api: "{url}/{endpoint}",
+  proxyHandler: credentialedProxyHandler,
+
+  mappings: {
+    configs: {
+      endpoint: "configs",
+      validate: ["mode"],
+    },
+    proxies: {
+      endpoint: "proxies",
+      validate: ["proxies"],
+    },
+    connections: {
+      endpoint: "connections",
+      validate: ["connections"],
+    },
+    version: {
+      endpoint: "version",
+      validate: ["version"],
+    },
+  },
+};
+
+export default widget;

--- a/src/widgets/clash/widget.test.js
+++ b/src/widgets/clash/widget.test.js
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { expectWidgetConfigShape } from "test-utils/widget-config";
+
+import widget from "./widget";
+
+describe("clash widget config", () => {
+  it("exports a valid widget config", () => {
+    expectWidgetConfigShape(widget);
+  });
+
+  it("validates required response keys for each endpoint", () => {
+    expect(widget.mappings.configs.validate).toEqual(["mode"]);
+    expect(widget.mappings.proxies.validate).toEqual(["proxies"]);
+    expect(widget.mappings.connections.validate).toEqual(["connections"]);
+    expect(widget.mappings.version.validate).toEqual(["version"]);
+  });
+
+  it("maps the configs, proxies, connections and version endpoints", () => {
+    expect(widget.mappings.configs.endpoint).toBe("configs");
+    expect(widget.mappings.proxies.endpoint).toBe("proxies");
+    expect(widget.mappings.connections.endpoint).toBe("connections");
+    expect(widget.mappings.version.endpoint).toBe("version");
+  });
+});

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -98,6 +98,7 @@ const components = {
   octoprint: dynamic(() => import("./octoprint/component")),
   omada: dynamic(() => import("./omada/component")),
   ombi: dynamic(() => import("./ombi/component")),
+  clash: dynamic(() => import("./clash/component")),
   opendtu: dynamic(() => import("./opendtu/component")),
   opnsense: dynamic(() => import("./opnsense/component")),
   overseerr: dynamic(() => import("./seerr/component")),

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -17,6 +17,7 @@ import calibreweb from "./calibreweb/widget";
 import changedetectionio from "./changedetectionio/widget";
 import channelsdvrserver from "./channelsdvrserver/widget";
 import checkmk from "./checkmk/widget";
+import clash from "./clash/widget";
 import cloudflared from "./cloudflared/widget";
 import coinmarketcap from "./coinmarketcap/widget";
 import crowdsec from "./crowdsec/widget";
@@ -174,6 +175,7 @@ const widgets = {
   beszel,
   caddy,
   calibreweb,
+  clash,
   changedetectionio,
   channelsdvrserver,
   checkmk,


### PR DESCRIPTION
Adds a Clash RESTful API service widget, compatible with mihomo (formerly Clash Meta) cores such as the one used by OpenClash on OpenWrt.

Default fields: `mode`, `active`, `up`, `down`. Optional fields: `connections`, `latency`, `version`.

See the [mihomo / Clash API documentation](https://wiki.metacubex.one/api/).

> Note: This PR was developed with AI assistance (Codex).