### PR TITLE
Enhancement: Add bearer authentication to whatsupdocker widget

### DIFF
--- a/docs/widgets/services/whatsupdocker.md
+++ b/docs/widgets/services/whatsupdocker.md
@@ -13,4 +13,5 @@ widget:
   url: http://whatsupdocker:port
   username: username # optional
   password: password # optional
+  key: bearer-token # optional, takes precedence over username/password
 ```

--- a/src/utils/proxy/handlers/credentialed.js
+++ b/src/utils/proxy/handlers/credentialed.js
@@ -77,7 +77,7 @@ export default async function credentialedProxyHandler(req, res, map) {
         } else {
           headers.Authorization = basicAuthHeader(widget);
         }
-      } else if (widget.type === "ntfy") {
+      } else if (["ntfy", "whatsupdocker"].includes(widget.type)) {
         if (widget.key) {
           headers.Authorization = `Bearer ${widget.key}`;
         } else if (widget.username && widget.password) {

--- a/src/utils/proxy/handlers/credentialed.test.js
+++ b/src/utils/proxy/handlers/credentialed.test.js
@@ -35,6 +35,7 @@ vi.mock("widgets/widgets", () => ({
     proxmox: { api: "{url}/api2/json/{endpoint}" },
     truenas: { api: "{url}/api/v2.0/{endpoint}" },
     ntfy: { api: "{url}/{endpoint}" },
+    whatsupdocker: { api: "{url}/{endpoint}" },
     proxmoxbackupserver: { api: "{url}/api2/json/{endpoint}" },
     checkmk: { api: "{url}/{endpoint}" },
     stocks: { api: "{url}/{endpoint}" },
@@ -184,6 +185,24 @@ describe("utils/proxy/handlers/credentialed", () => {
 
     const [, params] = httpProxy.mock.calls.at(-1);
     expect(params.headers.Authorization).toBe("Bearer k");
+  });
+
+  it.each([
+    ["Bearer", { key: "token" }, "Bearer token"],
+    ["Basic", { username: "u", password: "p" }, `Basic ${Buffer.from("u:p").toString("base64")}`],
+    ["no", {}, undefined],
+    ["Bearer over Basic", { key: "token", username: "u", password: "p" }, "Bearer token"],
+  ])("uses %s auth for whatsupdocker", async (_mode, credentials, authorization) => {
+    getServiceWidget.mockResolvedValue({ type: "whatsupdocker", url: "http://whatsupdocker", ...credentials });
+    httpProxy.mockResolvedValue([200, "application/json", []]);
+
+    const req = { method: "GET", query: { group: "g", service: "s", endpoint: "api/containers", index: 0 } };
+    const res = createMockRes();
+
+    await credentialedProxyHandler(req, res);
+
+    const [, params] = httpProxy.mock.calls.at(-1);
+    expect(params.headers.Authorization).toBe(authorization);
   });
 
   it("uses Bearer auth for ntfy when key is provided", async () => {

--- a/src/widgets/whatsupdocker/widget.js
+++ b/src/widgets/whatsupdocker/widget.js
@@ -1,8 +1,8 @@
-import genericProxyHandler from "utils/proxy/handlers/generic";
+import credentialedProxyHandler from "utils/proxy/handlers/credentialed";
 
 const widget = {
   api: "{url}/{endpoint}",
-  proxyHandler: genericProxyHandler,
+  proxyHandler: credentialedProxyHandler,
 
   mappings: {
     containers: {


### PR DESCRIPTION
## Proposed change

<!--
Please include a summary of the change. Screenshots and/or videos can also be helpful if appropriate.

New service widgets should include example(s) of relevant API output as well as updates to the docs for the new widget.
-->
Add support for bearer/token based API authentication for What's Up Docker introduced with 9.0.0.

Tested against WUD 9.0.0.

Closes #7133 

## Type of change

<!--
What type of change does your PR introduce to Homepage?
-->

- [ ] New service widget
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Documentation only
- [ ] Other (please explain)

## Checklist:

- [x] If applicable, I have added corresponding documentation changes.
- [x] If applicable, I have added or updated tests for new features and bug fixes (see [testing](https://gethomepage.dev/widgets/authoring/getting-started/#testing)).
- [x] If applicable, I have reviewed the [feature / enhancement](https://gethomepage.dev/widgets/authoring/getting-started/#new-feature-guidelines) and / or [service widget guidelines](https://gethomepage.dev/widgets/authoring/getting-started/#service-widget-guidelines).
- [x] I have checked that all code style checks pass using [pre-commit hooks](https://gethomepage.dev/widgets/authoring/getting-started/#code-formatting-with-pre-commit-hooks) and [linting checks](https://gethomepage.dev/widgets/authoring/getting-started/#code-linting).
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] In the description above I have disclosed the use of AI tools in the coding of this PR.



ℹ️ Implementation assisted with GPT-6 Astra running in the Codex harness. 100% of the changes were reviewed and edited by me (a human).