### PR TITLE
Fix: rotate the winston log file

### DIFF
--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -6,6 +6,10 @@ import checkAndCopyConfig, { CONF_DIR, getSettings } from "utils/config/config";
 
 let winstonLogger;
 
+// Unbounded by default, which fills the volume on a long-running instance with LOG_LEVEL=debug.
+const LOG_MAX_BYTES = 10 * 1024 * 1024;
+const LOG_MAX_FILES = 5;
+
 function combineMessageAndSplat() {
   return {
     transform: (info, opts) => {
@@ -57,6 +61,9 @@ function getFileLogger() {
       winston.format.printf(messageFormatter),
     ),
     filename: `${logpath}/logs/homepage.log`,
+    maxsize: LOG_MAX_BYTES,
+    maxFiles: LOG_MAX_FILES,
+    tailable: true,
     handleExceptions: true,
     handleRejections: true,
   });


### PR DESCRIPTION
## Proposed change

The winston `File` transport sets no `maxsize` or `maxFiles`, so `config/logs/homepage.log` grows without bound. On a long-running instance with `LOG_LEVEL=debug` this eventually fills the volume.

This PR caps the log at 10MB across 5 files, with `tailable: true` so the active file keeps its name (`homepage.log` stays current; rotated files get numbered suffixes).

AI disclosure, per CONTRIBUTING.md: this PR was coded by Claude Code under the direction and review of @kwp3.

## Type of change

- [ ] New service widget
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [ ] If applicable, I have added corresponding documentation changes.
- [ ] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [ ] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] In the description above I have disclosed the use of AI tools in the coding of this PR.
