### PR TITLE
Feature: BookOrbit service widget

### DIFF
--- a/docs/widgets/services/bookorbit.md
+++ b/docs/widgets/services/bookorbit.md
@@ -1,0 +1,36 @@
+---
+title: BookOrbit
+description: BookOrbit Widget Configuration
+---
+
+Learn more about [BookOrbit](https://github.com/bookorbit/bookorbit).
+
+BookOrbit issues short-lived access tokens rather than API keys, so the widget signs in with your BookOrbit username and password and renews the token as it expires.
+
+Allowed fields: `["libraries", "books", "reading", "finished"]`
+
+| Field       | Renders as                  | Shows                                                                             |
+| ----------- | --------------------------- | --------------------------------------------------------------------------------- |
+| `libraries` | Libraries                   | How many libraries the widget covers. Left out when a single library is selected. |
+| `books`     | Books / Audiobooks / Comics | Number of titles held in those libraries.                                         |
+| `reading`   | Reading / Listening         | Titles started but not finished.                                                  |
+| `finished`  | Finished                    | Titles marked finished.                                                           |
+
+The field name never changes, only the label, so `fields: ["books"]` picks the item count whether it renders Books, Audiobooks or Comics.
+
+```yaml
+widget:
+  type: bookorbit
+  url: https://bookorbit.host.or.ip
+  username: username
+  password: password
+  libraries: [eBooks, Audiobooks] # optional, defaults to all if excluded
+  label: Reading room # optional, defaults to the media kind
+```
+
+## Optional fields
+
+| Option      | Details                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `libraries` | This field is optional and defaults to `all` when left out. Library names or ids can be used for specific libraries instead, for example `eBooks`, `[eBooks, Audiobooks]`, `[1, 2]`. Wrap more than one value in `[]`; a single value needs none.<br><br>Picking a single library drops the library count block, since it would read "1" every time.                                                                                                                                                                                                                                                                                                         |
+| `label`     | This optional field overrides the item count label, so a library of PDFs can read PDFs rather than Books.<br><br>Left out, the label follows BookOrbit's own convention of classifying an item by its file format, with the majority of files deciding:<br><br>`m4b` `mp3` `m4a` `opus` `ogg` `flac` &rarr; Audiobooks / Listening<br>`cbz` `cbr` `cb7` `cbx` &rarr; Comics / Reading<br>everything else, `epub` and `pdf` among them &rarr; Books / Reading<br><br>A stray ebook among the audiobooks does not change the naming, since the majority decides. A selection spanning several kinds, or a library with nothing in it, reads Books and Reading. |

--- a/docs/widgets/services/index.md
+++ b/docs/widgets/services/index.md
@@ -19,6 +19,7 @@ You can also find a list of all available service widgets in the sidebar navigat
 - [Backrest](backrest.md)
 - [Bazarr](bazarr.md)
 - [Booklore](booklore.md)
+- [BookOrbit](bookorbit.md)
 - [Beszel](beszel.md)
 - [Caddy](caddy.md)
 - [Calendar](calendar.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ nav:
           - widgets/services/backrest.md
           - widgets/services/bazarr.md
           - widgets/services/booklore.md
+          - widgets/services/bookorbit.md
           - widgets/services/beszel.md
           - widgets/services/caddy.md
           - widgets/services/calendar.md

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -854,6 +854,15 @@
         "reading": "Reading",
         "finished": "Finished"
     },
+    "bookorbit": {
+        "libraries": "Libraries",
+        "books": "Books",
+        "audiobooks": "Audiobooks",
+        "comics": "Comics",
+        "reading": "Reading",
+        "listening": "Listening",
+        "finished": "Finished"
+    },
     "jdownloader": {
         "downloadCount": "Queue",
         "downloadBytesRemaining": "Remaining",

--- a/src/widgets/bookorbit/component.jsx
+++ b/src/widgets/bookorbit/component.jsx
@@ -1,0 +1,59 @@
+import Block from "components/services/widget/block";
+import Container from "components/services/widget/container";
+import { useTranslation } from "next-i18next/pages";
+
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+function countLabel(kind) {
+  if (kind === "audiobook") return "bookorbit.audiobooks";
+  if (kind === "comic") return "bookorbit.comics";
+  return "bookorbit.books";
+}
+
+function progressLabel(kind) {
+  return kind === "audiobook" ? "bookorbit.listening" : "bookorbit.reading";
+}
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+  const { widget } = service;
+
+  const { data: bookorbitData, error: bookorbitError } = useWidgetAPI(widget);
+
+  if (bookorbitError) {
+    return <Container service={service} error={bookorbitError} />;
+  }
+
+  const number = (value) => t("common.number", { value: value ?? 0 });
+
+  // A widget scoped to one library would report "1" every time, so the block is dropped.
+  const singleLibrary = bookorbitData?.libraries === 1;
+
+  if (!bookorbitData) {
+    return (
+      <Container service={service}>
+        {!singleLibrary && <Block label="bookorbit.libraries" />}
+        <Block label="bookorbit.books" field="bookorbit.books" />
+        <Block label="bookorbit.reading" field="bookorbit.reading" />
+        <Block label="bookorbit.finished" />
+      </Container>
+    );
+  }
+
+  return (
+    <Container service={service}>
+      {!singleLibrary && <Block label="bookorbit.libraries" value={number(bookorbitData.libraries)} />}
+      <Block
+        label={bookorbitData.label ?? countLabel(bookorbitData.mediaKind)}
+        field="bookorbit.books"
+        value={number(bookorbitData.books)}
+      />
+      <Block
+        label={progressLabel(bookorbitData.mediaKind)}
+        field="bookorbit.reading"
+        value={number(bookorbitData.reading)}
+      />
+      <Block label="bookorbit.finished" value={number(bookorbitData.finished)} />
+    </Container>
+  );
+}

--- a/src/widgets/bookorbit/component.test.jsx
+++ b/src/widgets/bookorbit/component.test.jsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+
+import { screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "test-utils/render-with-providers";
+
+const { useWidgetAPI } = vi.hoisted(() => ({
+  useWidgetAPI: vi.fn(),
+}));
+
+vi.mock("utils/proxy/use-widget-api", () => ({
+  default: useWidgetAPI,
+}));
+
+import Component from "./component";
+
+describe("widgets/bookorbit/component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders placeholders while loading", () => {
+    useWidgetAPI.mockReturnValue({ data: undefined, error: undefined });
+
+    const { container } = renderWithProviders(<Component service={{ widget: { type: "bookorbit" } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expect(container.querySelectorAll(".service-block")).toHaveLength(4);
+    expect(screen.getByText("bookorbit.libraries")).toBeInTheDocument();
+    expect(screen.getByText("bookorbit.books")).toBeInTheDocument();
+    expect(screen.getByText("bookorbit.reading")).toBeInTheDocument();
+    expect(screen.getByText("bookorbit.finished")).toBeInTheDocument();
+  });
+
+  it("renders values with nullish fallback defaults", () => {
+    useWidgetAPI.mockReturnValue({
+      data: { libraries: 3, books: 2, finished: 4 }, // reading missing -> 0
+      error: undefined,
+    });
+
+    renderWithProviders(<Component service={{ widget: { type: "bookorbit" } }} />, { settings: { hideErrors: false } });
+
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("0")).toBeInTheDocument();
+    expect(screen.getByText("4")).toBeInTheDocument();
+  });
+
+  it("names the count block for the media kind and drops the library count", () => {
+    useWidgetAPI.mockReturnValue({
+      data: { libraries: 1, books: 12, reading: 0, finished: 0, mediaKind: "comic" },
+      error: undefined,
+    });
+
+    const { container } = renderWithProviders(
+      <Component service={{ widget: { type: "bookorbit", libraries: ["Magazines"] } }} />,
+      { settings: { hideErrors: false } },
+    );
+
+    expect(container.querySelectorAll(".service-block")).toHaveLength(3);
+    expect(screen.getByText("bookorbit.comics")).toBeInTheDocument();
+    expect(screen.queryByText("bookorbit.books")).not.toBeInTheDocument();
+    expect(screen.queryByText("bookorbit.libraries")).not.toBeInTheDocument();
+  });
+
+  it("keeps the library count when several libraries are selected", () => {
+    useWidgetAPI.mockReturnValue({
+      data: { libraries: 2, books: 12, reading: 0, finished: 0 },
+      error: undefined,
+    });
+
+    const { container } = renderWithProviders(
+      <Component service={{ widget: { type: "bookorbit", libraries: "Comics, Magazines" } }} />,
+      { settings: { hideErrors: false } },
+    );
+
+    expect(container.querySelectorAll(".service-block")).toHaveLength(4);
+    expect(screen.getByText("bookorbit.libraries")).toBeInTheDocument();
+    expect(screen.getByText("bookorbit.books")).toBeInTheDocument();
+  });
+
+  it("words an audiobook selection as listening", () => {
+    useWidgetAPI.mockReturnValue({
+      data: { libraries: 1, books: 20, reading: 2, finished: 0, mediaKind: "audiobook" },
+      error: undefined,
+    });
+
+    renderWithProviders(<Component service={{ widget: { type: "bookorbit", libraries: ["Audiobooks"] } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expect(screen.getByText("bookorbit.listening")).toBeInTheDocument();
+    expect(screen.getByText("bookorbit.audiobooks")).toBeInTheDocument();
+    expect(screen.queryByText("bookorbit.reading")).not.toBeInTheDocument();
+  });
+  it("renders the error container when the API fails", () => {
+    useWidgetAPI.mockReturnValue({ data: undefined, error: { message: "boom" } });
+
+    const { container } = renderWithProviders(<Component service={{ widget: { type: "bookorbit" } }} />, {
+      settings: { hideErrors: false },
+    });
+
+    expect(container.querySelectorAll(".service-block")).toHaveLength(0);
+  });
+});

--- a/src/widgets/bookorbit/proxy.js
+++ b/src/widgets/bookorbit/proxy.js
@@ -1,0 +1,251 @@
+import cache from "memory-cache";
+
+import getServiceWidget from "utils/config/service-helpers";
+import createLogger from "utils/logger";
+import { formatApiCall } from "utils/proxy/api-helpers";
+import { httpProxy } from "utils/proxy/http";
+import widgets from "widgets/widgets";
+
+const proxyName = "bookorbitProxyHandler";
+const sessionTokenCacheKey = `${proxyName}__sessionToken`;
+const logger = createLogger(proxyName);
+
+const defaultTokenTtl = 10 * 60 * 1000;
+const tokenExpiryMargin = 60 * 1000;
+
+function tokenCacheTtl(accessToken) {
+  try {
+    const [, payload] = accessToken.split(".");
+    const { exp } = JSON.parse(Buffer.from(payload, "base64url").toString());
+
+    if (Number.isFinite(exp)) {
+      return exp * 1000 - Date.now() - tokenExpiryMargin;
+    }
+  } catch (e) {
+    logger.debug("Unable to read the expiry of the BookOrbit access token: %s", e);
+  }
+
+  return defaultTokenTtl;
+}
+
+async function login(widget, service) {
+  if (!widget.username || !widget.password) {
+    logger.debug("Missing credentials for BookOrbit service '%s'", service);
+    return { accessToken: false };
+  }
+
+  const api = widgets?.[widget.type]?.api;
+  const loginUrl = new URL(formatApiCall(api, { ...widget, endpoint: "auth/login" }));
+
+  const [status, , data] = await httpProxy(loginUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      accept: "application/json",
+    },
+    body: JSON.stringify({
+      username: widget.username,
+      password: widget.password,
+    }),
+  });
+
+  if (status !== 200) {
+    logger.debug("BookOrbit login failed for service '%s' with status %d", service, status);
+    return { accessToken: false };
+  }
+
+  try {
+    const { accessToken } = JSON.parse(data.toString());
+
+    if (accessToken) {
+      const ttl = tokenCacheTtl(accessToken);
+
+      if (ttl > 0) {
+        cache.put(`${sessionTokenCacheKey}.${service}`, accessToken, ttl);
+      }
+
+      return { accessToken };
+    }
+  } catch (e) {
+    logger.error("Unable to login to BookOrbit API: %s", e);
+  }
+
+  return { accessToken: false };
+}
+
+async function apiCall(widget, endpoint, service) {
+  const cacheKey = `${sessionTokenCacheKey}.${service}`;
+  let accessToken = cache.get(cacheKey);
+
+  if (!accessToken) {
+    ({ accessToken } = await login(widget, service));
+  }
+
+  if (!accessToken) {
+    return { status: 401, data: null };
+  }
+
+  const headers = {
+    accept: "application/json",
+    Authorization: `Bearer ${accessToken}`,
+  };
+
+  const url = new URL(formatApiCall(widgets[widget.type].api, { ...widget, endpoint }));
+  let [status, , data] = await httpProxy(url, {
+    method: "GET",
+    headers,
+  });
+
+  if (status === 401 || status === 403) {
+    logger.debug("BookOrbit API rejected the request, attempting to obtain new session token");
+    const refreshedToken = (await login(widget, service)).accessToken;
+    if (!refreshedToken) {
+      return { status, data: null };
+    }
+    headers.Authorization = `Bearer ${refreshedToken}`;
+    [status, , data] = await httpProxy(url, {
+      method: "GET",
+      headers,
+    });
+  }
+
+  if (status !== 200) {
+    logger.error("Error getting data from BookOrbit: %s status %d. Data: %s", url, status, data);
+    return { status, data: null };
+  }
+
+  try {
+    return { status, data: JSON.parse(data.toString()) };
+  } catch (e) {
+    logger.error("Error parsing BookOrbit response: %s", e);
+  }
+
+  return { status, data: null };
+}
+
+// The format sets BookOrbit itself uses to derive a book's media kind.
+const audioFormats = new Set(["m4b", "mp3", "m4a", "opus", "ogg", "flac"]);
+const comicFormats = new Set(["cbz", "cbr", "cb7", "cbx"]);
+
+function mediaKind(formatCounts) {
+  let audio = 0;
+  let comic = 0;
+  let ebook = 0;
+
+  for (const [format, count] of Object.entries(formatCounts ?? {})) {
+    const files = count ?? 0;
+    if (audioFormats.has(format.toLowerCase())) audio += files;
+    else if (comicFormats.has(format.toLowerCase())) comic += files;
+    else ebook += files;
+  }
+
+  if (audio + comic + ebook === 0) return null;
+  if (audio > comic && audio > ebook) return "audiobook";
+  if (comic > audio && comic > ebook) return "comic";
+  return "ebook";
+}
+
+function selectLibraries(widget, libraries) {
+  const configured = widget.libraries;
+
+  if (configured === undefined || configured === null || configured === "") {
+    return null;
+  }
+
+  const wanted = (Array.isArray(configured) ? configured : configured.toString().split(","))
+    .map((entry) => entry.toString().trim().toLowerCase())
+    .filter((entry) => entry.length > 0);
+
+  if (wanted.length === 0 || (wanted.length === 1 && wanted[0] === "all")) {
+    return null;
+  }
+
+  return libraries.filter(
+    (library) => wanted.includes(library.id?.toString()) || wanted.includes(library.name?.toLowerCase()),
+  );
+}
+
+export default async function bookorbitProxyHandler(req, res) {
+  const { group, service, index } = req.query;
+
+  if (!group || !service) {
+    logger.debug("Invalid or missing service '%s' or group '%s'", service, group);
+    return res.status(400).json({ error: "Invalid proxy service type" });
+  }
+
+  const widget = await getServiceWidget(group, service, index);
+
+  if (!widget) {
+    logger.debug("Invalid or missing widget for service '%s' in group '%s'", service, group);
+    return res.status(400).json({ error: "Invalid proxy service type" });
+  }
+
+  if (!widget.username || !widget.password) {
+    logger.debug("Missing credentials for BookOrbit widget in service '%s'", service);
+    return res.status(400).json({ error: "Missing BookOrbit credentials" });
+  }
+
+  // Sequential so a cold cache triggers one login; the login endpoint is throttled.
+  const { data: librariesData, status: librariesStatus } = await apiCall(widget, "libraries", service);
+
+  if (librariesStatus !== 200 || !Array.isArray(librariesData)) {
+    return res.status(librariesStatus || 500).send(librariesData || { error: "Error fetching libraries" });
+  }
+
+  const selected = selectLibraries(widget, librariesData);
+
+  if (selected?.length === 0) {
+    logger.error("No BookOrbit library matches the libraries configured for service '%s'", service);
+    return res.status(404).send({ error: "No matching BookOrbit libraries" });
+  }
+
+  let books = 0;
+  const kinds = new Set();
+
+  if (selected) {
+    // Authoritative for a count; the format distribution counts multi-format books twice.
+    for (const library of selected) {
+      const { data: stats, status: statsStatus } = await apiCall(widget, `libraries/${library.id}/stats`, service);
+
+      if (statsStatus !== 200 || !stats) {
+        return res.status(statsStatus || 500).send(stats || { error: "Error fetching library stats" });
+      }
+
+      books += stats.totalBooks ?? 0;
+      kinds.add(mediaKind(stats.formatCounts));
+    }
+  } else {
+    const { data: overviewData, status: overviewStatus } = await apiCall(
+      widget,
+      "dashboard/widgets/library-overview",
+      service,
+    );
+
+    if (overviewStatus !== 200 || !overviewData) {
+      return res.status(overviewStatus || 500).send(overviewData || { error: "Error fetching library overview" });
+    }
+
+    books = overviewData.totalBooks ?? 0;
+  }
+
+  const summaryEndpoint = selected
+    ? `user-statistics/summary?${selected.map((library) => `libraryIds=${library.id}`).join("&")}`
+    : "user-statistics/summary";
+
+  const { data: summaryData, status: summaryStatus } = await apiCall(widget, summaryEndpoint, service);
+
+  if (summaryStatus !== 200 || !summaryData) {
+    return res.status(summaryStatus || 500).send(summaryData || { error: "Error fetching reading statistics" });
+  }
+
+  const named = kinds.size === 1 ? [...kinds][0] : null;
+
+  return res.status(200).send({
+    libraries: (selected ?? librariesData).length,
+    books,
+    reading: summaryData.inProgressBooks ?? 0,
+    finished: summaryData.completedBooks ?? 0,
+    label: widget.label ?? undefined,
+    mediaKind: named ?? undefined,
+  });
+}

--- a/src/widgets/bookorbit/proxy.test.js
+++ b/src/widgets/bookorbit/proxy.test.js
@@ -1,0 +1,458 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import createMockRes from "test-utils/create-mock-res";
+
+const { httpProxy, getServiceWidget, cache, logger } = vi.hoisted(() => {
+  const store = new Map();
+
+  return {
+    httpProxy: vi.fn(),
+    getServiceWidget: vi.fn(),
+    cache: {
+      get: vi.fn((k) => store.get(k)),
+      put: vi.fn((k, v) => store.set(k, v)),
+      del: vi.fn((k) => store.delete(k)),
+      _reset: () => store.clear(),
+    },
+    logger: {
+      debug: vi.fn(),
+      error: vi.fn(),
+    },
+  };
+});
+
+vi.mock("utils/logger", () => ({
+  default: () => logger,
+}));
+
+vi.mock("utils/config/service-helpers", () => ({
+  default: getServiceWidget,
+}));
+
+vi.mock("utils/proxy/http", () => ({
+  httpProxy,
+}));
+
+vi.mock("memory-cache", () => ({
+  default: cache,
+  ...cache,
+}));
+
+vi.mock("widgets/widgets", () => ({
+  default: {
+    bookorbit: {
+      api: "{url}/api/v1/{endpoint}",
+    },
+  },
+}));
+
+import bookorbitProxyHandler from "./proxy";
+
+const widget = {
+  type: "bookorbit",
+  url: "http://bookorbit",
+  username: "u",
+  password: "p",
+};
+
+function accessToken(expiresInSeconds, name = "tok") {
+  const payload = Buffer.from(JSON.stringify({ exp: Math.floor(Date.now() / 1000) + expiresInSeconds })).toString(
+    "base64url",
+  );
+  return `header.${payload}.${name}`;
+}
+
+function json(body, status = 200) {
+  return [status, "application/json", Buffer.from(JSON.stringify(body))];
+}
+
+const libraries = [
+  { id: 1, name: "eBooks" },
+  { id: 2, name: "Audiobooks" },
+];
+const overview = { totalBooks: 42, totalAuthors: 8, totalSeries: 3 };
+const summary = { trackedBooks: 12, startedBooks: 10, inProgressBooks: 3, completedBooks: 7 };
+
+describe("widgets/bookorbit/proxy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cache._reset();
+  });
+
+  it("returns 400 when BookOrbit credentials are missing", async () => {
+    getServiceWidget.mockResolvedValue({ type: "bookorbit", url: "http://bookorbit" });
+
+    const req = { query: { group: "g", service: "svc", index: "0" } };
+    const res = createMockRes();
+
+    await bookorbitProxyHandler(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: "Missing BookOrbit credentials" });
+    expect(httpProxy).not.toHaveBeenCalled();
+  });
+
+  it("logs in once and summarizes libraries, books and reading status", async () => {
+    getServiceWidget.mockResolvedValue(widget);
+
+    const token = accessToken(15 * 60);
+
+    httpProxy
+      .mockResolvedValueOnce(json({ accessToken: token }))
+      .mockResolvedValueOnce(json(libraries))
+      .mockResolvedValueOnce(json(overview))
+      .mockResolvedValueOnce(json(summary));
+
+    const req = { query: { group: "g", service: "svc", index: "0" } };
+    const res = createMockRes();
+
+    await bookorbitProxyHandler(req, res);
+
+    expect(httpProxy).toHaveBeenCalledTimes(4);
+
+    const [loginUrl, loginOptions] = httpProxy.mock.calls[0];
+    expect(loginUrl.toString()).toBe("http://bookorbit/api/v1/auth/login");
+    expect(loginOptions.method).toBe("POST");
+    expect(JSON.parse(loginOptions.body)).toEqual({ username: "u", password: "p" });
+
+    expect(httpProxy.mock.calls.slice(1).map(([url]) => url.toString())).toEqual([
+      "http://bookorbit/api/v1/libraries",
+      "http://bookorbit/api/v1/dashboard/widgets/library-overview",
+      "http://bookorbit/api/v1/user-statistics/summary",
+    ]);
+    expect(httpProxy.mock.calls[1][1].headers.Authorization).toBe(`Bearer ${token}`);
+
+    expect(cache.put).toHaveBeenCalledTimes(1);
+    expect(cache.put.mock.calls[0][2]).toBeLessThan(15 * 60 * 1000);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      libraries: 2,
+      books: 42,
+      reading: 3,
+      finished: 7,
+    });
+  });
+
+  it("logs in again and retries when a cached token is rejected", async () => {
+    getServiceWidget.mockResolvedValue(widget);
+    cache.put("bookorbitProxyHandler__sessionToken.svc", "stale-token");
+
+    const token = accessToken(15 * 60, "fresh");
+    const responses = [
+      json({ error: "Unauthorized" }, 401),
+      json({ accessToken: token }),
+      json(libraries),
+      json(overview),
+      json(summary),
+    ];
+
+    // The retry reuses the headers object, so record each header as it is sent.
+    const sent = [];
+    httpProxy.mockImplementation(async (url, options) => {
+      sent.push({ url: url.toString(), authorization: options.headers?.Authorization });
+      return responses.shift();
+    });
+
+    const req = { query: { group: "g", service: "svc", index: "0" } };
+    const res = createMockRes();
+
+    await bookorbitProxyHandler(req, res);
+
+    expect(sent[0]).toEqual({
+      url: "http://bookorbit/api/v1/libraries",
+      authorization: "Bearer stale-token",
+    });
+    expect(sent[1].url).toBe("http://bookorbit/api/v1/auth/login");
+    expect(sent[2]).toEqual({
+      url: "http://bookorbit/api/v1/libraries",
+      authorization: `Bearer ${token}`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      libraries: 2,
+      books: 42,
+      reading: 3,
+      finished: 7,
+    });
+  });
+
+  it("passes an upstream failure through", async () => {
+    getServiceWidget.mockResolvedValue(widget);
+
+    httpProxy
+      .mockResolvedValueOnce(json({ accessToken: accessToken(15 * 60) }))
+      .mockResolvedValueOnce(json({ message: "Internal Server Error" }, 500));
+
+    const req = { query: { group: "g", service: "svc", index: "0" } };
+    const res = createMockRes();
+
+    await bookorbitProxyHandler(req, res);
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({ error: "Error fetching libraries" });
+  });
+
+  it("scopes the counts to the configured libraries and labels a single one", async () => {
+    getServiceWidget.mockResolvedValue({ ...widget, libraries: ["audiobooks"] });
+
+    httpProxy
+      .mockResolvedValueOnce(json({ accessToken: accessToken(15 * 60) }))
+      .mockResolvedValueOnce(json(libraries))
+      .mockResolvedValueOnce(json({ totalBooks: 20, formatCounts: { mp3: 14 } }))
+      .mockResolvedValueOnce(json({ inProgressBooks: 1, completedBooks: 5 }));
+
+    const req = { query: { group: "g", service: "svc", index: "0" } };
+    const res = createMockRes();
+
+    await bookorbitProxyHandler(req, res);
+
+    expect(httpProxy.mock.calls.slice(2).map(([url]) => url.toString())).toEqual([
+      "http://bookorbit/api/v1/libraries/2/stats",
+      "http://bookorbit/api/v1/user-statistics/summary?libraryIds=2",
+    ]);
+
+    expect(res.body).toEqual({
+      libraries: 1,
+      books: 20,
+      reading: 1,
+      finished: 5,
+      mediaKind: "audiobook",
+    });
+  });
+
+  it("sums several configured libraries and leaves the label alone", async () => {
+    getServiceWidget.mockResolvedValue({ ...widget, libraries: "eBooks, 2" });
+
+    httpProxy
+      .mockResolvedValueOnce(json({ accessToken: accessToken(15 * 60) }))
+      .mockResolvedValueOnce(json(libraries))
+      .mockResolvedValueOnce(json({ totalBooks: 19 }))
+      .mockResolvedValueOnce(json({ totalBooks: 20 }))
+      .mockResolvedValueOnce(json({ inProgressBooks: 2, completedBooks: 0 }));
+
+    const req = { query: { group: "g", service: "svc", index: "0" } };
+    const res = createMockRes();
+
+    await bookorbitProxyHandler(req, res);
+
+    expect(httpProxy.mock.calls[4][0].toString()).toBe(
+      "http://bookorbit/api/v1/user-statistics/summary?libraryIds=1&libraryIds=2",
+    );
+    expect(res.body).toEqual({
+      libraries: 2,
+      books: 39,
+      reading: 2,
+      finished: 0,
+    });
+  });
+
+  it("returns 404 when no library matches the configured names", async () => {
+    getServiceWidget.mockResolvedValue({ ...widget, libraries: ["Magazines"] });
+
+    httpProxy.mockResolvedValueOnce(json({ accessToken: accessToken(15 * 60) })).mockResolvedValueOnce(json(libraries));
+
+    const req = { query: { group: "g", service: "svc", index: "0" } };
+    const res = createMockRes();
+
+    await bookorbitProxyHandler(req, res);
+
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toEqual({ error: "No matching BookOrbit libraries" });
+  });
+  it("treats `all` as no filter", async () => {
+    getServiceWidget.mockResolvedValue({ ...widget, libraries: "all" });
+
+    httpProxy
+      .mockResolvedValueOnce(json({ accessToken: accessToken(15 * 60) }))
+      .mockResolvedValueOnce(json(libraries))
+      .mockResolvedValueOnce(json(overview))
+      .mockResolvedValueOnce(json(summary));
+
+    const req = { query: { group: "g", service: "svc", index: "0" } };
+    const res = createMockRes();
+
+    await bookorbitProxyHandler(req, res);
+
+    expect(httpProxy.mock.calls[2][0].toString()).toBe("http://bookorbit/api/v1/dashboard/widgets/library-overview");
+    expect(httpProxy.mock.calls[3][0].toString()).toBe("http://bookorbit/api/v1/user-statistics/summary");
+    expect(res.body.libraries).toBe(2);
+    expect(res.body.books).toBe(42);
+  });
+
+  it("classifies a library from its own file formats", async () => {
+    getServiceWidget.mockResolvedValue({ ...widget, libraries: ["Audiobooks"] });
+
+    httpProxy
+      .mockResolvedValueOnce(json({ accessToken: accessToken(15 * 60) }))
+      .mockResolvedValueOnce(json(libraries))
+      .mockResolvedValueOnce(json({ totalBooks: 20, formatCounts: { mp3: 14, m4b: 4, m4a: 1, epub: 1 } }))
+      .mockResolvedValueOnce(json({ inProgressBooks: 1, completedBooks: 0 }));
+
+    const req = { query: { group: "g", service: "svc", index: "0" } };
+    const res = createMockRes();
+
+    await bookorbitProxyHandler(req, res);
+
+    expect(res.body.mediaKind).toBe("audiobook");
+    expect(res.body.label).toBeUndefined();
+  });
+
+  it("leaves the media kind unset when the selection is mixed", async () => {
+    getServiceWidget.mockResolvedValue({ ...widget, libraries: ["eBooks", "Audiobooks"] });
+
+    httpProxy
+      .mockResolvedValueOnce(json({ accessToken: accessToken(15 * 60) }))
+      .mockResolvedValueOnce(json(libraries))
+      .mockResolvedValueOnce(json({ totalBooks: 19, formatCounts: { epub: 14, pdf: 5 } }))
+      .mockResolvedValueOnce(json({ totalBooks: 20, formatCounts: { mp3: 19 } }))
+      .mockResolvedValueOnce(json({ inProgressBooks: 2, completedBooks: 0 }));
+
+    const req = { query: { group: "g", service: "svc", index: "0" } };
+    const res = createMockRes();
+
+    await bookorbitProxyHandler(req, res);
+
+    expect(res.body.mediaKind).toBeUndefined();
+    expect(res.body.books).toBe(39);
+  });
+  it("lets a configured label override the library name", async () => {
+    getServiceWidget.mockResolvedValue({ ...widget, libraries: ["Audiobooks"], label: "Listening room" });
+
+    httpProxy
+      .mockResolvedValueOnce(json({ accessToken: accessToken(15 * 60) }))
+      .mockResolvedValueOnce(json(libraries))
+      .mockResolvedValueOnce(json({ totalBooks: 20, formatCounts: { mp3: 19 } }))
+      .mockResolvedValueOnce(json({ inProgressBooks: 1, completedBooks: 0 }));
+
+    const req = { query: { group: "g", service: "svc", index: "0" } };
+    const res = createMockRes();
+
+    await bookorbitProxyHandler(req, res);
+
+    expect(res.body.label).toBe("Listening room");
+    expect(res.body.mediaKind).toBe("audiobook");
+  });
+
+  it("labels an unnamed selection with the override too", async () => {
+    getServiceWidget.mockResolvedValue({ ...widget, label: "Everything" });
+
+    httpProxy
+      .mockResolvedValueOnce(json({ accessToken: accessToken(15 * 60) }))
+      .mockResolvedValueOnce(json(libraries))
+      .mockResolvedValueOnce(json(overview))
+      .mockResolvedValueOnce(json(summary));
+
+    const req = { query: { group: "g", service: "svc", index: "0" } };
+    const res = createMockRes();
+
+    await bookorbitProxyHandler(req, res);
+
+    expect(res.body.label).toBe("Everything");
+    expect(res.body.libraries).toBe(2);
+  });
+  it("returns 400 when the group or service is missing", async () => {
+    const res = createMockRes();
+
+    await bookorbitProxyHandler({ query: { index: "0" } }, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: "Invalid proxy service type" });
+    expect(getServiceWidget).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when the service has no widget", async () => {
+    getServiceWidget.mockResolvedValue(null);
+
+    const res = createMockRes();
+    await bookorbitProxyHandler({ query: { group: "g", service: "svc", index: "0" } }, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: "Invalid proxy service type" });
+  });
+
+  it("gives up when the login is rejected", async () => {
+    getServiceWidget.mockResolvedValue(widget);
+    httpProxy.mockResolvedValueOnce(json({ message: "Unauthorized" }, 401));
+
+    const res = createMockRes();
+    await bookorbitProxyHandler({ query: { group: "g", service: "svc", index: "0" } }, res);
+
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toEqual({ error: "Error fetching libraries" });
+  });
+
+  it("gives up when the login response cannot be read", async () => {
+    getServiceWidget.mockResolvedValue(widget);
+    httpProxy.mockResolvedValueOnce([200, "application/json", Buffer.from("not json")]);
+
+    const res = createMockRes();
+    await bookorbitProxyHandler({ query: { group: "g", service: "svc", index: "0" } }, res);
+
+    expect(res.statusCode).toBe(401);
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it("falls back to a default lifetime when the token carries no expiry", async () => {
+    getServiceWidget.mockResolvedValue(widget);
+
+    httpProxy
+      .mockResolvedValueOnce(json({ accessToken: "not.a.jwt" }))
+      .mockResolvedValueOnce(json(libraries))
+      .mockResolvedValueOnce(json(overview))
+      .mockResolvedValueOnce(json(summary));
+
+    const res = createMockRes();
+    await bookorbitProxyHandler({ query: { group: "g", service: "svc", index: "0" } }, res);
+
+    expect(cache.put.mock.calls[0][2]).toBe(10 * 60 * 1000);
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("passes a library stats failure through", async () => {
+    getServiceWidget.mockResolvedValue({ ...widget, libraries: ["eBooks"] });
+
+    httpProxy
+      .mockResolvedValueOnce(json({ accessToken: accessToken(15 * 60) }))
+      .mockResolvedValueOnce(json(libraries))
+      .mockResolvedValueOnce(json({ message: "Server Error" }, 500));
+
+    const res = createMockRes();
+    await bookorbitProxyHandler({ query: { group: "g", service: "svc", index: "0" } }, res);
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({ error: "Error fetching library stats" });
+  });
+
+  it("passes a library overview failure through", async () => {
+    getServiceWidget.mockResolvedValue(widget);
+
+    httpProxy
+      .mockResolvedValueOnce(json({ accessToken: accessToken(15 * 60) }))
+      .mockResolvedValueOnce(json(libraries))
+      .mockResolvedValueOnce(json({ message: "Server Error" }, 500));
+
+    const res = createMockRes();
+    await bookorbitProxyHandler({ query: { group: "g", service: "svc", index: "0" } }, res);
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({ error: "Error fetching library overview" });
+  });
+
+  it("passes a reading statistics failure through", async () => {
+    getServiceWidget.mockResolvedValue(widget);
+
+    httpProxy
+      .mockResolvedValueOnce(json({ accessToken: accessToken(15 * 60) }))
+      .mockResolvedValueOnce(json(libraries))
+      .mockResolvedValueOnce(json(overview))
+      .mockResolvedValueOnce(json({ message: "Server Error" }, 500));
+
+    const res = createMockRes();
+    await bookorbitProxyHandler({ query: { group: "g", service: "svc", index: "0" } }, res);
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({ error: "Error fetching reading statistics" });
+  });
+});

--- a/src/widgets/bookorbit/widget.js
+++ b/src/widgets/bookorbit/widget.js
@@ -1,0 +1,8 @@
+import bookorbitProxyHandler from "./proxy";
+
+const widget = {
+  api: "{url}/api/v1/{endpoint}",
+  proxyHandler: bookorbitProxyHandler,
+};
+
+export default widget;

--- a/src/widgets/bookorbit/widget.test.js
+++ b/src/widgets/bookorbit/widget.test.js
@@ -1,0 +1,11 @@
+import { describe, it } from "vitest";
+
+import { expectWidgetConfigShape } from "test-utils/widget-config";
+
+import widget from "./widget";
+
+describe("bookorbit widget config", () => {
+  it("exports a valid widget config", () => {
+    expectWidgetConfigShape(widget);
+  });
+});

--- a/src/widgets/components.js
+++ b/src/widgets/components.js
@@ -14,6 +14,7 @@ const components = {
   bazarr: dynamic(() => import("./bazarr/component")),
   beszel: dynamic(() => import("./beszel/component")),
   booklore: dynamic(() => import("./booklore/component")),
+  bookorbit: dynamic(() => import("./bookorbit/component")),
   caddy: dynamic(() => import("./caddy/component")),
   calendar: dynamic(() => import("./calendar/component")),
   calibreweb: dynamic(() => import("./calibreweb/component")),

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -11,6 +11,7 @@ import backrest from "./backrest/widget";
 import bazarr from "./bazarr/widget";
 import beszel from "./beszel/widget";
 import booklore from "./booklore/widget";
+import bookorbit from "./bookorbit/widget";
 import caddy from "./caddy/widget";
 import calendar from "./calendar/widget";
 import calibreweb from "./calibreweb/widget";
@@ -171,6 +172,7 @@ const widgets = {
   backrest,
   bazarr,
   booklore,
+  bookorbit,
   beszel,
   caddy,
   calibreweb,


### PR DESCRIPTION
## Proposed change

Adds a service widget for BookOrbit, a self-hosted library and reading platform. It shows libraries, books, in progress and finished in a single row of blocks.

BookOrbit issues short-lived access tokens rather than API keys, so the widget signs in with a username and password the way the Booklore widget does. Tokens last fifteen minutes by default, so the proxy caches each one until just before it expires and signs in again if the API rejects a request.

Counts come from three read-only endpoints: the library list, the dashboard library overview, and the per-user statistics summary. Example output from the per-library stats endpoint:

```json
{ "totalBooks": 20, "formatCounts": { "mp3": 14, "m4a": 1, "m4b": 4, "epub": 1 } }
```

Two optional settings. `libraries` scopes the counts to named libraries, by name or id, and defaults to all of them. `label` renames the count block.

Blocks are named for what a library holds rather than what it is called, reusing BookOrbit's own classification of a book by file format: audio reads Audiobooks and Listening, comics read Comics, everything else reads Books and Reading. The majority of a library's files decides, so the stray ebook in the example above does not change it.

Documentation is added for the widget, with nav and index entries.

Feature request: https://github.com/gethomepage/homepage/discussions/6838 — now over the 20 upvotes the service widget guidelines ask for. The single row, and the option to scope it to particular libraries, both follow suggestions the requester made in that thread.

AI disclosure: this was written with AI assistance (Claude Code). Every endpoint it calls was verified against a live BookOrbit instance rather than taken from documentation, and the widget was checked on desktop and mobile. I have reviewed the generated code myself.

## Type of change

- [X] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [X] If applicable, I have added corresponding documentation changes.
- [X] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [X] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [X] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [X] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [X] In the description above I have disclosed the use of AI tools in the coding of this PR.
