### PR TITLE
Enhancement: Add album count to Jellyfin widget

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -132,7 +132,8 @@
         "movies": "Movies",
         "series": "Series",
         "episodes": "Episodes",
-        "songs": "Songs"
+        "songs": "Songs",
+        "albums": "Albums"
     },
     "esphome": {
         "offline": "Offline",

--- a/src/widgets/jellyfin/component.jsx
+++ b/src/widgets/jellyfin/component.jsx
@@ -182,14 +182,11 @@ function CountBlocks({ service, countData }) {
     series: "SeriesCount",
     episodes: "EpisodeCount",
     albums: "AlbumCount",
-    songs: "SongCount"
+    songs: "SongCount",
   };
 
   const userFields = service?.widget?.fields || Object.keys(availableFields);
-  const displayFields = userFields
-    .filter((field) => availableFields[field])
-    .slice(0, 4);
-
+  const displayFields = userFields.filter((field) => availableFields[field]).slice(0, 4);
 
   return (
     <Container service={service}>

--- a/src/widgets/jellyfin/component.jsx
+++ b/src/widgets/jellyfin/component.jsx
@@ -176,27 +176,33 @@ function SessionEntry({ playCommand, session, enableUser, showEpisodeNumber, ena
 
 function CountBlocks({ service, countData }) {
   const { t } = useTranslation();
+  const { widget } = service;
 
-  const availableFields = {
-    movies: "MovieCount",
-    series: "SeriesCount",
-    episodes: "EpisodeCount",
-    albums: "AlbumCount",
-    songs: "SongCount",
-  };
+  if (!widget.fields || widget.fields.length === 0) {
+    widget.fields = ["movies", "series", "episodes", "songs"];
+  } else if (widget.fields?.length > 4) {
+    widget.fields = widget.fields.slice(0, 4);
+  }
 
-  const userFields = service?.widget?.fields || Object.keys(availableFields);
-  const displayFields = userFields.filter((field) => availableFields[field]).slice(0, 4);
+  if (!countData) {
+    return (
+      <Container service={service}>
+        <Block label="jellyfin.movies" />
+        <Block label="jellyfin.series" />
+        <Block label="jellyfin.episodes" />
+        <Block label="jellyfin.songs" />
+        <Block label="jellyfin.albums" />
+      </Container>
+    );
+  }
 
   return (
     <Container service={service}>
-      {displayFields.map((field) => (
-        <Block
-          key={`jellyfin.${field}`}
-          label={`jellyfin.${field}`}
-          value={countData ? t("common.number", { value: countData[availableFields[field]] }) : undefined}
-        />
-      ))}
+      <Block label="jellyfin.movies" value={t("common.number", { value: countData.MovieCount })} />
+      <Block label="jellyfin.series" value={t("common.number", { value: countData.SeriesCount })} />
+      <Block label="jellyfin.episodes" value={t("common.number", { value: countData.EpisodeCount })} />
+      <Block label="jellyfin.songs" value={t("common.number", { value: countData.SongCount })} />
+      <Block label="jellyfin.albums" value={t("common.number", { value: countData.AlbumCount })} />
     </Container>
   );
 }

--- a/src/widgets/jellyfin/component.jsx
+++ b/src/widgets/jellyfin/component.jsx
@@ -176,26 +176,33 @@ function SessionEntry({ playCommand, session, enableUser, showEpisodeNumber, ena
 
 function CountBlocks({ service, countData }) {
   const { t } = useTranslation();
+  const mappings = [
+    { key: "jellyfin.movies", dataKey: "MovieCount" },
+    { key: "jellyfin.series", dataKey: "SeriesCount" },
+    { key: "jellyfin.episodes", dataKey: "EpisodeCount" },
+    { key: "jellyfin.albums", dataKey: "AlbumCount" },
+    { key: "jellyfin.songs", dataKey: "SongCount" }
+  ];
 
   if (!countData) {
     return (
       <Container service={service}>
-        <Block label="jellyfin.movies" />
-        <Block label="jellyfin.series" />
-        <Block label="jellyfin.episodes" />
-        <Block label="jellyfin.albums" />
-        <Block label="jellyfin.songs" />
+        {mappings.slice(0, 4).map(({ key }) => (
+          <Block label={key} />
+        ))}
       </Container>
     );
   }
 
   return (
     <Container service={service}>
-      <Block label="jellyfin.movies" value={t("common.number", { value: countData.MovieCount })} />
-      <Block label="jellyfin.series" value={t("common.number", { value: countData.SeriesCount })} />
-      <Block label="jellyfin.episodes" value={t("common.number", { value: countData.EpisodeCount })} />
-      <Block label="jellyfin.albums" value={t("common.number", { value: countData.AlbumCount })} />
-      <Block label="jellyfin.songs" value={t("common.number", { value: countData.SongCount })} />
+      {mappings.slice(0, 4).map(({ key, dataKey }) => (
+        <Block
+          key={key}
+          label={key}
+          value={countData ? t("common.number", { value: countData[dataKey] }) : undefined} 
+        />
+      ))}
     </Container>
   );
 }

--- a/src/widgets/jellyfin/component.jsx
+++ b/src/widgets/jellyfin/component.jsx
@@ -176,31 +176,28 @@ function SessionEntry({ playCommand, session, enableUser, showEpisodeNumber, ena
 
 function CountBlocks({ service, countData }) {
   const { t } = useTranslation();
-  const mappings = [
-    { key: "jellyfin.movies", dataKey: "MovieCount" },
-    { key: "jellyfin.series", dataKey: "SeriesCount" },
-    { key: "jellyfin.episodes", dataKey: "EpisodeCount" },
-    { key: "jellyfin.albums", dataKey: "AlbumCount" },
-    { key: "jellyfin.songs", dataKey: "SongCount" },
-  ];
 
-  if (!countData) {
-    return (
-      <Container service={service}>
-        {mappings.slice(0, 4).map(({ key }) => (
-          <Block label={key} />
-        ))}
-      </Container>
-    );
-  }
+  const availableFields = {
+    movies: "MovieCount",
+    series: "SeriesCount",
+    episodes: "EpisodeCount",
+    albums: "AlbumCount",
+    songs: "SongCount"
+  };
+
+  const userFields = service?.widget?.fields || Object.keys(availableFields);
+  const displayFields = userFields
+    .filter((field) => availableFields[field])
+    .slice(0, 4);
+
 
   return (
     <Container service={service}>
-      {mappings.slice(0, 4).map(({ key, dataKey }) => (
+      {displayFields.map((field) => (
         <Block
-          key={key}
-          label={key}
-          value={countData ? t("common.number", { value: countData[dataKey] }) : undefined}
+          key={`jellyfin.${field}`}
+          label={`jellyfin.${field}`}
+          value={countData ? t("common.number", { value: countData[availableFields[field]] }) : undefined}
         />
       ))}
     </Container>

--- a/src/widgets/jellyfin/component.jsx
+++ b/src/widgets/jellyfin/component.jsx
@@ -181,7 +181,7 @@ function CountBlocks({ service, countData }) {
     { key: "jellyfin.series", dataKey: "SeriesCount" },
     { key: "jellyfin.episodes", dataKey: "EpisodeCount" },
     { key: "jellyfin.albums", dataKey: "AlbumCount" },
-    { key: "jellyfin.songs", dataKey: "SongCount" }
+    { key: "jellyfin.songs", dataKey: "SongCount" },
   ];
 
   if (!countData) {
@@ -200,7 +200,7 @@ function CountBlocks({ service, countData }) {
         <Block
           key={key}
           label={key}
-          value={countData ? t("common.number", { value: countData[dataKey] }) : undefined} 
+          value={countData ? t("common.number", { value: countData[dataKey] }) : undefined}
         />
       ))}
     </Container>

--- a/src/widgets/jellyfin/component.jsx
+++ b/src/widgets/jellyfin/component.jsx
@@ -183,6 +183,7 @@ function CountBlocks({ service, countData }) {
         <Block label="jellyfin.movies" />
         <Block label="jellyfin.series" />
         <Block label="jellyfin.episodes" />
+        <Block label="jellyfin.albums" />
         <Block label="jellyfin.songs" />
       </Container>
     );
@@ -193,6 +194,7 @@ function CountBlocks({ service, countData }) {
       <Block label="jellyfin.movies" value={t("common.number", { value: countData.MovieCount })} />
       <Block label="jellyfin.series" value={t("common.number", { value: countData.SeriesCount })} />
       <Block label="jellyfin.episodes" value={t("common.number", { value: countData.EpisodeCount })} />
+      <Block label="jellyfin.albums" value={t("common.number", { value: countData.AlbumCount })} />
       <Block label="jellyfin.songs" value={t("common.number", { value: countData.SongCount })} />
     </Container>
   );

--- a/src/widgets/jellyfin/component.test.jsx
+++ b/src/widgets/jellyfin/component.test.jsx
@@ -33,6 +33,7 @@ describe("widgets/jellyfin/component", () => {
     expect(screen.getByText("jellyfin.series")).toBeInTheDocument();
     expect(screen.getByText("jellyfin.episodes")).toBeInTheDocument();
     expect(screen.getByText("jellyfin.songs")).toBeInTheDocument();
+    expect(screen.getByText("jellyfin.albums")).toBeInTheDocument();
     expect(screen.getAllByText("-").length).toBeGreaterThan(0);
   });
 

--- a/src/widgets/jellyfin/component.test.jsx
+++ b/src/widgets/jellyfin/component.test.jsx
@@ -32,7 +32,7 @@ describe("widgets/jellyfin/component", () => {
     expect(screen.getByText("jellyfin.movies")).toBeInTheDocument();
     expect(screen.getByText("jellyfin.series")).toBeInTheDocument();
     expect(screen.getByText("jellyfin.episodes")).toBeInTheDocument();
-    expect(screen.getByText("jellyfin.albums")).toBeInTheDocument();
+    expect(screen.getByText("jellyfin.songs")).toBeInTheDocument();
     expect(screen.getAllByText("-").length).toBeGreaterThan(0);
   });
 
@@ -57,7 +57,7 @@ describe("widgets/jellyfin/component", () => {
     expect(screen.getByText("1")).toBeInTheDocument();
     expect(screen.getByText("2")).toBeInTheDocument();
     expect(screen.getByText("3")).toBeInTheDocument();
-    expect(screen.getByText("5")).toBeInTheDocument();
+    expect(screen.getByText("4")).toBeInTheDocument();
   });
 
   it("renders a single now-playing entry (expanded to two rows by default)", () => {
@@ -88,5 +88,22 @@ describe("widgets/jellyfin/component", () => {
     // Time strings are rendered in a combined node (e.g. "00:00/01:00").
     expect(screen.getByText(/00:00/)).toBeInTheDocument();
     expect(screen.getByText(/01:00/)).toBeInTheDocument();
+  });
+
+  it("renders optional albums field when included", () => {
+    useWidgetAPI
+      .mockReturnValueOnce({ data: [], error: undefined, mutate: vi.fn() }) // sessions
+      .mockImplementation(() => ({
+        data: { MovieCount: 1, SeriesCount: 2, EpisodeCount: 3, SongCount: 4, AlbumCount: 5 },
+        error: undefined,
+      }));
+
+    renderWithProviders(
+      <Component
+        service={{
+          widget: { type: "jellyfin", url: "http://x", fields: ["movies", "series", "episodes", "albums"] },
+        }}
+      />,
+    );
   });
 });

--- a/src/widgets/jellyfin/component.test.jsx
+++ b/src/widgets/jellyfin/component.test.jsx
@@ -32,7 +32,6 @@ describe("widgets/jellyfin/component", () => {
     expect(screen.getByText("jellyfin.movies")).toBeInTheDocument();
     expect(screen.getByText("jellyfin.series")).toBeInTheDocument();
     expect(screen.getByText("jellyfin.episodes")).toBeInTheDocument();
-    expect(screen.getByText("jellyfin.songs")).toBeInTheDocument();
     expect(screen.getByText("jellyfin.albums")).toBeInTheDocument();
     expect(screen.getAllByText("-").length).toBeGreaterThan(0);
   });
@@ -41,7 +40,7 @@ describe("widgets/jellyfin/component", () => {
     useWidgetAPI
       .mockReturnValueOnce({ data: [], error: undefined, mutate: vi.fn() }) // sessions
       .mockReturnValueOnce({
-        data: { MovieCount: 1, SeriesCount: 2, EpisodeCount: 3, SongCount: 4 },
+        data: { MovieCount: 1, SeriesCount: 2, EpisodeCount: 3, SongCount: 4, AlbumCount: 5 },
         error: undefined,
       }); // count
 
@@ -58,7 +57,7 @@ describe("widgets/jellyfin/component", () => {
     expect(screen.getByText("1")).toBeInTheDocument();
     expect(screen.getByText("2")).toBeInTheDocument();
     expect(screen.getByText("3")).toBeInTheDocument();
-    expect(screen.getByText("4")).toBeInTheDocument();
+    expect(screen.getByText("5")).toBeInTheDocument();
   });
 
   it("renders a single now-playing entry (expanded to two rows by default)", () => {


### PR DESCRIPTION
## Proposed change

Adds the album count to the Jellyfin widget as requested by [Services widget Jellyfin - add field "albums"](https://github.com/gethomepage/homepage/discussions/6343). This is easily achieved as the data was already present in the API call.

Appreciate this breaks the guidance that "widgets should be no more than 4 blocks wide" however given consumers are free to configure fields to be displayed it doesn't force 5 blocks

Web view with all 5 fields
<img width="598" height="190" alt="image" src="https://github.com/user-attachments/assets/18b46cbb-3f35-4925-8b33-69fc06798db7" />

Just audio counts configured (mobile)
<img width="408" height="176" alt="image" src="https://github.com/user-attachments/assets/3d9af9b1-d55f-4ec4-afea-eb020d59df8c" />

Just video counts configured (mobile)
<img width="408" height="176" alt="image" src="https://github.com/user-attachments/assets/761aa8e8-9cfc-44b0-b2f2-34037f35ec67" />



## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [ ] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] In the description above I have disclosed the use of AI tools in the coding of this PR.
