### PR TITLE
Fix: apply bookmarksStyle setting to bookmark groups in layout sections

### DIFF
--- a/src/__tests__/pages/index.test.jsx
+++ b/src/__tests__/pages/index.test.jsx
@@ -127,7 +127,11 @@ vi.mock("utils/hooks/window-focus", () => ({
 }));
 
 vi.mock("components/bookmarks/group", () => ({
-  default: ({ bookmarks }) => <div data-testid="bookmarks-group">{bookmarks?.name}</div>,
+  default: ({ bookmarks, bookmarksStyle }) => (
+    <div data-testid="bookmarks-group" data-bookmarks-style={bookmarksStyle ?? ""}>
+      {bookmarks?.name}
+    </div>
+  ),
 }));
 
 vi.mock("components/services/group", () => ({
@@ -432,6 +436,23 @@ describe("pages/index Home behavior", () => {
 
     expect(await screen.findByTestId("services-group")).toHaveTextContent("Services");
     expect(screen.getByTestId("bookmarks-group")).toHaveTextContent("Bookmarks");
+  });
+
+  it("passes bookmarksStyle to bookmark groups in both the layout and default sections", async () => {
+    state.bookmarksData = [
+      { name: "Layout Bookmarks", bookmarks: [] },
+      { name: "Bottom Bookmarks", bookmarks: [] },
+    ];
+
+    await renderIndex({
+      initialSettings: { title: "Homepage", layout: { "Layout Bookmarks": {} } },
+      settings: { title: "Homepage", layout: { "Layout Bookmarks": {} }, bookmarksStyle: "icons", language: "en" },
+    });
+
+    const groups = await screen.findAllByTestId("bookmarks-group");
+    const styleByName = Object.fromEntries(groups.map((g) => [g.textContent, g.dataset.bookmarksStyle]));
+    expect(styleByName["Layout Bookmarks"]).toBe("icons");
+    expect(styleByName["Bottom Bookmarks"]).toBe("icons");
   });
 
   it("renders tab navigation and filters groups by active tab", async () => {

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -354,6 +354,7 @@ function Home({ initialSettings }) {
                   disableCollapse={settings.disableCollapse}
                   maxGroupColumns={settings.maxBookmarkGroupColumns ?? settings.maxGroupColumns}
                   groupsInitiallyCollapsed={settings.groupsInitiallyCollapsed}
+                  bookmarksStyle={settings.bookmarksStyle}
                 />
               ),
             )}


### PR DESCRIPTION
## Proposed change

The global `bookmarksStyle: icons` setting from `settings.yaml` is ignored for any bookmark group that is listed in the `layout` block.

`src/pages/index.jsx` renders `BookmarksGroup` from two branches: the mixed services+bookmarks layout branch and the default bottom section. Only the bottom branch passed `bookmarksStyle={settings.bookmarksStyle}`, so bookmark groups placed via `layout` always fell back to the default list style.

This PR passes `bookmarksStyle` in the layout branch as well (`settings.bookmarksStyle` was already in the `useMemo` dependency array), and adds a regression test to the existing page suite in `src/__tests__/pages/index.test.jsx` asserting both call sites receive the setting. The test fails without the one-line fix and passes with it.

AI disclosure, per CONTRIBUTING.md: this PR was coded by Claude Code under the direction and review of @kwp3.

## Type of change

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [ ] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] In the description above I have disclosed the use of AI tools in the coding of this PR.
