### PR TITLE
Fix: Default Jellyfin widget to v2 API for Jellyfin 12.0 compatibility

### DIFF
--- a/docs/widgets/services/jellyfin.md
+++ b/docs/widgets/services/jellyfin.md
@@ -13,15 +13,17 @@ Allowed fields: `["movies", "series", "episodes", "songs", "albums"]`.
 
 | Jellyfin Version | Homepage Widget Version |
 | ---------------- | ----------------------- |
-| < 12 (10.12)     | 1 (default)             |
-| >= 12 (10.12)    | 2                       |
+| < 12.0           | 1                       |
+| >= 12.0          | 2 (default)             |
+
+Jellyfin 12.0 removed the legacy `/emby/` endpoint prefix and `?api_key=` query parameter authentication. If you are running Jellyfin < 12.0, set `version: 1` explicitly.
 
 ```yaml
 widget:
   type: jellyfin
   url: http://jellyfin.host.or.ip:port
   key: apikeyapikeyapikeyapikeyapikey
-  version: 2 # optional, default is 1
+  version: 2 # optional, default is 2 (set to 1 for Jellyfin < 12.0)
   enableBlocks: true # optional, defaults to false
   enableNowPlaying: true # optional, defaults to true
   enableUser: true # optional, defaults to false

--- a/src/widgets/jellyfin/component.jsx
+++ b/src/widgets/jellyfin/component.jsx
@@ -209,7 +209,7 @@ export default function Component({ service: configuredService }) {
 
   const service = withWidgetFields(configuredService, DEFAULT_FIELDS);
   const { widget } = service;
-  const version = widget?.version ?? 1;
+  const version = widget?.version ?? 2;
   const useJellyfinV2 = version === 2;
   const sessionsEndpoint = useJellyfinV2 ? "SessionsV2" : "Sessions";
   const countEndpoint = useJellyfinV2 ? "CountV2" : "Count";


### PR DESCRIPTION
## Summary

- Jellyfin 12.0 removed the legacy `/emby/` endpoint prefix and `?api_key=` query parameter authentication
- The widget's V1 endpoints relied on both, causing 404s on all API calls for users on Jellyfin 12.0
- Change the default widget `version` from `1` to `2` so Jellyfin 12.0+ users work without any config change
- Users on Jellyfin < 12.0 must now set `version: 1` explicitly in their widget config

## Test plan

- [x] Jellyfin 12.0+: widget loads sessions and counts with no `version` set in config
- [x] Jellyfin < 12.0: widget works with `version: 1` set explicitly
- [x] Docs table accurately reflects version requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VqZhJDKfUyoumZdkDdKeAS