### PR TITLE
Enhancement: add authorizationsLast24H field to Authentik widget, opt…

### DIFF
--- a/docs/widgets/services/authentik.md
+++ b/docs/widgets/services/authentik.md
@@ -5,7 +5,7 @@ description: Authentik Widget Configuration
 
 Learn more about [Authentik](https://github.com/goauthentik/authentik).
 
-This widget reads the number of active users in the system, as well as logins for the last 24 hours.
+This widget reads the number of active users in the system, as well as logins and authorizations for the last 24 hours.
 
 You will need to generate an API token for an existing user under `Admin Portal` > `Directory` > `Tokens & App passwords`.
 Make sure to set Intent to "API Token".

--- a/docs/widgets/services/authentik.md
+++ b/docs/widgets/services/authentik.md
@@ -5,7 +5,7 @@ description: Authentik Widget Configuration
 
 Learn more about [Authentik](https://github.com/goauthentik/authentik).
 
-This widget reads the number of active users in the system, as well as logins and authorizations (authorizations is supported only for v2 widget version) for the last 24 hours.
+This widget reads the number of active users in the system, as well as logins for the last 24 hours, and authorizations when using widget version 2.
 
 You will need to generate an API token for an existing user under `Admin Portal` > `Directory` > `Tokens & App passwords`.
 Make sure to set Intent to "API Token".
@@ -15,7 +15,7 @@ The account you made the API token for also needs the following **Assigned globa
 - authentik Core -> Can view User (Model: User)
 - authentik Events -> Can view Event (Model: Event)
 
-Allowed fields: `["users", "loginsLast24H", "failedLoginsLast24H", "authorizationsLast24H"]`.
+Allowed fields: `["users", "loginsLast24H", "failedLoginsLast24H", "authorizationsLast24H"]` (`authorizationsLast24H` works with v2 only).
 
 | Authentik Version | Homepage Widget Version |
 | ----------------- | ----------------------- |

--- a/docs/widgets/services/authentik.md
+++ b/docs/widgets/services/authentik.md
@@ -5,7 +5,7 @@ description: Authentik Widget Configuration
 
 Learn more about [Authentik](https://github.com/goauthentik/authentik).
 
-This widget reads the number of active users in the system, as well as logins and authorizations for the last 24 hours.
+This widget reads the number of active users in the system, as well as logins and authorizations (authorizations is supported only for v2 widget version) for the last 24 hours.
 
 You will need to generate an API token for an existing user under `Admin Portal` > `Directory` > `Tokens & App passwords`.
 Make sure to set Intent to "API Token".

--- a/docs/widgets/services/authentik.md
+++ b/docs/widgets/services/authentik.md
@@ -15,7 +15,7 @@ The account you made the API token for also needs the following **Assigned globa
 - authentik Core -> Can view User (Model: User)
 - authentik Events -> Can view Event (Model: Event)
 
-Allowed fields: `["users", "loginsLast24H", "failedLoginsLast24H"]`.
+Allowed fields: `["users", "loginsLast24H", "failedLoginsLast24H", "authorizationsLast24H"]`.
 
 | Authentik Version | Homepage Widget Version |
 | ----------------- | ----------------------- |

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -471,7 +471,8 @@
     "authentik": {
         "users": "Users",
         "loginsLast24H": "Logins (24h)",
-        "failedLoginsLast24H": "Failed Logins (24h)"
+        "failedLoginsLast24H": "Failed Logins (24h)",
+        "authorizationsLast24H": "Auths (24h)"
     },
     "proxmox": {
         "mem": "MEM",

--- a/src/widgets/authentik/component.jsx
+++ b/src/widgets/authentik/component.jsx
@@ -18,20 +18,15 @@ export default function Component({ service }) {
   const failedLoginsEndpoint = isV2 ? "" : "login_failed";
   const { data: failedLoginsData, error: failedLoginsError } = useWidgetAPI(widget, failedLoginsEndpoint);
 
-  const authorizationsEndpoint = isV2 ? "" : "authorizations";
-  const { data: authorizationsData, error: authorizationsError } = useWidgetAPI(widget, authorizationsEndpoint);
-
   const eventsDataEndpoint = isV2 ? "datav2" : "";
   const { data: eventsData, error: eventsDataError } = useWidgetAPI(widget, eventsDataEndpoint);
 
-  if (usersError || loginsError || failedLoginsError || authorizationsError || eventsDataError) {
-    const finalError = usersError ?? loginsError ?? failedLoginsError ?? authorizationsError ?? eventsDataError;
+  if (usersError || loginsError || failedLoginsError || eventsDataError) {
+    const finalError = usersError ?? loginsError ?? failedLoginsError ?? eventsDataError;
     return <Container service={service} error={finalError} />;
   }
 
-  const hasNoData = isV2
-    ? !usersData || !eventsData
-    : !usersData || !loginsData || !failedLoginsData || !authorizationsData;
+  const hasNoData = isV2 ? !usersData || !eventsData : !usersData || !loginsData || !failedLoginsData;
 
   if (hasNoData) {
     return (
@@ -39,7 +34,7 @@ export default function Component({ service }) {
         <Block label="authentik.users" />
         <Block label="authentik.loginsLast24H" />
         <Block label="authentik.failedLoginsLast24H" />
-        <Block label="authentik.authorizationsLast24H" />
+        {isV2 && <Block label="authentik.authorizationsLast24H" />}
       </Container>
     );
   }
@@ -59,11 +54,6 @@ export default function Component({ service }) {
         (total, current) => (current.x_cord >= yesterday ? total + current.y_cord : total),
         0,
       );
-      authorizationsLast24H =
-        authorizationsData.reduce?.(
-          (total, current) => (current.x_cord >= yesterday ? total + current.y_cord : total),
-          0,
-        ) || 0;
       break;
     case 2:
       const result = eventsData?.reduce(
@@ -95,7 +85,9 @@ export default function Component({ service }) {
       <Block label="authentik.users" value={t("common.number", { value: usersData.pagination.count })} />
       <Block label="authentik.loginsLast24H" value={t("common.number", { value: loginsLast24H })} />
       <Block label="authentik.failedLoginsLast24H" value={t("common.number", { value: failedLoginsLast24H })} />
-      <Block label="authentik.authorizationsLast24H" value={t("common.number", { value: authorizationsLast24H })} />
+      {isV2 && (
+        <Block label="authentik.authorizationsLast24H" value={t("common.number", { value: authorizationsLast24H })} />
+      )}
     </Container>
   );
 }

--- a/src/widgets/authentik/component.jsx
+++ b/src/widgets/authentik/component.jsx
@@ -11,29 +11,55 @@ export default function Component({ service }) {
 
   const { data: usersData, error: usersError } = useWidgetAPI(widget, "users");
 
-  const loginsEndpoint = widget.version === 2 ? "loginv2" : "login";
-  const { data: loginsData, error: loginsError } = useWidgetAPI(widget, loginsEndpoint);
+  let loginsError;
+  let failedLoginsError;
+  let authorizationsError;
+  let loginsData;
+  let failedLoginsData;
+  let authorizationsData;
 
-  const failedLoginsEndpoint = widget.version === 2 ? "login_failedv2" : "login_failed";
-  const { data: failedLoginsData, error: failedLoginsError } = useWidgetAPI(widget, failedLoginsEndpoint);
+  if (widget.version === 2) {
+    const v2DataResult = useWidgetAPI(widget, "datav2");
 
-  if (usersError || loginsError || failedLoginsError) {
-    const finalError = usersError ?? loginsError ?? failedLoginsError;
+    loginsError = v2DataResult.error;
+    loginsData = v2DataResult.data;
+  } else {
+    const v1LoginsResult = useWidgetAPI(widget, "login");
+    const v1FailedLoginsResult = useWidgetAPI(widget, "login_failed");
+    const v1AuthsResult = useWidgetAPI(widget, "authorizations");
+
+    loginsError = v1LoginsResult.error;
+    loginsData = v1LoginsResult.data;
+    failedLoginsError = v1FailedLoginsResult.error;
+    failedLoginsData = v1FailedLoginsResult.data;
+    authorizationsError = v1AuthsResult.error;
+    authorizationsData = v1AuthsResult.data;
+  }
+
+  if (usersError || loginsError || failedLoginsError || authorizationsError) {
+    const finalError = usersError ?? loginsError ?? failedLoginsError ?? authorizationsError;
     return <Container service={service} error={finalError} />;
   }
 
-  if (!usersData || !loginsData || !failedLoginsData) {
+  const hasNoData =
+    widget.version === 2
+      ? !usersData || !loginsData
+      : !usersData || !loginsData || !failedLoginsData || !authorizationsData;
+
+  if (hasNoData) {
     return (
       <Container service={service}>
         <Block label="authentik.users" />
         <Block label="authentik.loginsLast24H" />
         <Block label="authentik.failedLoginsLast24H" />
+        <Block label="authentik.authorizationsLast24H" />
       </Container>
     );
   }
 
   let loginsLast24H;
   let failedLoginsLast24H;
+  let authorizationsLast24H;
   switch (widget.version) {
     case 1:
       const yesterday = new Date(Date.now()).setHours(-24);
@@ -45,15 +71,34 @@ export default function Component({ service }) {
         (total, current) => (current.x_cord >= yesterday ? total + current.y_cord : total),
         0,
       );
-      break;
-    case 2:
-      loginsLast24H =
-        loginsData.reduce?.(
-          (total, current) => (current?.count && current?.action === "login" ? total + current.count : total),
+      authorizationsLast24H =
+        authorizationsData.reduce?.(
+          (total, current) => (current.x_cord >= yesterday ? total + current.y_cord : total),
           0,
         ) || 0;
-      failedLoginsLast24H =
-        failedLoginsData.reduce?.((total, current) => (current?.count ? total + current.count : total), 0) || 0;
+      break;
+    case 2:
+      const result = loginsData.reduce(
+        (acc, current) => {
+          if (!current?.count || !current?.action) {
+            return acc;
+          }
+
+          if (current.action === "login") {
+            acc.logins += current.count;
+          } else if (current.action === "login_failed") {
+            acc.failed += current.count;
+          } else if (current.action === "authorize_application") {
+            acc.authorizations += current.count;
+          }
+
+          return acc;
+        },
+        { logins: 0, failed: 0, authorizations: 0 },
+      );
+      loginsLast24H = result.logins;
+      failedLoginsLast24H = result.failed;
+      authorizationsLast24H = result.authorizations;
       break;
   }
 
@@ -62,6 +107,7 @@ export default function Component({ service }) {
       <Block label="authentik.users" value={t("common.number", { value: usersData.pagination.count })} />
       <Block label="authentik.loginsLast24H" value={t("common.number", { value: loginsLast24H })} />
       <Block label="authentik.failedLoginsLast24H" value={t("common.number", { value: failedLoginsLast24H })} />
+      <Block label="authentik.authorizationsLast24H" value={t("common.number", { value: authorizationsLast24H })} />
     </Container>
   );
 }

--- a/src/widgets/authentik/component.jsx
+++ b/src/widgets/authentik/component.jsx
@@ -56,7 +56,8 @@ export default function Component({ service }) {
       );
       break;
     case 2:
-      const result = eventsData?.reduce(
+      const events = Array.isArray(eventsData) ? eventsData : [];
+      const result = events.reduce(
         (acc, current) => {
           if (!current?.count || !current?.action) {
             return acc;
@@ -73,7 +74,7 @@ export default function Component({ service }) {
           return acc;
         },
         { logins: 0, failed: 0, authorizations: 0 },
-      ) || { logins: 0, failed: 0, authorizations: 0 };
+      );
       loginsLast24H = result.logins;
       failedLoginsLast24H = result.failed;
       authorizationsLast24H = result.authorizations;

--- a/src/widgets/authentik/component.jsx
+++ b/src/widgets/authentik/component.jsx
@@ -8,43 +8,30 @@ export default function Component({ service }) {
   const { t } = useTranslation();
 
   const { widget } = service;
+  const isV2 = widget.version === 2;
 
   const { data: usersData, error: usersError } = useWidgetAPI(widget, "users");
 
-  let loginsError;
-  let failedLoginsError;
-  let authorizationsError;
-  let loginsData;
-  let failedLoginsData;
-  let authorizationsData;
+  const loginsEndpoint = isV2 ? "" : "login";
+  const { data: loginsData, error: loginsError } = useWidgetAPI(widget, loginsEndpoint);
 
-  if (widget.version === 2) {
-    const v2DataResult = useWidgetAPI(widget, "datav2");
+  const failedLoginsEndpoint = isV2 ? "" : "login_failed";
+  const { data: failedLoginsData, error: failedLoginsError } = useWidgetAPI(widget, failedLoginsEndpoint);
 
-    loginsError = v2DataResult.error;
-    loginsData = v2DataResult.data;
-  } else {
-    const v1LoginsResult = useWidgetAPI(widget, "login");
-    const v1FailedLoginsResult = useWidgetAPI(widget, "login_failed");
-    const v1AuthsResult = useWidgetAPI(widget, "authorizations");
+  const authorizationsEndpoint = isV2 ? "" : "authorizations";
+  const { data: authorizationsData, error: authorizationsError } = useWidgetAPI(widget, authorizationsEndpoint);
 
-    loginsError = v1LoginsResult.error;
-    loginsData = v1LoginsResult.data;
-    failedLoginsError = v1FailedLoginsResult.error;
-    failedLoginsData = v1FailedLoginsResult.data;
-    authorizationsError = v1AuthsResult.error;
-    authorizationsData = v1AuthsResult.data;
-  }
+  const eventsDataEndpoint = isV2 ? "datav2" : "";
+  const { data: eventsData, error: eventsDataError } = useWidgetAPI(widget, eventsDataEndpoint);
 
-  if (usersError || loginsError || failedLoginsError || authorizationsError) {
-    const finalError = usersError ?? loginsError ?? failedLoginsError ?? authorizationsError;
+  if (usersError || loginsError || failedLoginsError || authorizationsError || eventsDataError) {
+    const finalError = usersError ?? loginsError ?? failedLoginsError ?? authorizationsError ?? eventsDataError;
     return <Container service={service} error={finalError} />;
   }
 
-  const hasNoData =
-    widget.version === 2
-      ? !usersData || !loginsData
-      : !usersData || !loginsData || !failedLoginsData || !authorizationsData;
+  const hasNoData = isV2
+    ? !usersData || !eventsData
+    : !usersData || !loginsData || !failedLoginsData || !authorizationsData;
 
   if (hasNoData) {
     return (
@@ -79,7 +66,7 @@ export default function Component({ service }) {
         ) || 0;
       break;
     case 2:
-      const result = loginsData.reduce(
+      const result = eventsData?.reduce(
         (acc, current) => {
           if (!current?.count || !current?.action) {
             return acc;
@@ -96,7 +83,7 @@ export default function Component({ service }) {
           return acc;
         },
         { logins: 0, failed: 0, authorizations: 0 },
-      );
+      ) || { logins: 0, failed: 0, authorizations: 0 };
       loginsLast24H = result.logins;
       failedLoginsLast24H = result.failed;
       authorizationsLast24H = result.authorizations;

--- a/src/widgets/authentik/component.test.jsx
+++ b/src/widgets/authentik/component.test.jsx
@@ -30,24 +30,31 @@ describe("widgets/authentik/component", () => {
       settings: { hideErrors: false },
     });
 
-    expect(container.querySelectorAll(".service-block")).toHaveLength(3);
+    expect(container.querySelectorAll(".service-block")).toHaveLength(4);
     expect(screen.getByText("authentik.users")).toBeInTheDocument();
     expect(screen.getByText("authentik.loginsLast24H")).toBeInTheDocument();
     expect(screen.getByText("authentik.failedLoginsLast24H")).toBeInTheDocument();
+    expect(screen.getByText("authentik.authorizationsLast24H")).toBeInTheDocument();
   });
 
   it("computes v2 login/failed counts from action data", () => {
     useWidgetAPI.mockImplementation((widget, endpoint) => {
       if (endpoint === "users") return { data: { pagination: { count: 10 } }, error: undefined };
-      if (endpoint === "loginv2")
+      if (endpoint === "datav2")
         return {
           data: [
             { action: "login", count: 2 },
+            { action: "login", count: 4 },
             { action: "logout", count: 9 },
+            { action: "login_failed", count: 1 },
+            { action: "login_failed", count: 2 },
+            { action: "authorize_application", count: 10 },
+            { action: "authorize_application", count: 8 },
+            { action: null, count: null },
+            { action: "login", count: null },
           ],
           error: undefined,
         };
-      if (endpoint === "login_failedv2") return { data: [{ count: 3 }, { count: null }], error: undefined };
       return { data: undefined, error: undefined };
     });
 
@@ -55,10 +62,11 @@ describe("widgets/authentik/component", () => {
       settings: { hideErrors: false },
     });
 
-    expect(container.querySelectorAll(".service-block")).toHaveLength(3);
+    expect(container.querySelectorAll(".service-block")).toHaveLength(4);
     expectBlockValue(container, "authentik.users", 10);
-    expectBlockValue(container, "authentik.loginsLast24H", 2);
+    expectBlockValue(container, "authentik.loginsLast24H", 6);
     expectBlockValue(container, "authentik.failedLoginsLast24H", 3);
+    expectBlockValue(container, "authentik.authorizationsLast24H", 18);
   });
 
   it("computes v1 login/failed counts for entries within the last 24h window", () => {
@@ -87,6 +95,14 @@ describe("widgets/authentik/component", () => {
           ],
           error: undefined,
         };
+      if (endpoint === "authorizations")
+        return {
+          data: [
+            { x_cord: oneHourAgo, y_cord: 7 },
+            { x_cord: twentyFiveHoursAgo, y_cord: 80 },
+          ],
+          error: undefined,
+        };
       return { data: undefined, error: undefined };
     });
 
@@ -94,9 +110,10 @@ describe("widgets/authentik/component", () => {
       settings: { hideErrors: false },
     });
 
-    expect(container.querySelectorAll(".service-block")).toHaveLength(3);
+    expect(container.querySelectorAll(".service-block")).toHaveLength(4);
     expectBlockValue(container, "authentik.users", 5);
     expectBlockValue(container, "authentik.loginsLast24H", 2);
     expectBlockValue(container, "authentik.failedLoginsLast24H", 1);
+    expectBlockValue(container, "authentik.authorizationsLast24H", 7);
   });
 });

--- a/src/widgets/authentik/component.test.jsx
+++ b/src/widgets/authentik/component.test.jsx
@@ -127,6 +127,7 @@ describe("widgets/authentik/component", () => {
       if (endpoint === "users") return { data: { pagination: { count: 5 } }, error: undefined };
       if (endpoint === "login") return { data: [{ x_cord: oneHourAgo, y_cord: 2 }], error: undefined };
       if (endpoint === "login_failed") return { data: [{ x_cord: oneHourAgo, y_cord: 1 }], error: undefined };
+      if (endpoint === "authorizations") return { data: [{ x_cord: oneHourAgo, y_cord: 7 }], error: undefined };
       return { data: undefined, error: undefined };
     });
 
@@ -139,5 +140,6 @@ describe("widgets/authentik/component", () => {
     expectBlockValue(container, "authentik.users", 5);
     expectBlockValue(container, "authentik.loginsLast24H", 2);
     expectBlockValue(container, "authentik.failedLoginsLast24H", 1);
+    expectBlockValue(container, "authentik.authorizationsLast24H", 7);
   });
 });

--- a/src/widgets/authentik/component.test.jsx
+++ b/src/widgets/authentik/component.test.jsx
@@ -95,14 +95,6 @@ describe("widgets/authentik/component", () => {
           ],
           error: undefined,
         };
-      if (endpoint === "authorizations")
-        return {
-          data: [
-            { x_cord: oneHourAgo, y_cord: 7 },
-            { x_cord: twentyFiveHoursAgo, y_cord: 80 },
-          ],
-          error: undefined,
-        };
       return { data: undefined, error: undefined };
     });
 
@@ -110,11 +102,10 @@ describe("widgets/authentik/component", () => {
       settings: { hideErrors: false },
     });
 
-    expect(container.querySelectorAll(".service-block")).toHaveLength(4);
+    expect(container.querySelectorAll(".service-block")).toHaveLength(3);
     expectBlockValue(container, "authentik.users", 5);
     expectBlockValue(container, "authentik.loginsLast24H", 2);
     expectBlockValue(container, "authentik.failedLoginsLast24H", 1);
-    expectBlockValue(container, "authentik.authorizationsLast24H", 7);
   });
 
   it("falls back to v1 when no version is configured", () => {
@@ -127,7 +118,6 @@ describe("widgets/authentik/component", () => {
       if (endpoint === "users") return { data: { pagination: { count: 5 } }, error: undefined };
       if (endpoint === "login") return { data: [{ x_cord: oneHourAgo, y_cord: 2 }], error: undefined };
       if (endpoint === "login_failed") return { data: [{ x_cord: oneHourAgo, y_cord: 1 }], error: undefined };
-      if (endpoint === "authorizations") return { data: [{ x_cord: oneHourAgo, y_cord: 7 }], error: undefined };
       return { data: undefined, error: undefined };
     });
 
@@ -140,6 +130,5 @@ describe("widgets/authentik/component", () => {
     expectBlockValue(container, "authentik.users", 5);
     expectBlockValue(container, "authentik.loginsLast24H", 2);
     expectBlockValue(container, "authentik.failedLoginsLast24H", 1);
-    expectBlockValue(container, "authentik.authorizationsLast24H", 7);
   });
 });

--- a/src/widgets/authentik/widget.js
+++ b/src/widgets/authentik/widget.js
@@ -14,9 +14,6 @@ const widget = {
     login_failed: {
       endpoint: "events/events/per_month/?action=login_failed",
     },
-    authorizations: {
-      endpoint: "events/events/per_month/?action=authorize_application",
-    },
     datav2: {
       endpoint: "events/events/volume/?actions=login&actions=login_failed&actions=authorize_application&history_days=1",
     },

--- a/src/widgets/authentik/widget.js
+++ b/src/widgets/authentik/widget.js
@@ -11,14 +11,14 @@ const widget = {
     login: {
       endpoint: "events/events/per_month/?action=login",
     },
-    loginv2: {
-      endpoint: "events/events/volume/?action=login&&history_days=1",
-    },
     login_failed: {
       endpoint: "events/events/per_month/?action=login_failed",
     },
-    login_failedv2: {
-      endpoint: "events/events/volume/?action=login_failed&&history_days=1",
+    authorizations: {
+      endpoint: "events/events/per_month/?action=authorize_application",
+    },
+    datav2: {
+      endpoint: "events/events/volume/?actions=login&actions=login_failed&actions=authorize_application&history_days=1",
     },
   },
 };


### PR DESCRIPTION
## Proposed change

Adds Authorizations in last 24h field to the existing Authentik widget This will show how many apps were authorized via OIDC/Proxy/LDAP etc.
Optimizes API calls for v2 of the widget, since the new API can return the desired events data in 1 call

Closes #6245

## Type of change

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] In the description above I have disclosed the use of AI tools in the coding of this PR.
