### PR TITLE
Fix: settle proxy promise on gzip failure and time out hung upstream requests

### DIFF
--- a/src/utils/proxy/http.js
+++ b/src/utils/proxy/http.js
@@ -12,6 +12,16 @@ import createLogger from "utils/logger";
 
 const logger = createLogger("httpProxy");
 
+// Without this an upstream that accepts the connection and never replies holds a socket and a
+// pending promise forever, and widgets re-poll on a timer. Set HOMEPAGE_PROXY_TIMEOUT=0 to disable.
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+function requestTimeout(params) {
+  if (typeof params?.timeout === "number") return params.timeout;
+  const configured = Number.parseInt(process.env.HOMEPAGE_PROXY_TIMEOUT ?? "", 10);
+  return Number.isFinite(configured) && configured >= 0 ? configured : DEFAULT_TIMEOUT_MS;
+}
+
 function addCookieHandler(url, params) {
   setCookieHeader(url, params);
 
@@ -68,6 +78,15 @@ function handleRequest(requestor, url, params) {
     request.on("error", (error) => {
       reject([500, error]);
     });
+
+    const timeout = requestTimeout(params);
+    if (timeout > 0) {
+      // follow-redirects' setTimeout spans the whole redirect chain, unlike a per-socket timeout.
+      request.setTimeout(timeout);
+      request.on("timeout", () => {
+        request.destroy(Object.assign(new Error(`Request timed out after ${timeout}ms`), { code: "ETIMEDOUT" }));
+      });
+    }
 
     if (params?.body) {
       request.write(params.body);

--- a/src/utils/proxy/http.js
+++ b/src/utils/proxy/http.js
@@ -44,10 +44,13 @@ function handleRequest(requestor, url, params) {
           finishFlush: zlibConstants.Z_SYNC_FLUSH,
         });
 
-        // zlib errors
+        // zlib errors. Reassigning responseContent here would be dead code: the data/end listeners
+        // below are already bound to the unzip stream, and a failed Unzip never emits "end" -- so
+        // the old "fallback" left this promise pending forever, leaking the socket.
         responseContent.on("error", (e) => {
-          if (e) logger.error(e);
-          responseContent = response; // fallback
+          logger.error(e);
+          response.destroy();
+          reject([500, e]);
         });
         response.pipe(responseContent);
       }

--- a/src/utils/proxy/http.test.js
+++ b/src/utils/proxy/http.test.js
@@ -12,6 +12,8 @@ const { state, cache, logger, dns, net, cookieJar } = vi.hoisted(() => ({
     lastAgentOptions: null,
     lastRequestParams: null,
     lastWrittenBody: null,
+    lastTimeout: null,
+    hang: false,
   },
   cache: {
     get: vi.fn(),
@@ -59,11 +61,22 @@ vi.mock("follow-redirects", async () => {
       req.write = vi.fn((chunk) => {
         state.lastWrittenBody = chunk;
       });
+      req.setTimeout = vi.fn((ms) => {
+        state.lastTimeout = ms;
+      });
+      req.destroy = vi.fn((err) => {
+        req.emit("error", err);
+      });
       req.end = vi.fn(() => {
         state.lastAgent = params?.agent ?? null;
         state.lastAgentOptions = params?.agent?.opts ?? null;
         if (state.error) {
           req.emit("error", state.error);
+          return;
+        }
+        if (state.hang) {
+          // upstream accepted the connection and never replied
+          req.emit("timeout");
           return;
         }
 
@@ -101,6 +114,9 @@ describe("utils/proxy/http cachedRequest", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     state.error = null;
+    state.hang = false;
+    state.lastTimeout = null;
+    delete process.env.HOMEPAGE_PROXY_TIMEOUT;
     state.response = {
       statusCode: 200,
       headers: { "content-type": "application/json" },
@@ -158,6 +174,9 @@ describe("utils/proxy/http homepageDNSLookupFn", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     state.error = null;
+    state.hang = false;
+    state.lastTimeout = null;
+    delete process.env.HOMEPAGE_PROXY_TIMEOUT;
     state.lastAgentOptions = null;
     net.isIP.mockReturnValue(0);
     dns.lookup.mockImplementation((hostname, options, cb) => cb(null, "127.0.0.1", 4));
@@ -305,6 +324,9 @@ describe("utils/proxy/http httpProxy", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     state.error = null;
+    state.hang = false;
+    state.lastTimeout = null;
+    delete process.env.HOMEPAGE_PROXY_TIMEOUT;
     state.response = {
       statusCode: 200,
       headers: { "content-type": "application/json" },
@@ -440,5 +462,36 @@ describe("utils/proxy/http httpProxy", () => {
     expect(contentType).toBe("application/json");
     expect(data.error.message).toBe("boom");
     expect(data.error.url).toBe("example.com (see logs for details)");
+  });
+
+  it("times out an upstream that never replies", async () => {
+    state.hang = true;
+    const httpMod = await import("./http");
+
+    const [status, , data] = await httpMod.httpProxy("http://example.com");
+
+    expect(status).toBe(500);
+    expect(data.error.rawError.code).toBe("ETIMEDOUT");
+  });
+
+  it("applies the default timeout to every request", async () => {
+    const httpMod = await import("./http");
+
+    await httpMod.httpProxy("http://example.com");
+
+    expect(state.lastTimeout).toBe(30_000);
+  });
+
+  it("honours HOMEPAGE_PROXY_TIMEOUT, and treats 0 as disabled", async () => {
+    process.env.HOMEPAGE_PROXY_TIMEOUT = "1500";
+    let httpMod = await import("./http");
+    await httpMod.httpProxy("http://example.com");
+    expect(state.lastTimeout).toBe(1500);
+
+    state.lastTimeout = null;
+    process.env.HOMEPAGE_PROXY_TIMEOUT = "0";
+    httpMod = await import("./http");
+    await httpMod.httpProxy("http://example.com");
+    expect(state.lastTimeout).toBeNull();
   });
 });

--- a/src/utils/proxy/http.test.js
+++ b/src/utils/proxy/http.test.js
@@ -364,7 +364,7 @@ describe("utils/proxy/http httpProxy", () => {
     expect(Buffer.from(data).toString()).toBe("hello");
   });
 
-  it("logs when gzip decoding emits an error", async () => {
+  it("rejects instead of hanging when gzip decoding emits an error", async () => {
     const { PassThrough } = await import("node:stream");
 
     vi.doMock("node:zlib", async () => {
@@ -375,8 +375,9 @@ describe("utils/proxy/http httpProxy", () => {
           const pt = new PassThrough();
           pt.on("pipe", () => {
             queueMicrotask(() => {
+              // deliberately NOT followed by pt.end(): a real zlib.Unzip that errors never
+              // emits "end". Ending it here is what masked the hang this test now covers.
               pt.emit("error", new Error("bad gzip"));
-              pt.end();
             });
           });
           return pt;
@@ -390,9 +391,11 @@ describe("utils/proxy/http httpProxy", () => {
     state.response.headers["content-encoding"] = "gzip";
     state.response.body = Buffer.from("hello");
 
-    await httpMod.httpProxy("http://example.com");
+    const [status, , data] = await httpMod.httpProxy("http://example.com");
 
     expect(logger.error).toHaveBeenCalled();
+    expect(status).toBe(500);
+    expect(data.error.message).toBe("bad gzip");
 
     vi.unmock("node:zlib");
   });


### PR DESCRIPTION
## Proposed change

Two fixes for proxied widget requests that can hang forever, each holding a socket and a pending promise while widgets keep re-polling on their refresh interval.

First, settle the promise when gzip decoding fails. The `error` handler on the unzip stream reassigned a local variable as a "fallback", but the `data`/`end` listeners were already bound to the unzip stream by that point, so nothing was re-piped. A real `zlib.Unzip` that errors never emits `end`, which left `handleRequest`'s promise neither resolved nor rejected. The handler now rejects with a 500 and destroys the response so the socket is released. The existing test only passed against the broken code because its mock called `pt.end()` right after emitting the error, which a real `Unzip` never does; with that call removed, the old code times out and the new code passes.

Second, time out proxied requests. No timeout was set anywhere in the outbound proxy path, and the agents use `keepAlive`. An upstream that accepts the connection and never replies (a sleeping NAS, a service wedged mid-restart) accumulated hung requests until the process ran out of sockets or memory. Requests now default to a 30s timeout using follow-redirects' `setTimeout`, which spans the whole redirect chain, then destroy the request with `ETIMEDOUT` so the existing error path reports it. `HOMEPAGE_PROXY_TIMEOUT` overrides the default (`0` disables), and callers can pass `params.timeout` for widgets that need longer.

There is currently no central environment-variable reference in the docs; happy to document `HOMEPAGE_PROXY_TIMEOUT` wherever you prefer.

AI disclosure, per CONTRIBUTING.md: this PR was coded by Claude Code under the direction and review of @kwp3.

## Type of change

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [ ] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] In the description above I have disclosed the use of AI tools in the coding of this PR.
